### PR TITLE
docs(CCSDSPack): #43 define v2 compliance baseline

### DIFF
--- a/docs/CCSDS_COMPLIANCE.md
+++ b/docs/CCSDS_COMPLIANCE.md
@@ -1,0 +1,141 @@
+# CCSDSPack v2.0.0 Compliance Baseline
+
+## Status
+
+This document is the authoritative compliance baseline for CCSDSPack v2.0.0. It records the selected standards, the supported protocol scope, the current implementation status, and the evidence required before a compliance claim can be made.
+
+The presence of an API or a successful internal encode/decode round trip is not, by itself, conformance evidence.
+
+## Normative baseline
+
+| Area | Selected baseline | v2.0.0 decision |
+|---|---|---|
+| CCSDS Space Packet Protocol | CCSDS 133.0-B-2, Issue 2, June 2020, including published editorial corrections applicable to that issue | Primary packet-layer target |
+| Packet Utilisation Standard | ECSS-E-ST-70-41C, 15 April 2016 | Primary and only PUS revision targeted by v2.0.0 |
+| Historical PUS-A | ECSS-E-70-41A, 30 January 2003 | Deferred; no v2.0.0 compliance claim |
+
+Where this document and an implementation comment disagree, the normative standard and this baseline take precedence.
+
+## PUS revision decision
+
+- PUS-C means the revision defined by ECSS-E-ST-70-41C. It is not a generic variable-length secondary-header category.
+- PUS revision and packet direction are independent properties.
+- Telecommand and telemetry secondary headers are separate structures and shall not be interchangeable.
+- PUS-A support is deferred from v2.0.0. Existing `PusA` behavior is legacy behavior until separately redesigned and verified.
+- There is no standards revision named PUS-B in the selected baseline. Existing `PusB` behavior is non-compliant legacy behavior and shall be removed or renamed as proprietary before v2.0.0.
+- Existing `PusC` behavior is not considered ECSS-E-ST-70-41C compliant merely because of its class name.
+
+The standards-facing representation begins in `inc/CCSDSV2MissionProfile.h` with `PusRevision`, `PacketDirection`, and the mission-profile contract.
+
+## Supported scope
+
+CCSDSPack v2.0.0 targets:
+
+- CCSDS Space Packets with the fixed six-octet primary header;
+- packet creation, serialization, bounded parsing, and validation;
+- segmented and unsegmented packet sequence-control fields;
+- optional packet error control using no error-control field or CRC-16-CCITT;
+- ECSS-E-ST-70-41C telecommand and telemetry packet secondary headers;
+- mission-tailored identifiers and telemetry time fields;
+- independent, externally verifiable golden-vector tests.
+
+## Explicitly unsupported or deferred
+
+The following are outside the v2.0.0 compliance claim:
+
+- CCSDS transfer frames and virtual-channel processing;
+- COP-1;
+- CFDP;
+- SpaceWire or any other transport binding;
+- automatic reassembly of arbitrarily interleaved segmented streams;
+- a C core, stable C ABI, or C wrapper architecture;
+- complete implementation of every ECSS PUS service;
+- mission-specific payload packet semantics;
+- audio and video packet semantics;
+- PUS-A compliance;
+- the existing `PusB` wire format as a standards format.
+
+## Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| Implemented | Behavior is present and matches independent conformance evidence. |
+| Partially implemented | Some behavior exists, but one or more normative requirements or tests are missing. |
+| Mission-tailored | The standard permits or requires mission-specific selection recorded by `MissionProfile`. |
+| Unsupported | Intentionally outside the v2.0.0 scope. |
+| Not applicable | Requirement does not apply to this library layer. |
+| Non-compliant | Current behavior is known to conflict with the selected baseline. |
+| Planned | No compliant implementation exists yet. |
+
+## CCSDS Space Packet compliance matrix
+
+The matrix is intentionally requirement-oriented rather than a claim that every sentence of the Blue Book has already been satisfied. Clause identifiers shall be refined against the controlled copy of CCSDS 133.0-B-2 as implementation PRs are completed.
+
+| Requirement area | v2 requirement | Current status | Current implementation reference | Required evidence / target test |
+|---|---|---|---|---|
+| Primary header size | Primary header is exactly 6 octets | Partially implemented | `CCSDS::Header::serialize`, `CCSDS::Header::deserialize` | `test_v2_primary_header_exact_six_octets` |
+| Packet version number | Version field is validated and encoded in 3 bits; v2 Space Packet profile uses version 0 | Non-compliant | `Header::setVersionNumber` silently masks values | `test_v2_reject_invalid_packet_version` |
+| Packet type | Packet type is restricted to the defined one-bit values | Non-compliant | `Header::setType` silently masks values | `test_v2_reject_invalid_packet_type` |
+| Secondary-header flag | Flag is encoded exactly and agrees with packet construction | Partially implemented | `Header`, `Packet::update` | `test_v2_secondary_header_flag_consistency` |
+| APID | APID is an 11-bit value; normal APIDs 0..2046 are accepted and idle APID 2047 is handled explicitly | Non-compliant | Header storage is 16-bit, but configuration loads APID through `std::uint8_t` and setters mask values | `test_v2_apid_full_range_and_idle` |
+| Packet sequence flags | Sequence flags are encoded in 2 bits and invalid public inputs fail | Non-compliant | `Header::setSequenceFlags` silently masks values | `test_v2_reject_invalid_sequence_flags` |
+| Packet sequence count | Sequence count is 14 bits, preserved on parse, and may be non-zero for unsegmented packets | Non-compliant | `Packet::update` forces unsegmented count to zero; validator requires zero | `test_v2_unsegmented_nonzero_sequence_count` |
+| Sequence rollover | Automatic counters roll over modulo 16384 | Planned | Current manager/counter behavior not accepted as evidence | `test_v2_sequence_count_rollover` |
+| Independent counters | Higher-level automatic counters are maintained independently per APID; low-level codec remains stateless | Planned | Manager redesign required | `test_v2_independent_sequence_counters_per_apid` |
+| Packet Data Length | Encoded value is the number of octets in the packet data field minus one | Non-compliant | `Packet::update` writes the serialized data-field size directly | `test_v2_packet_data_length_golden_vector` |
+| Packet Data Length coverage | Secondary header, application data, and enabled packet error control are included | Non-compliant | Current CRC is outside the encoded length calculation | `test_v2_packet_data_length_includes_crc` |
+| Maximum packet size | Length calculation prevents overflow and rejects unrepresentable packets | Planned | No accepted v2 validation path | `test_v2_reject_packet_too_large` |
+| Packet boundary | Parser calculates total packet size as `6 + Packet Data Length + 1` | Non-compliant | `Packet::deserialize` copies all remaining bytes | `test_v2_parse_exact_packet_boundary` |
+| Truncation handling | Truncated packets return a specific error without out-of-bounds access | Partially implemented | Minimum-size checks exist, but declared packet boundary is not enforced | `test_v2_reject_truncated_packet` |
+| Concatenated packets | One parse consumes exactly one packet and reports consumed octets | Planned | Existing API does not report consumed length | `test_v2_parse_concatenated_packets` |
+| Error-control presence | Packet error control is explicitly configured as `None` or `CRC16` | Non-compliant | Serialization and parsing assume a two-octet CRC | `test_v2_crc_disabled_packet` |
+| CRC coverage | CRC covers the primary header, secondary header, and application data, ending before the CRC field | Non-compliant | `Packet::update` calculates CRC over the data field only | `test_v2_crc_complete_packet_golden_vector` |
+| CRC encoding | CRC is serialized in network byte order | Partially implemented | `Packet::getCRCVectorBytes` writes MSB first | `test_v2_crc_big_endian` |
+| CRC verification | Parser compares received and calculated CRC and returns a dedicated mismatch error | Non-compliant | Parser stores received CRC but does not verify it | `test_v2_crc_mismatch` |
+| Read-only inspection | Inspection of a parsed packet does not mutate header, length, count, or CRC | Non-compliant | Multiple getters call `Packet::update` | `test_v2_parsed_packet_inspection_is_non_mutating` |
+| Unknown extra bytes | Trailing bytes are not silently absorbed into a packet | Non-compliant | Existing deserialization consumes remaining input | `test_v2_trailing_bytes_not_consumed` |
+
+## ECSS PUS-C traceability matrix
+
+| Requirement area | v2 requirement | Classification | Current status | Required evidence / target test |
+|---|---|---|---|---|
+| Revision identity | PUS-C is represented explicitly as ECSS-E-ST-70-41C / version 2 | Mandatory | Contract added; codec planned | `test_v2_pus_revision_c_value` |
+| Packet direction | TC and TM are modeled separately from revision | Mandatory | Contract added; concrete types planned | `test_v2_tc_tm_type_separation` |
+| TC acknowledgement flags | PUS-C TC acknowledgement bits are represented and serialized | Mandatory for TC codec | Planned | `test_v2_pus_c_tc_ack_flags_vector` |
+| Service type/subtype | Service type and subtype are represented in TC and TM headers | Mandatory | Legacy fields exist; compliant layout planned | Independent TC/TM vectors |
+| Source identifier | Width is selected by mission profile | Mission-tailored | Profile contract added; validation/codec planned | `test_v2_source_id_widths` |
+| Destination identifier | Width is selected by mission profile | Mission-tailored | Profile contract added; validation/codec planned | `test_v2_destination_id_widths` |
+| TM time-reference status | Field is represented in PUS-C TM | Mandatory for TM codec | Planned | `test_v2_pus_c_tm_time_reference_status` |
+| TM message-type counter | Field is represented in PUS-C TM | Mandatory for TM codec | Planned | `test_v2_pus_c_tm_message_type_counter` |
+| TM timestamp presence | Presence is explicitly selected by mission profile | Mission-tailored | Profile contract added | `test_v2_tm_timestamp_presence_profile` |
+| TM time format | CCSDS time family and total encoded length are explicit | Mission-tailored | Profile contract added; codec planned | CUC/CDS/CCS vectors as supported |
+| Packet error control | Presence and algorithm are selected by mission profile | Mission-tailored | Profile contract added; packet integration planned | CRC and no-CRC PUS-C vectors |
+| PUS services | A mission selects only the services and capability sets it implements | Mission-tailored | Documentation baseline only | Service-specific tests when implemented |
+
+## Mission tailoring
+
+The initial mission-tailoring rules, validation constraints, and defaults are defined in [`MISSION_TAILORING.md`](MISSION_TAILORING.md). A profile must be supplied to standards-facing v2 packet construction and parsing. Code shall not infer a profile from remaining bytes or from a legacy class name.
+
+## Compliance evidence policy
+
+A matrix row may be changed to **Implemented** only when all of the following exist:
+
+1. a source-code reference;
+2. a focused regression test;
+3. an independent expected byte vector or independently calculated value where wire behavior is involved;
+4. a negative test for rejected inputs where validation is involved;
+5. no contradictory supported configuration path.
+
+Internal serialization/deserialization round trips are useful regression tests, but they are not independent conformance evidence.
+
+## Phase 0 decision record
+
+Phase 0 is complete when this document and the mission-tailoring specification are merged, and the following decisions are treated as change-controlled:
+
+- CCSDS 133.0-B-2 Issue 2 is the packet-layer baseline.
+- ECSS-E-ST-70-41C is the primary and only PUS revision targeted by v2.0.0.
+- PUS-A is deferred.
+- PUS-B is rejected as a standards concept.
+- TC and TM are separate directions, not PUS revisions.
+- mission-tailored fields are explicit configuration, never parser guesswork.
+- unsupported layers and services do not appear in v2 compliance claims.

