### PR TITLE
feat(CCSDSPack): #49 add optional packet error control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-
 <div style="text-align: center;">
     <img alt="ccsds_pack_logo" src="docs/imgs/Logo.png" width="400" />
 </div>
 
 # CCSDSPack [[ExoSpaceLabs](https://github.com/ExoSpaceLabs)]
-**CCSDSPack** is a lightweight, high-performance C++ library for handling 
-[CCSDS (Consultative Committee for Space Data Systems)](https://public.ccsds.org/) packets.
-It provides utilities to create, parse, and manage CCSDS-compliant telemetry (TM) and 
-telecommand (TC) packets with a modern C++ design and customizable serialization.
+**CCSDSPack** is a lightweight C++ library for creating, parsing, managing, and validating
+packet formats based on the [CCSDS Space Packet](https://public.ccsds.org/) primary-header structure.
+
+The **v1.x.x** release series provides CCSDS-oriented packet manipulation, configurable secondary
+headers, application-data handling, CRC16 support, segmentation utilities, and command-line tools.
+
+> [!IMPORTANT]
+> CCSDSPack v1.x.x is **not certified as compliant with ECSS Packet Utilisation Standard (PUS)**
+> revisions. The bundled `PusA`, `PusB`, and `PusC` classes are legacy project-specific secondary
+> header formats and must not be interpreted as official ECSS PUS implementations.
 
 
 ## Table of Contents
@@ -28,7 +33,7 @@ The following tables show the current overall build and regression test status o
 
 | Linux | Windows |
 |-------|---------|
- | ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/linux.yml?branch=main)| ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/windows.yml?branch=main) | 
+| ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/linux.yml?branch=main)| ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/windows.yml?branch=main) | 
 
 Specific distribution build and regression status are shown below
 
@@ -42,13 +47,13 @@ Specific distribution build and regression status are shown below
 
 ## Features
 
-- Support for both **TM** and **TC** CCSDS packets using integrated PUS standards
+- Support for packet types using the CCSDS Space Packet primary-header layout
 - Custom serialization with support for `std::vector`, `std::shared_ptr`, and user-defined types
-- End-to-end encoding / decoding and validation 
+- End-to-end encoding / decoding and validation
 - Easy to test and integrate
 - Built-in extensibility for secondary headers with clear abstraction
 - User-friendly installation and usage within your code.