--- a/docs/MISSION_TAILORING.md
+++ b/docs/MISSION_TAILORING.md
@@ -1,0 +1,115 @@
+# CCSDSPack v2 Mission Tailoring
+
+## Purpose
+
+ECSS-E-ST-70-41C is deliberately mission-tailorable. CCSDSPack v2 therefore does not pretend that one hard-coded secondary-header layout is universally compliant. A mission profile records every selected field width and optional behavior needed to encode and parse packets deterministically.
+
+The initial C++ contract is declared in `inc/CCSDSV2MissionProfile.h`. Phase 3 will add validation and codec integration.
+
+## Initial profile fields
+
+| Field | Meaning | Initial representation |
+|---|---|---|
+| PUS revision | Standards revision used by the PUS codec | `PusRevision::C` only for v2.0.0 |
+| Source-ID width | Number of octets used for the source identifier where applicable | `sourceIdOctets` |
+| Destination-ID width | Number of octets used for the destination identifier where applicable | `destinationIdOctets` |
+| Packet error control | Whether a packet has no error-control field or a CRC-16-CCITT field | `packetErrorControl` |
+| TM timestamp presence | Whether the telemetry secondary header carries a timestamp | `telemetryTimestampPresent` |
+| TM time-code family | Selected CCSDS time-code family | `telemetryTimeCode` |
+| TM time-code length | Total encoded timestamp length in octets | `telemetryTimeCodeOctets` |
+
+Widths are expressed in octets. A zero width disables an optional identifier only where the selected packet definition permits absence. The profile is not inferred from packet size.
+
+## Required behavior
+
+A standards-facing v2 encoder shall require an explicit mission profile before finalization. A standards-facing v2 parser shall receive the applicable mission profile from the caller or a higher-level routing context.
+
+The parser shall not:
+
+- guess whether a CRC is present from trailing bytes;
+- infer a timestamp format from the number of bytes left;
+- infer packet direction from a PUS class name;
+- reinterpret unknown layouts as PUS-C;
+- silently truncate identifiers to fit the configured width.
+
+## Validation rules
+
+The profile validator introduced in Phase 3 shall reject at least the following combinations:
+
+1. any PUS revision other than `PusRevision::C` in the v2.0.0 standards-facing API;
+2. `telemetryTimestampPresent == false` with a non-`None` time-code family;
+3. `telemetryTimestampPresent == false` with a non-zero time-code length;
+4. `telemetryTimestampPresent == true` with `TimeCodeFormat::None`;
+5. `telemetryTimestampPresent == true` with a zero time-code length;
+6. a time-code length that is invalid for the selected supported CCSDS time-code configuration;
+7. identifier widths that cannot represent the supplied source or destination identifier;
+8. identifier widths unsupported by the selected PUS-C packet layout;
+9. an unknown packet error-control mode;
+10. packet construction whose total packet-data field exceeds the CCSDS Packet Data Length representation.
+
+Validation shall return an error. It shall not normalize an invalid profile into a different valid profile.
+
+## Initial supported selections
+
+The Phase 0 contract intentionally permits the following selections while deferring exact codec limits to Phase 3:
+
+- PUS revision: PUS-C only;
+- packet direction: telemetry or telecommand, modeled separately from revision;
+- packet error control: none or CRC-16-CCITT;
+- telemetry time-code family: none, CUC, CDS, or CCS;
+- configurable source- and destination-ID widths;
+- optional telemetry timestamp.
+
+A listed selection means that the profile model can express it. It does not mean the current v1 codec already implements it correctly.
+
+## Default profile
+
+The initial in-code defaults are deliberately conservative and exist for object initialization, not for silently selecting a mission contract:
+
+```cpp
+CCSDS::v2::MissionProfile profile;
+```
+
+This yields:
+
+- PUS-C;
+- one-octet source identifier;
+- one-octet destination identifier;
+- CRC-16-CCITT packet error control;
+- no telemetry timestamp;
+- no time-code family;
+- zero timestamp octets.
+
+Public v2 configuration and CLI paths shall serialize every profile choice explicitly, even when it equals the initial default.
+
+## Configuration migration target
+
+The final Phase 6 configuration schema shall contain fields equivalent to:
+
+```text
+pus_revision = "C"
+packet_direction = "telecommand" | "telemetry"
+source_id_octets = <integer>
+destination_id_octets = <integer>
+packet_error_control = "none" | "crc16-ccitt"
+telemetry_timestamp_present = true | false
+telemetry_time_code = "none" | "cuc" | "cds" | "ccs"
+telemetry_time_code_octets = <integer>
+```
+
+Legacy values such as `secondary_header = "PusB"` shall fail with a migration error rather than being assigned an invented standards meaning.
+
+## Ownership of tailoring decisions
+
+CCSDSPack validates and applies a mission profile. It does not decide which PUS services, identifier widths, or time format a mission should use. Those selections belong in the mission's space-to-ground interface control documentation.
+
+## Change control
+
+Adding a new profile field requires all of the following:
+
+- a normative or mission-interface reason;
+- an explicit unit and valid range;
+- validation rules;
+- serialization and parsing behavior;
+- positive and negative tests;
+- an update to `docs/CCSDS_COMPLIANCE.md`.

--- a/docs/MISSION_TAILORING.md
+++ b/docs/MISSION_TAILORING.md
@@ -67,7 +67,7 @@ A listed selection means that the profile model can express it. It does not mean
 The initial in-code defaults are deliberately conservative and exist for object initialization, not for silently selecting a mission contract:
 
 ```cpp
-CCSDS::v2::MissionProfile profile;
+CCSDS::MissionProfile profile;
 ```
 
 This yields:

--- a/inc/CCSDSMissionProfile.h
+++ b/inc/CCSDSMissionProfile.h
@@ -6,10 +6,10 @@
 
 #include <cstdint>
 
-namespace CCSDS::v2 {
+namespace CCSDS {
 
   /**
-   * @brief PUS revisions accepted by the CCSDSPack v2 compliance profile.
+   * @brief PUS revisions accepted by the CCSDSPack v2+ compliance profile.
    *
    * ECSS-E-ST-70-41C encodes its PUS version number as 2. PUS-A is
    * intentionally not represented because it is deferred from v2.0.0.
@@ -24,7 +24,7 @@ namespace CCSDS::v2 {
     Telecommand = 1
   };
 
-  /** @brief Packet error-control modes exposed by the v2 mission profile. */
+  /** @brief Packet error-control modes exposed by the profile. */
   enum class PacketErrorControlMode : std::uint8_t {
     None = 0,
     Crc16Ccitt = 1
@@ -39,7 +39,7 @@ namespace CCSDS::v2 {
   };
 
   /**
-   * @brief Initial mission-tailoring contract for standards-facing v2 APIs.
+   * @brief Initial mission-tailoring contract for standards-facing v2+ APIs.
    *
    * Width values are expressed in octets. Zero disables an optional field.
    * Profile validation and codec integration are implemented in Phase 3.
@@ -54,6 +54,6 @@ namespace CCSDS::v2 {
     std::uint8_t telemetryTimeCodeOctets{0};
   };
 
-} // namespace CCSDS::v2
+} // namespace CCSDS
 
 #endif // CCSDS_V2_MISSION_PROFILE_H

--- a/inc/CCSDSV2MissionProfile.h
+++ b/inc/CCSDSV2MissionProfile.h
@@ -1,0 +1,59 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CCSDS_V2_MISSION_PROFILE_H
+#define CCSDS_V2_MISSION_PROFILE_H
+
+#include <cstdint>
+
+namespace CCSDS::v2 {
+
+  /**
+   * @brief PUS revisions accepted by the CCSDSPack v2 compliance profile.
+   *
+   * ECSS-E-ST-70-41C encodes its PUS version number as 2. PUS-A is
+   * intentionally not represented because it is deferred from v2.0.0.
+   */
+  enum class PusRevision : std::uint8_t {
+    C = 2
+  };
+
+  /** @brief Packet direction, independent from the selected PUS revision. */
+  enum class PacketDirection : std::uint8_t {
+    Telemetry = 0,
+    Telecommand = 1
+  };
+
+  /** @brief Packet error-control modes exposed by the v2 mission profile. */
+  enum class PacketErrorControlMode : std::uint8_t {
+    None = 0,
+    Crc16Ccitt = 1
+  };
+
+  /** @brief CCSDS time-code families supported by a mission profile. */
+  enum class TimeCodeFormat : std::uint8_t {
+    None = 0,
+    Cuc = 1,
+    Cds = 2,
+    Ccs = 3
+  };
+
+  /**
+   * @brief Initial mission-tailoring contract for standards-facing v2 APIs.
+   *
+   * Width values are expressed in octets. Zero disables an optional field.
+   * Profile validation and codec integration are implemented in Phase 3.
+   */
+  struct MissionProfile {
+    PusRevision pusRevision{PusRevision::C};
+    std::uint8_t sourceIdOctets{1};
+    std::uint8_t destinationIdOctets{1};
+    PacketErrorControlMode packetErrorControl{PacketErrorControlMode::Crc16Ccitt};
+    bool telemetryTimestampPresent{false};
+    TimeCodeFormat telemetryTimeCode{TimeCodeFormat::None};
+    std::uint8_t telemetryTimeCodeOctets{0};
+  };
+
+} // namespace CCSDS::v2
+
+#endif // CCSDS_V2_MISSION_PROFILE_H


### PR DESCRIPTION
Superseded by the completed Phase 0 merge and the v1.2.0 synchronization work in #108.