-- Example Executables (encoder, decoder and validator) see [Executables](docs/EXECUTABLES.md) 
+- Example Executables (encoder, decoder and validator) see [Executables](docs/EXECUTABLES.md)
 - Optimised for fast execution.
 - Pre-built .deb package downloadable from [Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases).
 - Pre-built docker image with library installed, see [docker](#docker).
@@ -59,7 +64,7 @@ Specific distribution build and regression status are shown below
 Full API documentation is available and hosted here:  [CCSDSPack Documentation](https://exospacelabs.github.io/CCSDSPack/html/)
 
 
-C++ Library for CCSDS Space Packet manipulation. i.e. generation, extraction, analysis and more
+C++ library for CCSDS-oriented packet generation, extraction, validation, and analysis.
 
 ![ccsds packet image](docs/imgs/Packet_management.png)
 
@@ -77,62 +82,79 @@ Features Provided by the CCSDS::Manager class(Assuming the Packet identifier dat
 ![ccsds packet image](docs/imgs/ccsdsPacket.png)
 
 - **Primary Header** — Fixed size, always present. Defines APID, packet type, data length, and other control flags.
-- **Secondary Header** — Optional; type depends on the mission and protocol standards used (e.g., PUS-A/B/C).
+- **Secondary Header** — Optional; v1.x.x supports custom and legacy project-specific header formats.
 - **Application Data** — Mission-specific payload bytes.
 - **Error Control Field (optional)** — CRC or checksum for integrity verification.
 
 ---
 
-### PUS Standards in CCSDSPack
+### Legacy Secondary Headers in v1.x.x
 
-The **Packet Utilization Standard (PUS)** defines conventions for structuring the Secondary Header and Application Data in CCSDS packets for ESA missions.  
-CCSDSPack includes **built-in support** for several PUS standards out of the box:
+CCSDSPack v1.x.x includes three built-in secondary-header implementations named `PusA`, `PusB`,
+and `PusC`.
+
+These names are retained for compatibility with the v1 API and configuration files. Their encoded
+layouts are **project-specific** and are not claimed to implement official ECSS PUS-A, PUS-C, or any
+other ECSS Packet Utilisation Standard revision.
+
+#### `PusA`
+
+A fixed-size legacy secondary header containing:
+
+- version,
+- service type,
+- service subtype,
+- source ID,
+- application-data length.
+
+![Legacy PusA secondary header](docs/imgs/pus-a.png)
+
+#### `PusB`
+
+A fixed-size legacy event-oriented secondary header containing:
+
+- version,
+- service type,
+- service subtype,
+- source ID,
+- event ID,
+- application-data length.
+
+![Legacy PusB secondary header](docs/imgs/pus-b.png)
+
+`PusB` is a CCSDSPack-specific format. It does not represent an official ECSS PUS revision or
+standard secondary-header type.
+
+#### `PusC`
+
+A variable-size legacy secondary header containing:
+
+- version,
+- service type,
+- service subtype,
+- source ID,
+- a variable byte sequence used as a time-code field,
+- application-data length.
+
+![Legacy PusC secondary header](docs/imgs/pus-c.png)
+
+The variable time-code field is treated as application-configured bytes and is not validated as a
+specific CCSDS or ECSS time-code format.
+
+#### v2 transition
+
+Standards-compliant CCSDS and ECSS PUS behaviour is planned for CCSDSPack v2.0.0. This includes
+correct packet-length semantics, packet error-control handling, sequence-count behaviour, and
+separate standards-based TC and TM secondary headers.
 
 ---
 
-#### **PUS-A Telecommand (TC)**
-
-A fixed-size secondary header format used in **Telecommand (TC)** packets.
-
-![PUS-A secondary header](docs/imgs/pus-a.png)
-
-- **Purpose:** Command packets sent from ground to spacecraft.
-- **Secondary Header size:** Fixed (typically 4–6 bytes depending on implementation).
-- **Common fields:** Service type, service subtype, source ID.
-- **Advantages:** Simple, low overhead, deterministic parsing.
-
----
-
-#### **PUS-B Telemetry (TM)**
-
-A fixed-size secondary header format used in **Telemetry (TM)** packets.
-
-![PUS-B secondary header](docs/imgs/pus-b.png)
-
-- **Purpose:** Data packets sent from spacecraft to ground.
-- **Secondary Header size:** Fixed (typically 6–8 bytes).
-- **Common fields:** PUS version, service type/subtype, time information, source ID, optional event ID.
-- **Advantages:** Standardized time coding, predictable layout, widely supported in ESA ground systems.
-
----
-
-#### **PUS-C** (Flexible / Variable)
-
-A more flexible and **variable-sized** secondary header format.
-
-![PUS-C secondary header](docs/imgs/pus-c.png)
-
-- **Purpose:** Allows missions to define a custom secondary header layout while still remaining PUS-compliant.
-- **Secondary Header size:** Variable (defined by mission config).
-- **Common use:** Missions requiring extended metadata, non-standard time formats, or extra identification fields.
-- **Advantages:** Flexibility for evolving mission requirements; still compatible with CCSDS framing.
-
----
 ### Other Documents
 Please check out the documentation on [ccsds documentation](https://public.ccsds.org/Publications/default.aspx). Recommended documents are within the Blue and Green
 books.
 
-Also take a look of the following documents:
+The following documents are useful protocol references. Their inclusion does not imply that
+CCSDSPack v1.x.x implements every requirement in these standards:
 
 * [CCSDS 133.0-B-2](https://public.ccsds.org/Pubs/133x0b2e2.pdf) - Space Packet Protocol
 * [CCSDS 133.1-B-3](https://public.ccsds.org/Pubs/133x1b3e1.pdf) - Encapsulation Packet Protocol
@@ -148,10 +170,10 @@ Also take a look of the following documents:
 ### Source
 CMake flags:
 
-The following flags can be provided to cmake when building the project to enable disable build of 
-specific provided features. such as tester, which may or may not be of interest. 
+The following flags can be provided to cmake when building the project to enable or disable build of
+specific provided features. such as tester, which may or may not be of interest.
 
-| Cmake Flag (default value) | Description                                                                  |
+| CMake Flag (default value) | Description                                                                  |
 |----------------------------|------------------------------------------------------------------------------|
 | -DCCSDSPACK_BUILD_MCU=OFF  | build the project as a static library for microcontrollers. *                |
 | -DENABLE_TESTER=ON         | build tester, that performs regression tests of the library.                 | 
@@ -180,7 +202,7 @@ git clone https://github.com/ExoSpaceLabs/CCSDSPack.git
 cd CCSDSPack
 ```
 
-set up cmake and build
+Configure CMake and build
 ```bash
 
 cd build && cmake .. && make
@@ -201,7 +223,7 @@ Note: this might require privileged `sudo` command as per permission restriction
 
 ---
 #### Windows
-tested on Windows-2019 and Windows-latest (see git hub [Actions](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml))
+tested on Windows-2019 and Windows-latest (see GitHub [Actions](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml))
 
 Install dependencies:
 
@@ -224,7 +246,7 @@ The tester can already be executed using the following commands:
 
 cd build/bin && ./CCSDSPack_tester.exe
 ```
-Note: Cmake will deploy test files to bin directory, if the tester is not executed from the
+Note: CMake will deploy test files to bin directory, if the tester is not executed from the
 bin directory some tests will fail.
 
 ---
@@ -240,12 +262,12 @@ sudo dpkg -i ccsdspack-v<version>-<system>-<architecture>.deb
 ```
 
 If the required system is not prebuilt or available on the above list, it can be generated by
-following instructions in [Packages](docs/PACKAGES.md) document. Where detailed information 
+following instructions in [Packages](docs/PACKAGES.md) document. Where detailed information
 is provided for library inclusion in private projects.
 
 ### Docker
 Prebuilt Docker images of CCSDSPack are published on [GHCR](https://github.com/ExoSpaceLabs/CCSDSPack/pkgs/container/ccsdspack).  
-They provide a ready-to-use environment with the library and command-line tools already installed, 
+They provide a ready-to-use environment with the library and command-line tools already installed,
 so you don’t need to compile from source or manage dependencies manually (almost none in this case).
 
 Pull a specific release image or the latest version:
@@ -308,10 +330,10 @@ cmake .. -DCMAKE_PREFIX_PATH=/path/to/install/prefix
 
 ### Encoder:
 
-Encode a specific file into the application data of CCSDS packets and save streamed packets 
+Encode a specific file into the application data of CCSDS packets and save streamed packets
 data to a desired file.
 
-requirements: 
+Requirements:
 * a file to encode
 * configuration file which holds the template packet data and settings
 
@@ -321,11 +343,11 @@ ccsds_encoder -i <file_to_encode> -o <encoded_binaryFile> -c <config_file>
 ```
 ### Decoder:
 
-Decode a previously encoded binary file holding serialized CCSDS packets, extract application 
-data and recreate original file. 
+Decode a previously encoded binary file holding serialized CCSDS packets, extract application
+data and recreate original file.
 
-requirements:
-* an encoded binary file 
+Requirements:
+* an encoded binary file
 * configuration file used to encode the packets holding template packet data and settings
 
 ```bash
@@ -337,7 +359,7 @@ Note: If the decoded file is named with the original file extension it will be u
 
 For more detailed info and other examples (e.g. Validator usage) see [Executables](docs/EXECUTABLES.md).
 
-The configuration file description and usage can be found under [Config file](docs/CONFIG.md). 
+The configuration file description and usage can be found under [Config file](docs/CONFIG.md).
 
 ### C++
 The following examples show how the high level C++ APIs can be used in a project
@@ -373,9 +395,9 @@ int main(){
   return 0;
 }
 ```
-Where the 'inputBytes' are a set of bytes that are to be set as application into the packets. This is performed by 
-first setting a template packet in the manager. Which then will be used as reference for all packets generated. and the 
-application data is then set using the setApplicationData manager member method. This generates CCSDS packets in  the 
+Where the 'inputBytes' are a set of bytes that are to be set as application into the packets. This is performed by
+first setting a template packet in the manager. Which then will be used as reference for all packets generated. and the
+application data is then set using the setApplicationData manager member method. This generates CCSDS packets in  the
 manager. It can be retrieved by using the getPackets method. and further manipulation can be performed if required.
 
 2) Assuming you already have a CCSDS packet stream and want to extract the data from it.
@@ -405,5 +427,4 @@ Assuming we have a vector of CCSDS packets prepared ad hoc. These packets then c
 If required the manager allows the packets to be validated for coherence, or if the template is set against it.
 In the example above the application data is retrieved from all packets into a single stream of data.
 
-for more examples see [Examples](docs/EXAMPLES.md).
-
+For more examples, see [Examples](docs/EXAMPLES.md).

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -41,6 +41,16 @@ namespace CCSDS {
     std::uint16_t finalXorValue = 0x0000;
   };
 
+  /**
+   * @brief Selects whether a CCSDS packet includes a packet error-control field.
+   *
+   * CRC16 remains the default to preserve the behaviour of existing v1 callers.
+   */
+  enum class PacketErrorControlMode : std::uint8_t {
+    None = 0,
+    CRC16 = 1
+  };
+
 
   /**
    * @brief Represents a CCSDS (Consultative Committee for Space Data Systems) packet.
@@ -48,13 +58,13 @@ namespace CCSDS {
    * This class provides functionality to construct and manage a CCSDS packet, which
    * includes both the primary header and the data field. It allows setting and getting
    * the primary header, data field headers (PusA, PusB, PusC), and application data.
-   * The packet also includes a CRC-16 checksum for error detection.
+   * The packet also includes an optional CRC-16 checksum for error detection.
    *
    * The class provides methods for managing the packet's data structure, including
    * printing the headers and data field, calculating the CRC-16, and combining the
-   * primary header, data field, and CRC into a complete packet. The header is updated
-   * automatically when necessary, and it provides both raw and vector representations
-   * of the data for further use or transmission.
+   * primary header, data field, and optional CRC into a complete packet. The header is
+   * updated automatically when necessary, and it provides both raw and vector
+   * representations of the data for further use or transmission.
    *
    * The `Packet` class also handles the internal state for CRC calculation and header
    * updates to ensure data consistency.
@@ -249,6 +259,21 @@ namespace CCSDS {
      */
     void setUpdatePacketEnable(bool enable);
 
+    /**
+     * @brief Selects the packet error-control field used during serialization and parsing.
+     *
+     * Existing callers retain CRC16 because it is the default mode.
+     */
+    void setPacketErrorControlMode(PacketErrorControlMode mode);
+
+    /** @brief Returns the configured packet error-control mode. */
+    [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const { return m_packetErrorControlMode; }
+
+    /** @brief Returns the encoded packet error-control field size in bytes. */
+    [[nodiscard]] std::uint16_t getPacketErrorControlSize() const {
+      return m_packetErrorControlMode == PacketErrorControlMode::CRC16 ? 2U : 0U;
+    }
+
     /** @brief Deserializes a vector of bytes into a CCSDS packet. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data);
 
@@ -281,11 +306,9 @@ namespace CCSDS {
     /**
      * @brief Retrieves the full packet as a vector of bytes.
      *
-     * Combines the primary header, data field, and CRC-16 checksum into
+     * Combines the primary header, data field, and optional CRC-16 checksum into
      * a single vector. Ensures that the header and data field sizes meet
      * minimum requirements.
-     *
-     * @note Header size must be 6 bytes and data field size must be greater than 1 byte.
      *
      * @return A vector containing the full packet in byte form.
      */
@@ -328,6 +351,7 @@ namespace CCSDS {
      *
      * The checksum is split into its most significant byte (MSB) and
      * least significant byte (LSB) and stored in a two-element vector.
+     * An empty vector is returned when packet error control is disabled.
      *
      * @return A vector containing the MSB and LSB of the CRC-16 checksum.
      */
@@ -336,11 +360,11 @@ namespace CCSDS {
     /**
      * @brief Computes and retrieves the CRC-16 checksum of the packet.
      *
-     * If the CRC-16 has not already been calculated, this function computes it
-     * using the full data field of the packet. The result is cached for
-     * future calls to improve performance.
+     * If packet error control is disabled this method returns zero. Otherwise,
+     * if the CRC-16 has not already been calculated, this function computes it
+     * and caches the result for future calls.
      *
-     * @return The 16-bit CRC-16 checksum.
+     * @return The 16-bit CRC-16 checksum or zero when disabled.
      */
     std::uint16_t getCRC();
 
@@ -415,8 +439,9 @@ namespace CCSDS {
   private:
     Header m_primaryHeader{};        ///< 6 bytes / 48 bits / 12 hex
     DataField m_dataField{};         ///< variable
-    std::uint16_t m_CRC16{};              ///< Cyclic Redundancy check 16 bits
+    std::uint16_t m_CRC16{};         ///< Cyclic Redundancy check 16 bits
     CRC16Config m_CRC16Config;       ///< structure holding configuration of crc calculation.
+    PacketErrorControlMode m_packetErrorControlMode{PacketErrorControlMode::CRC16}; ///< Optional packet error-control field.
     bool m_updateStatus{false};      ///< When setting data thus value should be set to false.
     bool m_enableUpdatePacket{true}; ///< Enables primary header and secondary header update.
     std::uint16_t m_sequenceCounter{0};

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -267,11 +267,15 @@ namespace CCSDS {
     void setPacketErrorControlMode(PacketErrorControlMode mode);
 
     /** @brief Returns the configured packet error-control mode. */
-    [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const { return m_packetErrorControlMode; }
+    [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const {
+      return (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK) != 0U
+               ? PacketErrorControlMode::None
+               : PacketErrorControlMode::CRC16;
+    }
 
     /** @brief Returns the encoded packet error-control field size in bytes. */
     [[nodiscard]] std::uint16_t getPacketErrorControlSize() const {
-      return m_packetErrorControlMode == PacketErrorControlMode::CRC16 ? 2U : 0U;
+      return getPacketErrorControlMode() == PacketErrorControlMode::CRC16 ? 2U : 0U;
     }
 
     /** @brief Deserializes a vector of bytes into a CCSDS packet. */
@@ -437,13 +441,17 @@ namespace CCSDS {
 #endif
 
   private:
+    static constexpr std::uint16_t SEQUENCE_COUNT_MASK = 0x3FFFU;
+    static constexpr std::uint16_t PACKET_ERROR_CONTROL_DISABLED_MASK = 0x8000U;
+
     Header m_primaryHeader{};        ///< 6 bytes / 48 bits / 12 hex
     DataField m_dataField{};         ///< variable
     std::uint16_t m_CRC16{};         ///< Cyclic Redundancy check 16 bits
     CRC16Config m_CRC16Config;       ///< structure holding configuration of crc calculation.
-    PacketErrorControlMode m_packetErrorControlMode{PacketErrorControlMode::CRC16}; ///< Optional packet error-control field.
     bool m_updateStatus{false};      ///< When setting data thus value should be set to false.
     bool m_enableUpdatePacket{true}; ///< Enables primary header and secondary header update.
+    // Lower 14 bits store the CCSDS sequence count. Bit 15 stores the v1.2
+    // packet-error-control mode so the Packet object layout remains ABI-stable.
     std::uint16_t m_sequenceCounter{0};
   };
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -22,10 +22,10 @@ void CCSDS::Packet::update() {
     if (m_primaryHeader.getSequenceFlags() == UNSEGMENTED) {
       m_primaryHeader.setSequenceCount(0);
     } else {
-      m_primaryHeader.setSequenceCount(m_sequenceCounter);
+      m_primaryHeader.setSequenceCount(m_sequenceCounter & SEQUENCE_COUNT_MASK);
     }
 
-    if (m_packetErrorControlMode == PacketErrorControlMode::CRC16) {
+    if (getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
       m_CRC16 = crc16(dataField, m_CRC16Config.polynomial, m_CRC16Config.initialValue, m_CRC16Config.finalXorValue);
     } else {
       m_CRC16 = 0;
@@ -120,7 +120,7 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
 #endif
 
 uint16_t CCSDS::Packet::getCRC() {
-  if (m_packetErrorControlMode == PacketErrorControlMode::None) {
+  if (getPacketErrorControlMode() == PacketErrorControlMode::None) {
     return 0;
   }
   update();
@@ -137,7 +137,7 @@ bool CCSDS::Packet::getDataFieldHeaderFlag() {
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getCRCVectorBytes() {
-  if (m_packetErrorControlMode == PacketErrorControlMode::None) {
+  if (getPacketErrorControlMode() == PacketErrorControlMode::None) {
     return {};
   }
 
@@ -266,10 +266,11 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &he
   RET_IF_ERR_MSG(headerData.size() != 6, ErrorCode::INVALID_HEADER_DATA,
                  "Cannot Deserialize Packet, Invalid Header Data provided.");
   FORWARD_RESULT(m_primaryHeader.deserialize( headerData ));
-  m_sequenceCounter = m_primaryHeader.getSequenceCount();
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
 
   std::vector<uint8_t> dataCopy;
-  if (m_packetErrorControlMode == PacketErrorControlMode::CRC16) {
+  if (getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
     RET_IF_ERR_MSG(data.size() < 2, ErrorCode::INVALID_DATA,
                    "Cannot Deserialize Packet, at least two packet error-control bytes are required in CRC16 mode.");
     m_CRC16 = (static_cast<std::uint16_t>(data[data.size() - 2]) << 8) + data.back();
@@ -297,25 +298,31 @@ uint16_t CCSDS::Packet::getFullPacketLength() {
 
 CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const std::uint64_t data) {
   FORWARD_RESULT(m_primaryHeader.setData( data ));
-  m_sequenceCounter = m_primaryHeader.getSequenceCount();
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
   m_updateStatus = false;
   return true;
 }
 
 CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const std::vector<uint8_t> &data) {
   FORWARD_RESULT(m_primaryHeader.deserialize( data ));
-  m_sequenceCounter = m_primaryHeader.getSequenceCount();
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
   m_updateStatus = false;
   return true;
 }
 
 void CCSDS::Packet::setPrimaryHeader(const Header &header) {
   m_primaryHeader = header;
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
+  m_updateStatus = false;
 }
 
 void CCSDS::Packet::setPrimaryHeader(const PrimaryHeader data) {
   m_primaryHeader.setData(data);
-  m_sequenceCounter = m_primaryHeader.getSequenceCount();
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
   m_updateStatus = false;
 }
 
@@ -369,7 +376,8 @@ void CCSDS::Packet::setSequenceFlags(const ESequenceFlag flags) {
 CCSDS::ResultBool CCSDS::Packet::setSequenceCount(const std::uint16_t count) {
   RET_IF_ERR_MSG(m_primaryHeader.getSequenceFlags() == UNSEGMENTED && count != 0, ErrorCode::INVALID_DATA,
                  "Unable to set non 0 value for UNSEGMENTED packet");
-  m_sequenceCounter = count;
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (count & SEQUENCE_COUNT_MASK);
   m_updateStatus = false;
   return true;
 }
@@ -384,9 +392,11 @@ void CCSDS::Packet::setUpdatePacketEnable(const bool enable) {
 }
 
 void CCSDS::Packet::setPacketErrorControlMode(const PacketErrorControlMode mode) {
-  m_packetErrorControlMode = mode;
   if (mode == PacketErrorControlMode::None) {
+    m_sequenceCounter |= PACKET_ERROR_CONTROL_DISABLED_MASK;
     m_CRC16 = 0;
+  } else {
+    m_sequenceCounter &= static_cast<std::uint16_t>(~PACKET_ERROR_CONTROL_DISABLED_MASK);
   }
   m_updateStatus = false;
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -24,7 +24,12 @@ void CCSDS::Packet::update() {
     } else {
       m_primaryHeader.setSequenceCount(m_sequenceCounter);
     }
-    m_CRC16 = crc16(dataField, m_CRC16Config.polynomial, m_CRC16Config.initialValue, m_CRC16Config.finalXorValue);
+
+    if (m_packetErrorControlMode == PacketErrorControlMode::CRC16) {
+      m_CRC16 = crc16(dataField, m_CRC16Config.polynomial, m_CRC16Config.initialValue, m_CRC16Config.finalXorValue);
+    } else {
+      m_CRC16 = 0;
+    }
     m_updateStatus = true;
   }
 }
@@ -77,6 +82,19 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
   m_primaryHeader.setSequenceFlags(sequenceFlag);
   m_primaryHeader.setSequenceCount(sequenceCount);
 
+  if (cfg.isKey("ccsds_packet_error_control")) {
+    std::string mode;
+    ASSIGN_CP(mode, cfg.get<std::string>("ccsds_packet_error_control"));
+    if (mode == "none" || mode == "None") {
+      setPacketErrorControlMode(PacketErrorControlMode::None);
+    } else if (mode == "crc16" || mode == "CRC16") {
+      setPacketErrorControlMode(PacketErrorControlMode::CRC16);
+    } else {
+      return Error{ErrorCode::CONFIG_FILE_ERROR,
+                   "Config: ccsds_packet_error_control must be 'none' or 'crc16'"};
+    }
+  }
+
   if (cfg.isKey( "data_field_size")) { // optional field
     std::uint16_t dataFieldSize;
     ASSIGN_OR_PRINT(dataFieldSize, cfg.get< int>( "data_field_size"));
@@ -102,6 +120,9 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
 #endif
 
 uint16_t CCSDS::Packet::getCRC() {
+  if (m_packetErrorControlMode == PacketErrorControlMode::None) {
+    return 0;
+  }
   update();
   return m_CRC16;
 }
@@ -116,6 +137,10 @@ bool CCSDS::Packet::getDataFieldHeaderFlag() {
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getCRCVectorBytes() {
+  if (m_packetErrorControlMode == PacketErrorControlMode::None) {
+    return {};
+  }
+
   std::vector<std::uint8_t> crc(2);
   const auto crcVar = getCRC();
   crc[0] = (crcVar >> 8) & 0xFF; // MSB (Most Significant Byte)
@@ -168,14 +193,17 @@ std::vector<std::uint8_t> CCSDS::Packet::serialize() {
   if (!getFullDataFieldBytes().empty()) {
     packet.insert(packet.end(), dataField.begin(), dataField.end());
   }
-  packet.insert(packet.end(), crc.begin(), crc.end());
+  if (!crc.empty()) {
+    packet.insert(packet.end(), crc.begin(), crc.end());
+  }
 
   return packet;
 }
 
 CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &data) {
-  RET_IF_ERR_MSG(data.size() <= 7, ErrorCode::INVALID_HEADER_DATA,
-                 "Cannot Deserialize Packet, Invalid Data provided data size must be at least 8 bytes");
+  const auto minimumPacketSize = static_cast<std::size_t>(6U + getPacketErrorControlSize());
+  RET_IF_ERR_MSG(data.size() < minimumPacketSize, ErrorCode::INVALID_HEADER_DATA,
+                 "Cannot Deserialize Packet, data is shorter than the primary header and configured packet error control");
 
   std::vector<std::uint8_t> dataFieldVector;
   std::copy(data.begin() + 6, data.end(), std::back_inserter(dataFieldVector));
@@ -186,8 +214,9 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &da
 }
 
 CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &data, const std::string &headerType, const std::int32_t headerSize) {
-  RET_IF_ERR_MSG(data.size() <= 8, ErrorCode::INVALID_DATA,
-                 "Cannot Deserialize Packet, Invalid Data provided data size must be at least 8 bytes");
+  const auto minimumPacketSize = static_cast<std::size_t>(6U + getPacketErrorControlSize());
+  RET_IF_ERR_MSG(data.size() < minimumPacketSize, ErrorCode::INVALID_DATA,
+                 "Cannot Deserialize Packet, invalid data provided");
   RET_IF_ERR_MSG(headerType == "BufferHeader", ErrorCode::INVALID_SECONDARY_HEADER_DATA,
                  "Cannot Deserialize Packet, BufferHeader is not of defined size");
   RET_IF_ERR_MSG(!m_dataField.getDataFieldHeaderFactory().typeIsRegistered(headerType),
@@ -200,6 +229,9 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &da
   }else {
     headerDataSizeBytes = secondaryHeader->getSize();
   }
+
+  RET_IF_ERR_MSG(data.size() < 6U + headerDataSizeBytes + getPacketErrorControlSize(), ErrorCode::INVALID_DATA,
+                 "Cannot Deserialize Packet, data is shorter than the configured secondary header and packet error control");
 
   std::vector<std::uint8_t> dataFieldHeaderVector;
   std::copy_n(data.begin() + 6, headerDataSizeBytes, std::back_inserter(dataFieldHeaderVector));
@@ -216,7 +248,7 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &da
 }
 
 CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &data, const std::uint16_t headerDataSizeBytes) {
-  RET_IF_ERR_MSG(data.size() < (8 + headerDataSizeBytes), ErrorCode::INVALID_DATA,
+  RET_IF_ERR_MSG(data.size() < (6U + headerDataSizeBytes + getPacketErrorControlSize()), ErrorCode::INVALID_DATA,
                  "Cannot Deserialize Packet, Invalid Data provided");
 
   std::vector<std::uint8_t> secondaryHeader;
@@ -236,23 +268,29 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &he
   FORWARD_RESULT(m_primaryHeader.deserialize( headerData ));
   m_sequenceCounter = m_primaryHeader.getSequenceCount();
 
-  RET_IF_ERR_MSG(data.size() < 2, ErrorCode::INVALID_DATA,
-                 "Cannot Deserialize Packet, Invalid Data provided, at least CRC is required.");
-
   std::vector<uint8_t> dataCopy;
-  m_CRC16 = (data[data.size() - 2] << 8) + data.back();
+  if (m_packetErrorControlMode == PacketErrorControlMode::CRC16) {
+    RET_IF_ERR_MSG(data.size() < 2, ErrorCode::INVALID_DATA,
+                   "Cannot Deserialize Packet, at least two packet error-control bytes are required in CRC16 mode.");
+    m_CRC16 = (static_cast<std::uint16_t>(data[data.size() - 2]) << 8) + data.back();
+    if (data.size() > 2) {
+      std::copy(data.begin(), data.end() - 2, std::back_inserter(dataCopy));
+    }
+  } else {
+    m_CRC16 = 0;
+    dataCopy = data;
+  }
 
-  if (data.size() == 2) return true; // returns since no application data is to be written.
+  if (!dataCopy.empty()) {
+    FORWARD_RESULT(m_dataField.setApplicationData(dataCopy));
+  }
 
-  std::copy(data.begin(), data.end() - 2, std::back_inserter(dataCopy));
-  FORWARD_RESULT(m_dataField.setApplicationData(dataCopy));
-
-  return true;;
+  m_updateStatus = true;
+  return true;
 }
 
 uint16_t CCSDS::Packet::getFullPacketLength() {
-  // where 8 is derived from 6 bytes for Primary header and 2 bytes for CRC16.
-  return 8 + m_dataField.getDataFieldUsedBytesSize();
+  return static_cast<std::uint16_t>(6U + m_dataField.getDataFieldUsedBytesSize() + getPacketErrorControlSize());
 }
 
 CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const std::uint64_t data) {
@@ -341,4 +379,12 @@ void CCSDS::Packet::setDataFieldSize(const std::uint16_t size) {
 void CCSDS::Packet::setUpdatePacketEnable(const bool enable) {
   m_enableUpdatePacket = enable;
   m_dataField.setDataFieldHeaderAutoUpdateStatus(enable);
+}
+
+void CCSDS::Packet::setPacketErrorControlMode(const PacketErrorControlMode mode) {
+  m_packetErrorControlMode = mode;
+  if (mode == PacketErrorControlMode::None) {
+    m_CRC16 = 0;
+  }
+  m_updateStatus = false;
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -285,7 +285,9 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &he
     FORWARD_RESULT(m_dataField.setApplicationData(dataCopy));
   }
 
-  m_updateStatus = true;
+  // Preserve the v1 lifecycle: dependent fields are recalculated on the next
+  // getter/serialization call unless automatic updates are explicitly disabled.
+  m_updateStatus = false;
   return true;
 }
 

--- a/test/src/testGroupEdgeCases.cpp
+++ b/test/src/testGroupEdgeCases.cpp
@@ -92,4 +92,42 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     auto res = pkt.deserialize(shortData);
     return !res; // Should fail
   });
+
+  tester->unitTest("Packet error control defaults to CRC16", []() {
+    CCSDS::Packet packet;
+    if (packet.getPacketErrorControlMode() != CCSDS::PacketErrorControlMode::CRC16) return false;
+    if (packet.getPacketErrorControlSize() != 2) return false;
+
+    TEST_VOID(packet.setApplicationData({0xAA, 0x55}));
+    const auto serialized = packet.serialize();
+    return serialized.size() == 10 && packet.getFullPacketLength() == 10;
+  });
+
+  tester->unitTest("Packet error control can be disabled", []() {
+    CCSDS::Packet packet;
+    packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    TEST_VOID(packet.setApplicationData({0xAA, 0x55}));
+
+    const auto serialized = packet.serialize();
+    if (serialized.size() != 8) return false;
+    if (packet.getFullPacketLength() != 8) return false;
+    if (!packet.getCRCVectorBytes().empty()) return false;
+    if (packet.getCRC() != 0) return false;
+
+    CCSDS::Packet decoded;
+    decoded.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    TEST_VOID(decoded.deserialize(serialized));
+    return decoded.getApplicationDataBytes() == std::vector<std::uint8_t>({0xAA, 0x55});
+  });
+
+  tester->unitTest("CRC16 mode still strips the received error control field", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setApplicationData({0x10, 0x20, 0x30}));
+    const auto serialized = packet.serialize();
+
+    CCSDS::Packet decoded;
+    TEST_VOID(decoded.deserialize(serialized));
+    if (decoded.getPacketErrorControlMode() != CCSDS::PacketErrorControlMode::CRC16) return false;
+    return decoded.getApplicationDataBytes() == std::vector<std::uint8_t>({0x10, 0x20, 0x30});
+  });
 }


### PR DESCRIPTION
## Summary

Adds explicit packet error-control selection to the v1 API as the first v1.2.0 compliance patch.

## Changes

- adds `PacketErrorControlMode::{None, CRC16}`;
- preserves `CRC16` as the default for all existing callers;
- omits the two-byte CRC field when `None` is selected;
- makes packet-size calculation depend on the configured mode;
- makes deserialization treat trailing bytes according to the configured mode instead of always assuming CRC16;
- adds optional `ccsds_packet_error_control` configuration support using `none` or `crc16`;
- adds regression tests for the default, CRC-disabled round trips, and CRC16 parsing.

## Compatibility

- Existing public APIs remain available.
- Existing construction/configuration paths continue to use CRC16 by default.
- `Packet` retains its existing object layout: the mode is stored in an unused bit of the existing 16-bit sequence-counter backing field, while the public sequence count remains limited to its CCSDS 14-bit range.
- Existing v1 deserialization/update lifecycle is preserved.

## Validation

- Linux workflow passes on Ubuntu 22.04, Ubuntu 24.04, and `ubuntu-latest`.
- Windows workflow passes on `windows-latest`.

## Follow-up

Packet Data Length and CRC coverage remain intentionally unchanged in this PR and are handled by #47 and #50.

Closes #49.