### PR TITLE
fix(CCSDSPack): #52 #53 #70 enforce stream identity and stable inspection

### DIFF
--- a/inc/CCSDSDataField.h
+++ b/inc/CCSDSDataField.h
@@ -54,20 +54,27 @@ namespace CCSDS {
     void setDataFieldHeader(std::shared_ptr<SecondaryHeaderAbstract> header);
 
     SecondaryHeaderFactory &getDataFieldHeaderFactory() { return m_secondaryHeaderFactory; }
+    [[nodiscard]] const SecondaryHeaderFactory &getDataFieldHeaderFactory() const {
+      return m_secondaryHeaderFactory;
+    }
     SecondaryHeaderAbstract &getDataFieldHeader() { return *m_secondaryHeader; }
+    [[nodiscard]] const SecondaryHeaderAbstract &getDataFieldHeader() const { return *m_secondaryHeader; }
     void setDataPacketSize(const std::uint16_t &value);
     void setDataFieldHeaderAutoUpdateStatus(const bool enable) { m_enableDataFieldUpdate = enable; }
 
-    std::uint16_t getDataFieldAbsoluteBytesSize() const;
-    std::uint16_t getApplicationDataBytesSize() const;
-    std::uint16_t getDataFieldUsedBytesSize() const;
-    std::uint16_t getDataFieldAvailableBytesSize() const;
+    [[nodiscard]] std::uint16_t getDataFieldAbsoluteBytesSize() const;
+    [[nodiscard]] std::uint16_t getApplicationDataBytesSize() const;
+    [[nodiscard]] std::uint16_t getDataFieldUsedBytesSize() const;
+    [[nodiscard]] std::uint16_t getDataFieldAvailableBytesSize() const;
     std::vector<std::uint8_t> getDataFieldHeaderBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
     std::vector<std::uint8_t> serialize();
     std::vector<std::uint8_t> getApplicationData();
+    [[nodiscard]] std::vector<std::uint8_t> getApplicationData() const;
     [[nodiscard]] bool getDataFieldHeaderAutoUpdateStatus() const { return m_enableDataFieldUpdate; }
     [[nodiscard]] bool getDataFieldHeaderFlag() const { return m_secondaryHeader != nullptr; }
-    [[nodiscard]] std::shared_ptr<SecondaryHeaderAbstract> getSecondaryHeader();
+    std::shared_ptr<SecondaryHeaderAbstract> getSecondaryHeader();
+    [[nodiscard]] std::shared_ptr<const SecondaryHeaderAbstract> getSecondaryHeader() const;
     void update();
 
   private:

--- a/inc/CCSDSHeader.h
+++ b/inc/CCSDSHeader.h
@@ -11,19 +11,39 @@
 namespace CCSDS {
   inline constexpr std::uint16_t IDLE_APID = 0x07FFU;
 
+  /**
+   * @brief Represents the sequence flags used in CCSDS telemetry transfer frames.
+   *
+   * This enum defines the possible sequence flag values that indicate the type
+   * and position of a data segment in a telemetry frame:
+   * - CONTINUING_SEGMENT: An intermediate segment of a packet.
+   * - FIRST_SEGMENT: The first segment of a new packet.
+   * - LAST_SEGMENT: The last segment of a packet that spans multiple frames.
+   * - UNSEGMENTED: A complete unsegmented packet contained in a single frame.
+   */
   enum ESequenceFlag : std::uint8_t {
-    CONTINUING_SEGMENT,
-    FIRST_SEGMENT,
-    LAST_SEGMENT,
-    UNSEGMENTED
+    CONTINUING_SEGMENT, ///< 00 Intermediate segment of a packet.
+    FIRST_SEGMENT,      ///< 01 First segment of a new packet.
+    LAST_SEGMENT,       ///< 10 Last segment of a packet.
+    UNSEGMENTED         ///< 11 Complete unsegmented packet.
   };
 
+  /**
+   * @brief Describes whether the current primary header is normal, idle, or invalid.
+   *
+   * `INVALID` is used as a fail-safe when a checked mutation fails and its
+   * returned error is ignored. An invalid header cannot be serialized.
+   */
   enum EHeaderStatus : std::uint8_t {
     NORMAL,
     IDLE,
     INVALID
   };
 
+  /**
+   * @struct PrimaryHeader
+   * @brief Represents the fields of a CCSDS primary header.
+   */
   struct PrimaryHeader {
     std::uint8_t versionNumber{};
     std::uint8_t type{};
@@ -49,6 +69,10 @@ namespace CCSDS {
         dataLength(dataLength_value) {}
   };
 
+  /**
+   * @class Header
+   * @brief Manages the decomposition and manipulation of CCSDS primary headers.
+   */
   class Header {
   public:
     Header() = default;
@@ -62,9 +86,17 @@ namespace CCSDS {
     [[nodiscard]] std::uint16_t getDataLength()         const { return m_dataLength;          }
     [[nodiscard]] EHeaderStatus getHeaderStatus()       const { return m_status;              }
 
+    /**
+     * @brief Serializes the current primary header.
+     * @return Six header bytes, or an empty vector when the header is invalid.
+     */
     std::vector<std::uint8_t> serialize();
     [[nodiscard]] std::vector<std::uint8_t> serialize() const;
 
+    /**
+     * @brief Returns the packed 48-bit primary header in a 64-bit value.
+     * @return The packed header, or zero when the header is invalid.
+     */
     std::uint64_t getFullHeader();
     [[nodiscard]] std::uint64_t getFullHeader() const;
 

--- a/inc/CCSDSHeader.h
+++ b/inc/CCSDSHeader.h
@@ -11,39 +11,19 @@
 namespace CCSDS {
   inline constexpr std::uint16_t IDLE_APID = 0x07FFU;
 
-  /**
-   * @brief Represents the sequence flags used in CCSDS telemetry transfer frames.
-   *
-   * This enum defines the possible sequence flag values that indicate the type
-   * and position of a data segment in a telemetry frame:
-   * - CONTINUING_SEGMENT: An intermediate segment of a packet.
-   * - FIRST_SEGMENT: The first segment of a new packet.
-   * - LAST_SEGMENT: The last segment of a packet that spans multiple frames.
-   * - UNSEGMENTED: A complete unsegmented packet contained in a single frame.
-   */
   enum ESequenceFlag : std::uint8_t {
-    CONTINUING_SEGMENT, ///< 00 Intermediate segment of a packet.
-    FIRST_SEGMENT,      ///< 01 First segment of a new packet.
-    LAST_SEGMENT,       ///< 10 Last segment of a packet.
-    UNSEGMENTED         ///< 11 Complete unsegmented packet.
+    CONTINUING_SEGMENT,
+    FIRST_SEGMENT,
+    LAST_SEGMENT,
+    UNSEGMENTED
   };
 
-  /**
-   * @brief Describes whether the current primary header is normal, idle, or invalid.
-   *
-   * `INVALID` is used as a fail-safe when a checked mutation fails and its
-   * returned error is ignored. An invalid header cannot be serialized.
-   */
   enum EHeaderStatus : std::uint8_t {
     NORMAL,
     IDLE,
     INVALID
   };
 
-  /**
-   * @struct PrimaryHeader
-   * @brief Represents the fields of a CCSDS primary header.
-   */
   struct PrimaryHeader {
     std::uint8_t versionNumber{};
     std::uint8_t type{};
@@ -69,10 +49,6 @@ namespace CCSDS {
         dataLength(dataLength_value) {}
   };
 
-  /**
-   * @class Header
-   * @brief Manages the decomposition and manipulation of CCSDS primary headers.
-   */
   class Header {
   public:
     Header() = default;
@@ -86,29 +62,11 @@ namespace CCSDS {
     [[nodiscard]] std::uint16_t getDataLength()         const { return m_dataLength;          }
     [[nodiscard]] EHeaderStatus getHeaderStatus()       const { return m_status;              }
 
-    /**
-     * @brief Serializes the current primary header.
-     * @return Six header bytes, or an empty vector when the header is invalid.
-     */
     std::vector<std::uint8_t> serialize();
+    [[nodiscard]] std::vector<std::uint8_t> serialize() const;
 
-    /**
-     * @brief Returns the packed 48-bit primary header in a 64-bit value.
-     * @return The packed header, or zero when the header is invalid.
-     */
-    std::uint64_t getFullHeader() {
-      if (m_status == INVALID) {
-        return 0;
-      }
-      m_packetSequenceControl = (static_cast<std::uint16_t>(m_sequenceFlags) << 14) | m_sequenceCount;
-      m_packetIdentificationAndVersion = (static_cast<std::uint16_t>(m_versionNumber) << 13)
-                                         | (static_cast<std::uint16_t>(m_type) << 12)
-                                         | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11)
-                                         | m_APID;
-      return (static_cast<std::uint64_t>(m_packetIdentificationAndVersion) << 32)
-             | (static_cast<std::uint32_t>(m_packetSequenceControl) << 16)
-             | m_dataLength;
-    }
+    std::uint64_t getFullHeader();
+    [[nodiscard]] std::uint64_t getFullHeader() const;
 
     [[nodiscard]] ResultBool setVersionNumber(const std::uint8_t &value);
     [[nodiscard]] ResultBool setType(const std::uint8_t &value);

--- a/inc/CCSDSManager.h
+++ b/inc/CCSDSManager.h
@@ -10,10 +10,23 @@
 #include "CCSDSValidator.h"
 
 namespace CCSDS {
+  /**
+   * @class Manager
+   * @brief Manages CCSDS packets and their templates.
+   *
+   * This class provides an interface for managing CCSDS packets, allowing
+   * users to set a packet template, configure data field sizes, and retrieve
+   * application data and packet instances.
+   */
   class Manager {
   public:
+    /** @brief Default constructor. */
     Manager() = default;
 
+    /**
+     * @brief Constructs a Manager with a given packet template.
+     * @param packet The packet template to be used as a reference.
+     */
     explicit Manager(Packet packet) {
       packet.update();
       m_templatePacket = std::move(packet);
@@ -24,58 +37,142 @@ namespace CCSDS {
       m_validator.configure(true, true, true);
     }
 
+    /**
+     * Set the sync pattern that indicates the start of a CCSDS packet.
+     * Insertion is disabled by default; use setSyncPatternEnable to enable it.
+     */
     void setSyncPattern(std::uint32_t syncPattern);
+
+    /** @return The currently configured sync pattern. */
     [[nodiscard]] std::uint32_t getSyncPattern() const;
+
+    /** @brief Enables sync-pattern insertion and parsing. */
     void setSyncPatternEnable(bool enable);
+
+    /** @return Whether sync-pattern handling is enabled. */
     [[nodiscard]] bool getSyncPatternEnable() const;
 
+    /**
+     * @brief Sets a new packet template.
+     * @param packet The new packet template to use.
+     */
     [[nodiscard]] ResultBool setPacketTemplate(Packet packet);
+
+    /** @brief Loads a template packet from a configuration file. */
     [[nodiscard]] ResultBool loadTemplateConfigFile(const std::string &configPath);
 #ifndef CCSDS_MCU
+    /** @brief Loads a template packet from a configuration object. */
     [[nodiscard]] ResultBool loadTemplateConfig(const Config &cfg);
 #endif
 
+    /** @brief Sets the size of the data field. */
     void setDataFieldSize(std::uint16_t size);
+
+    /** @return The configured data-field size, including a secondary header. */
     [[nodiscard]] std::uint16_t getDataFieldSize() const;
+
+    /**
+     * @brief Segments and assigns application data using the packet template.
+     * @return ResultBool indicating success or failure.
+     */
     [[nodiscard]] ResultBool setApplicationData(const std::vector<std::uint8_t> &data);
 
+    /** @brief Enables or disables automatic packet finalization. */
     void setAutoUpdateEnable(bool enable);
+
+    /** @brief Enables or disables automatic packet validation. */
     void setAutoValidateEnable(bool enable);
 
+    /**
+     * @brief Enables or disables automatic sequence-count advancement.
+     *
+     * Automatic mode assigns the current count to each generated packet and
+     * advances modulo 16384. Manual mode reuses the configured count.
+     */
     void setAutoSequenceCountEnable(bool enable);
+
+    /** @return Whether automatic sequence-count advancement is enabled. */
     [[nodiscard]] bool getAutoSequenceCountEnable() const {
       return (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) == 0U;
     }
+
+    /** @brief Sets the Manager stream sequence count in the range 0..16383. */
     [[nodiscard]] ResultBool setSequenceCount(std::uint16_t count);
+
+    /** @return The current 14-bit Manager stream sequence count. */
     [[nodiscard]] std::uint16_t getSequenceCount() const {
       return m_sequenceCount & SEQUENCE_COUNT_MASK;
     }
 
+    /** @brief Retrieves the packet template in serialized form. */
     ResultBuffer getPacketTemplate();
+
+    /** @brief Retrieves a serialized packet at the specified index. */
     ResultBuffer getPacketBufferAtIndex(std::uint16_t index);
+
+    /** @brief Retrieves all stored packets as one sequential byte buffer. */
     [[nodiscard]] std::vector<std::uint8_t> getPacketsBuffer() const;
+
+    /** @brief Retrieves reassembled application data from the packets. */
     [[nodiscard]] ResultBuffer getApplicationDataBuffer();
+
+    /** @brief Retrieves application data from one packet. */
     ResultBuffer getApplicationDataBufferAtIndex(std::uint16_t index);
+
+    /** @return The total number of stored packets. */
     [[nodiscard]] std::uint16_t getTotalPackets() const;
+
+    /** @return True when automatic packet updates are enabled. */
     [[nodiscard]] bool getAutoUpdateEnable() const { return m_updateEnable; }
 
+    /** @return A copy of the stored packet template. */
     Packet getTemplate() { return m_templatePacket; }
     [[nodiscard]] Packet getTemplate() const { return m_templatePacket; }
+
+    /** @return A copy of all stored packets. */
     std::vector<Packet> getPackets();
     [[nodiscard]] std::vector<Packet> getPackets() const;
 
+    /**
+     * @brief Adds a packet when its complete Packet Identification matches the
+     * Manager-bound stream identifier.
+     */
     [[nodiscard]] ResultBool addPacket(Packet packet);
+
+    /** @brief Parses and adds one packet from a byte buffer. */
     [[nodiscard]] ResultBool addPacketFromBuffer(const std::vector<std::uint8_t> &packetBuffer);
+
+    /** @brief Transactionally loads a collection of packets. */
     [[nodiscard]] ResultBool load(const std::vector<Packet> &packets);
+
+    /** @brief Transactionally loads one or more concatenated packets. */
     [[nodiscard]] ResultBool load(const std::vector<std::uint8_t> &packetsBuffer);
+
+    /** @brief Loads packets from a binary file. */
     [[nodiscard]] ResultBool read(const std::string &binaryFile);
+
+    /** @brief Writes stored packets to a binary file. */
     [[nodiscard]] ResultBool write(const std::string &binaryFile) const;
+
+    /** @brief Loads a template packet from a binary or configuration file. */
     [[nodiscard]] ResultBool readTemplate(const std::string &filename);
 
+    /** @brief Clears packets, template, identifier binding, and sequence state. */
     void clear();
+
+    /** @brief Clears stored packets and resets the sequence counter to zero. */
     void clearPackets();
 
+    /**
+     * @brief Returns a reference to the Manager's Validator.
+     * @note Changing this instance affects Manager validation.
+     */
     Validator &getValidatorReference() { return m_validator; }
+
+    /**
+     * @brief Returns a reference to the packets vector.
+     * @note Direct mutation can bypass Manager invariants.
+     */
     std::vector<Packet> &getPacketsReference() { return m_packets; }
 
   private:
@@ -90,17 +187,17 @@ namespace CCSDS {
     void advanceSequenceCount();
     void syncSequenceCountFromPacket(const Packet &packet);
 
-    Packet m_templatePacket{};
-    bool m_templateIsSet{false};
-    bool m_updateEnable{true};
-    bool m_validateEnable{true};
-    bool m_syncPattEnable{false};
-    std::vector<Packet> m_packets;
-    std::uint16_t m_sequenceCount{0};
+    Packet m_templatePacket{};         ///< Template used for generating new packets.
+    bool m_templateIsSet{false};       ///< Whether a template has been configured.
+    bool m_updateEnable{true};         ///< Whether automatic packet finalization is enabled.
+    bool m_validateEnable{true};       ///< Whether automatic validation is enabled.
+    bool m_syncPattEnable{false};      ///< Whether sync-pattern handling is enabled.
+    std::vector<Packet> m_packets;     ///< Collection of stored packets.
+    std::uint16_t m_sequenceCount{0};  ///< Count in low 14 bits; manual-mode flag in bit 15.
 
     Validator m_validator{};
     std::uint32_t m_syncPattern{0x1ACFFC1D};
   };
-}
+} // namespace CCSDS
 
 #endif // CCSDS_MANAGER_H

--- a/inc/CCSDSManager.h
+++ b/inc/CCSDSManager.h
@@ -10,272 +10,97 @@
 #include "CCSDSValidator.h"
 
 namespace CCSDS {
-  /**
-   * @class Manager
-   * @brief Manages CCSDS packets and their templates.
-   *
-   * This class provides an interface for managing CCSDS packets, allowing
-   * users to set a packet template, configure data field sizes, and retrieve
-   * application data and packet instances.
-   */
   class Manager {
   public:
-    /**
-     * @brief Default constructor.
-     */
     Manager() = default;
 
-    /**
-     * @brief Constructs a Manager with a given packet template.
-     *
-     * @param packet The packet template to be used as a reference.
-     */
-    explicit Manager(Packet packet) : m_templatePacket(std::move(packet)) {
+    explicit Manager(Packet packet) {
+      packet.update();
+      m_templatePacket = std::move(packet);
       m_templateIsSet = true;
+      m_sequenceCount = m_templatePacket.getPrimaryHeader().getSequenceCount() & SEQUENCE_COUNT_MASK;
       m_templatePacket.setUpdatePacketEnable(false);
       m_validator.setTemplatePacket(m_templatePacket);
       m_validator.configure(true, true, true);
-
     }
 
-    /**
-     * set sync pattern that should indicate the start of a CCSDS packet. insertion
-     * is disabled by default. use setSyncPatternEnable to enable.
-     *
-     * @param syncPattern std::uint32_t (default 0x1ACFFC1D)
-     */
     void setSyncPattern(std::uint32_t syncPattern);
-
-    /**
-     * returns the currently set sync pattern.
-     *
-     * @return std::uint32_t
-     */
-    std::uint32_t getSyncPattern() const;
-
-    /**
-     * enable sync pattern utilization both in serialization, deserialization, read and write.
-     *
-     * @param enable bool (default false)
-     */
+    [[nodiscard]] std::uint32_t getSyncPattern() const;
     void setSyncPatternEnable(bool enable);
+    [[nodiscard]] bool getSyncPatternEnable() const;
 
-    /**
-     * returns the current settings of the sync pattern enable
-     *
-     * @return bool
-     */
-    bool getSyncPatternEnable() const;
-
-    /**
-     * @brief Sets a new packet template.
-     *
-     * @param packet The new packet template to use.
-     */
     [[nodiscard]] ResultBool setPacketTemplate(Packet packet);
-
-    /**
-    * @brief Loads a template packet from a configuration file.
-    *
-    * @param configPath  path to the configuration file.
-    */
     [[nodiscard]] ResultBool loadTemplateConfigFile(const std::string &configPath);
 #ifndef CCSDS_MCU
-    /**
-    * @brief Loads a template packet from a configuration object.
-    *
-    * @param cfg  Configuration obj to load template from.
-    */
     [[nodiscard]] ResultBool loadTemplateConfig(const Config &cfg);
 #endif
 
-    /**
-     * @brief Sets the size of the data field.
-     *
-     * @param size The new data field size in bytes.
-     */
-    void setDataFieldSize( std::uint16_t size );
+    void setDataFieldSize(std::uint16_t size);
+    [[nodiscard]] std::uint16_t getDataFieldSize() const;
+    [[nodiscard]] ResultBool setApplicationData(const std::vector<std::uint8_t> &data);
 
-    /**
-     * @brief retrieves the set data field size (this includes the secondary header if present)
-     *
-     * @return std::uint16_t the size of data length in bytes.
-     */
-    std::uint16_t getDataFieldSize() const;
+    void setAutoUpdateEnable(bool enable);
+    void setAutoValidateEnable(bool enable);
 
-    /**
-     * @brief Sets the application data for the packet.
-     *
-     * @param data The application data as a vector of bytes.
-     * @return ResultBool indicating success or failure.
-     */
-    ResultBool setApplicationData( const std::vector<std::uint8_t> &data );
+    void setAutoSequenceCountEnable(bool enable);
+    [[nodiscard]] bool getAutoSequenceCountEnable() const {
+      return (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) == 0U;
+    }
+    [[nodiscard]] ResultBool setSequenceCount(std::uint16_t count);
+    [[nodiscard]] std::uint16_t getSequenceCount() const {
+      return m_sequenceCount & SEQUENCE_COUNT_MASK;
+    }
 
-    /**
-     * @brief Enables or disables automatic updates for packets.
-     *
-     * @param enable Set to true to enable automatic updates, false to disable.
-     */
-    void setAutoUpdateEnable( bool enable );
-
-    /**
-     * @brief Enables or disables automatic validation of packets.
-     *
-     * @param enable Set to true to enable automatic validation, false to disable.
-     */
-    void setAutoValidateEnable( bool enable );
-
-    /**
-     * @brief Retrieves the packet template in serialized form.
-     *
-     * @return A ResultBuffer containing the serialized packet template.
-     */
     ResultBuffer getPacketTemplate();
-
-    /**
-     * @brief Retrieves a packet at the specified index.
-     *
-     * @param index The index of the packet to retrieve.
-     * @return A ResultBuffer containing the requested packet.
-     */
-    ResultBuffer getPacketBufferAtIndex( std::uint16_t index );
-
-
-    /**
-     * @brief Retrieves a buffer containing all the stored packets sequentially.
-     *
-     * @return A vector of bytes containing the packets data.
-     */
-    std::vector<std::uint8_t> getPacketsBuffer() const;
-
-    /**
-     * @brief Retrieves the application data from the packets.
-     *
-     * @return A ResultBuffer containing the application data.
-     */
+    ResultBuffer getPacketBufferAtIndex(std::uint16_t index);
+    [[nodiscard]] std::vector<std::uint8_t> getPacketsBuffer() const;
     [[nodiscard]] ResultBuffer getApplicationDataBuffer();
-
-    /**
-     * @brief Retrieves the application data from a packet at the given index.
-     *
-     * @param index The index of the packet.
-     * @return A ResultBuffer containing the application data of the selected packet.
-     */
-    ResultBuffer getApplicationDataBufferAtIndex( std::uint16_t index );
-
-    /**
-     * @brief Retrieves the total number of packets managed.
-     *
-     * @return The total number of stored packets.
-     */
+    ResultBuffer getApplicationDataBufferAtIndex(std::uint16_t index);
     [[nodiscard]] std::uint16_t getTotalPackets() const;
-
-    /**
-     * @brief Checks if automatic updates are enabled.
-     *
-     * @return True if auto-update is enabled, false otherwise.
-     */
     [[nodiscard]] bool getAutoUpdateEnable() const { return m_updateEnable; }
 
-    /**
-     * @brief Retrieves the packet template.
-     *
-     * @return The stored packet template.
-     */
-    Packet getTemplate() { return m_templatePacket; };
-
-    /**
-     * @brief Retrieves all stored packets.
-     *
-     * @return A vector containing all managed packets.
-     */
+    Packet getTemplate() { return m_templatePacket; }
+    [[nodiscard]] Packet getTemplate() const { return m_templatePacket; }
     std::vector<Packet> getPackets();
+    [[nodiscard]] std::vector<Packet> getPackets() const;
 
-    /**
-     * @brief Adds a new packet to the list.
-     *
-     * @param packet The new packet to be added.
-     */
     [[nodiscard]] ResultBool addPacket(Packet packet);
+    [[nodiscard]] ResultBool addPacketFromBuffer(const std::vector<std::uint8_t> &packetBuffer);
+    [[nodiscard]] ResultBool load(const std::vector<Packet> &packets);
+    [[nodiscard]] ResultBool load(const std::vector<std::uint8_t> &packetsBuffer);
+    [[nodiscard]] ResultBool read(const std::string &binaryFile);
+    [[nodiscard]] ResultBool write(const std::string &binaryFile) const;
+    [[nodiscard]] ResultBool readTemplate(const std::string &filename);
 
-    /**
-     * @brief Adds a new packet to the list.
-     *
-     * @param packetBuffer The new packet to be added in the form of a buffer.
-     */
-    [[nodiscard]] ResultBool addPacketFromBuffer(const std::vector<std::uint8_t>& packetBuffer);
-
-    /**
-     * @brief Load a vector of packets.
-     *
-     * @param packets The packets
-     */
-    [[nodiscard]] ResultBool load(const std::vector<Packet>& packets);
-
-    /**
-     * @brief Load a packet or a series of packets from a buffer
-     *
-     * @param packetsBuffer The buffer holding packet data.
-     */
-    [[nodiscard]] ResultBool load(const std::vector<std::uint8_t>& packetsBuffer);
-
-    /**
-     * @brief Load a packet or a series of packets from a binary file
-     *
-     * @param binaryFile path to the file holding packet data.
-     */
-    [[nodiscard]] ResultBool read(const std::string& binaryFile);
-
-    /**
-     * @brief Write a packet or a series of packets to a binary file
-     *
-     * @param binaryFile destination file path for packets data.
-     */
-    [[nodiscard]] ResultBool write(const std::string& binaryFile) const;
-
-    /**
-     * @brief Load a template packet from a binary or configuration file
-     *
-     * @param filename path to the file holding template.
-     */
-    [[nodiscard]] ResultBool readTemplate(const std::string& filename);
-
-    /**
-     * @brief Clears the manager, removes all packets and template.
-     */
     void clear();
-
-    /**
-     * @brief Clears the packets and sets the counter to 0.
-     */
     void clearPackets();
 
-    /**
-     * @brief Returns a reverence to the manager's Validator
-     *
-     * @note changing settings of this instance will affect the manager
-     */
-    Validator& getValidatorReference() { return m_validator; }
-
-    /**
-     * @brief Returns a reference to the packets vector
-     *
-     * @note changing the data will affect the packets stored in the manager.
-     */
-    std::vector<Packet>& getPacketsReference() { return m_packets; }
+    Validator &getValidatorReference() { return m_validator; }
+    std::vector<Packet> &getPacketsReference() { return m_packets; }
 
   private:
-    Packet m_templatePacket{};         ///< The template packet used for generating new packets.
-    bool m_templateIsSet  { false };   ///< Boolean to indicate if Template has been set or not.
-    bool m_updateEnable   {  true };   ///< bool indicating whether automatic updates are enabled (default: true).
-    bool m_validateEnable {  true };   ///< bool indicating whether automatic validation is enabled (default: true).
-    bool m_syncPattEnable { false };   ///< bool indicating whether automatic sync pattern insertion is enabled (default: false).
-    std::vector<Packet> m_packets;     ///< Collection of stored packets.
-    std::uint16_t m_sequenceCount{ 0 };
+    static constexpr std::uint16_t SEQUENCE_COUNT_MASK{0x3FFFU};
+    static constexpr std::uint16_t AUTO_SEQUENCE_DISABLED_MASK{0x8000U};
+
+    [[nodiscard]] static std::uint16_t packetIdentifier(const Packet &packet);
+    [[nodiscard]] bool hasIdentifierBinding() const;
+    [[nodiscard]] std::uint16_t boundPacketIdentifier() const;
+    [[nodiscard]] ResultBool validatePacketIdentifier(const Packet &packet) const;
+    [[nodiscard]] PacketErrorControlMode boundPacketErrorControlMode() const;
+    void advanceSequenceCount();
+    void syncSequenceCountFromPacket(const Packet &packet);
+
+    Packet m_templatePacket{};
+    bool m_templateIsSet{false};
+    bool m_updateEnable{true};
+    bool m_validateEnable{true};
+    bool m_syncPattEnable{false};
+    std::vector<Packet> m_packets;
+    std::uint16_t m_sequenceCount{0};
 
     Validator m_validator{};
     std::uint32_t m_syncPattern{0x1ACFFC1D};
   };
-} // namespace CCSDS
+}
 
 #endif // CCSDS_MANAGER_H

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -87,24 +87,39 @@ namespace CCSDS {
                                                          std::uint16_t headerDataSizeBytes);
 
     std::uint64_t getPrimaryHeader64bit();
+    [[nodiscard]] std::uint64_t getPrimaryHeader64bit() const;
     std::uint16_t getFullPacketLength();
+    [[nodiscard]] std::uint16_t getFullPacketLength() const;
     std::vector<std::uint8_t> serialize();
     std::vector<std::uint8_t> getPrimaryHeaderBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getPrimaryHeaderBytes() const;
     std::vector<std::uint8_t> getDataFieldHeaderBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
     std::vector<std::uint8_t> getApplicationDataBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getApplicationDataBytes() const;
     std::vector<std::uint8_t> getFullDataFieldBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getFullDataFieldBytes() const;
     std::vector<std::uint8_t> getCRCVectorBytes();
+    [[nodiscard]] std::vector<std::uint8_t> getCRCVectorBytes() const;
     std::uint16_t getCRC();
-    std::uint16_t getDataFieldMaximumSize() const;
+    [[nodiscard]] std::uint16_t getCRC() const;
+    [[nodiscard]] std::uint16_t getDataFieldMaximumSize() const;
     bool getDataFieldHeaderFlag();
+    [[nodiscard]] bool getDataFieldHeaderFlag() const;
     DataField &getDataField();
+    [[nodiscard]] const DataField &getDataField() const;
     Header &getPrimaryHeader();
+    [[nodiscard]] const Header &getPrimaryHeader() const;
 
-    void setCrcConfig(const CRC16Config crcConfig) { m_CRC16Config = crcConfig; }
+    void setCrcConfig(const CRC16Config crcConfig) {
+      m_CRC16Config = crcConfig;
+      m_updateStatus = false;
+    }
     void setCrcConfig(const std::uint16_t polynomial,
                       const std::uint16_t initialValue,
                       const std::uint16_t finalXorValue) {
       m_CRC16Config = {polynomial, initialValue, finalXorValue};
+      m_updateStatus = false;
     }
 
     void update();

--- a/inc/CCSDSValidator.h
+++ b/inc/CCSDSValidator.h
@@ -1,87 +1,67 @@
 // Copyright 2025-2026 ExoSpaceLabs
 // SPDX-License-Identifier: Apache-2.0
 
-/// @file CCSDSValidator.h
-/// @brief Defines the Validator class for CCSDS packet validation.
 #ifndef CCSDS_VALIDATOR_H
 #define CCSDS_VALIDATOR_H
 
 #include "CCSDSPacket.h"
 
 namespace CCSDS {
-  /**
-   * @brief Handles validation of CCSDS packets.
-   *
-   * The Validator class checks packet coherence and compares packets against a template.
-   */
   class Validator {
   public:
-    /// @brief Default constructor.
     Validator() = default;
-
-    /// @brief Default destructor.
     ~Validator() = default;
 
-    /**
-     * @brief Constructs a Validator with a template packet.
-     * @param templatePacket The packet template to use for validation.
-     */
-    explicit Validator(const Packet &templatePacket) : m_templatePacket(templatePacket) {
-    };
+    explicit Validator(const Packet &templatePacket) : m_templatePacket(templatePacket) {}
 
-    /**
-     * @brief Sets the template packet for validation.
-     * @param templatePacket The new template packet.
-     */
-    void setTemplatePacket(const Packet &templatePacket) { m_templatePacket = templatePacket; }
+    void setTemplatePacket(const Packet &templatePacket) {
+      m_templatePacket = templatePacket;
+    }
 
-    /**
-     * @brief Configures validation options.
-     * @param validatePacketCoherence Enables/disables packet coherence validation.
-     * @param validateSequenceCount
-     * @param validateAgainstTemplate Enables/disables comparison against the template.
-     */
-    void configure(bool validatePacketCoherence, bool validateSequenceCount, bool validateAgainstTemplate);
+    void configure(bool validatePacketCoherence,
+                   bool validateSequenceCount,
+                   bool validateAgainstTemplate);
 
-    /**
-     * @brief Validates a given packet.
-     * @param packet The packet to validate.
-     * @return True if the packet passes validation, otherwise false.
-     */
     bool validate(const Packet &packet);
 
     /**
-     * @brief Returns a report of performed validation checks.
-     *
-     * - Packet Coherence:
-     *     - index [0]: Data Field Length Header declared equals actual data field length
-     *     - index [1]: CRC15 value declared equals calculated CRC16 of the data field
-     *     - index [2]: Sequence Control flags and count coherence
-     *     - index [3]: Sequence Control count coherence (incremental start from 1)
-     * - Compare Against Template:
-     *     - index [4]: Identification and Version in packet matches template
-     *     - index [5]: Template Sequence Control match
-     *
-     * @return A vector of boolean results for each performed check.
+     * Report indices:
+     * [0] Packet Data Length coherence
+     * [1] CRC coherence
+     * [2] sequence-flag coherence
+     * [3] sequence-count continuity
+     * [4] complete Packet Identification matches template
+     * [5] segmented/unsegmented class matches template
      */
     [[nodiscard]] std::vector<bool> getReport() const { return m_report; }
 
-    /**
-     * @brief Clears the validator, resets counter
-     *
-     */
     void clear();
 
   private:
-    Packet m_templatePacket;               ///< Template packet used for validation.
-    bool m_validatePacketCoherence{true};  ///< Whether to validate packet length and CRC (default is true).
-    bool m_validateAgainstTemplate{false}; ///< Whether to validate against the template packet (default is false).
-    bool m_validateSegmentedCount{true};  ///< Whether to validate the count of segmented packets.
-    std::uint16_t m_sequenceCounter{1};         ///< Counter for segmented Packets
-    std::vector<bool> m_report{};          ///< List of boolean results representing performed checks.
-    size_t m_reportSize{6};                ///< Expected size of the validation report.
+    static constexpr std::uint16_t SEQUENCE_COUNT_MASK{0x3FFFU};
+    static constexpr std::uint16_t SEGMENT_OPEN_MASK{0x4000U};
+    static constexpr std::uint16_t SEQUENCE_INITIALIZED_MASK{0x8000U};
+
+    [[nodiscard]] bool sequenceInitialized() const {
+      return (m_sequenceCounter & SEQUENCE_INITIALIZED_MASK) != 0U;
+    }
+    [[nodiscard]] bool segmentOpen() const {
+      return (m_sequenceCounter & SEGMENT_OPEN_MASK) != 0U;
+    }
+    [[nodiscard]] std::uint16_t expectedSequenceCount() const {
+      return m_sequenceCounter & SEQUENCE_COUNT_MASK;
+    }
+    void acceptSequence(const Header &header);
+
+    Packet m_templatePacket;
+    bool m_validatePacketCoherence{true};
+    bool m_validateAgainstTemplate{false};
+    bool m_validateSegmentedCount{true};
+    std::uint16_t m_sequenceCounter{0};
+    std::vector<bool> m_report{};
+    std::size_t m_reportSize{6};
     CRC16Config m_CRCConfig;
   };
-} // namespace CCSDS
+}
 
 #endif // CCSDS_VALIDATOR_H

--- a/inc/CCSDSValidator.h
+++ b/inc/CCSDSValidator.h
@@ -1,40 +1,72 @@
 // Copyright 2025-2026 ExoSpaceLabs
 // SPDX-License-Identifier: Apache-2.0
 
+/// @file CCSDSValidator.h
+/// @brief Defines the Validator class for CCSDS packet validation.
 #ifndef CCSDS_VALIDATOR_H
 #define CCSDS_VALIDATOR_H
 
 #include "CCSDSPacket.h"
 
 namespace CCSDS {
+  /**
+   * @brief Handles validation of CCSDS packets.
+   *
+   * The Validator class checks packet coherence, sequence-stream coherence,
+   * and comparison against a packet template.
+   */
   class Validator {
   public:
+    /// @brief Default constructor.
     Validator() = default;
+
+    /// @brief Default destructor.
     ~Validator() = default;
 
+    /**
+     * @brief Constructs a Validator with a template packet.
+     * @param templatePacket The packet template to use for validation.
+     */
     explicit Validator(const Packet &templatePacket) : m_templatePacket(templatePacket) {}
 
-    void setTemplatePacket(const Packet &templatePacket) {
-      m_templatePacket = templatePacket;
-    }
+    /**
+     * @brief Sets the template packet for validation.
+     * @param templatePacket The new template packet.
+     */
+    void setTemplatePacket(const Packet &templatePacket) { m_templatePacket = templatePacket; }
 
+    /**
+     * @brief Configures validation options.
+     * @param validatePacketCoherence Enables packet length, CRC, and flag-coherence validation.
+     * @param validateSequenceCount Enables sequence-count continuity validation.
+     * @param validateAgainstTemplate Enables comparison against the template.
+     */
     void configure(bool validatePacketCoherence,
                    bool validateSequenceCount,
                    bool validateAgainstTemplate);
 
+    /**
+     * @brief Validates a given packet.
+     * @param packet The packet to validate.
+     * @return True if the packet passes validation, otherwise false.
+     */
     bool validate(const Packet &packet);
 
     /**
-     * Report indices:
-     * [0] Packet Data Length coherence
-     * [1] CRC coherence
-     * [2] sequence-flag coherence
-     * [3] sequence-count continuity
-     * [4] complete Packet Identification matches template
-     * [5] segmented/unsegmented class matches template
+     * @brief Returns a report of performed validation checks.
+     *
+     * - Packet coherence:
+     *     - index [0]: Packet Data Length matches the packet data field.
+     *     - index [1]: Received CRC16 matches the calculated CRC16.
+     *     - index [2]: Sequence flags are coherent with segmentation state.
+     *     - index [3]: Sequence count matches the expected next count.
+     * - Compare against template:
+     *     - index [4]: Complete Packet Identification matches the template.
+     *     - index [5]: Segmented/unsegmented class matches the template.
      */
     [[nodiscard]] std::vector<bool> getReport() const { return m_report; }
 
+    /** @brief Clears the validator and resets sequence-stream state. */
     void clear();
 
   private:
@@ -53,15 +85,15 @@ namespace CCSDS {
     }
     void acceptSequence(const Header &header);
 
-    Packet m_templatePacket;
-    bool m_validatePacketCoherence{true};
-    bool m_validateAgainstTemplate{false};
-    bool m_validateSegmentedCount{true};
-    std::uint16_t m_sequenceCounter{0};
-    std::vector<bool> m_report{};
-    std::size_t m_reportSize{6};
+    Packet m_templatePacket;               ///< Template packet used for validation.
+    bool m_validatePacketCoherence{true};  ///< Whether to validate packet length, CRC, and sequence flags.
+    bool m_validateAgainstTemplate{false}; ///< Whether to validate against the template packet.
+    bool m_validateSegmentedCount{true};   ///< Whether to validate sequence-count continuity.
+    std::uint16_t m_sequenceCounter{0};    ///< Expected count and segmentation state packed in one word.
+    std::vector<bool> m_report{};          ///< Results of the performed validation checks.
+    std::size_t m_reportSize{6};           ///< Expected report size.
     CRC16Config m_CRCConfig;
   };
-}
+} // namespace CCSDS
 
 #endif // CCSDS_VALIDATOR_H

--- a/src/CCSDSDataField.cpp
+++ b/src/CCSDSDataField.cpp
@@ -7,7 +7,7 @@
 
 std::vector<std::uint8_t> CCSDS::DataField::serialize() {
   update();
-  const auto dataFieldHeader = getDataFieldHeaderBytes();
+  const auto dataFieldHeader = static_cast<const DataField &>(*this).getDataFieldHeaderBytes();
   std::vector<std::uint8_t> fullData{};
   fullData.reserve(dataFieldHeader.size() + m_applicationData.size());
   fullData.insert(fullData.end(), dataFieldHeader.begin(), dataFieldHeader.end());
@@ -16,6 +16,10 @@ std::vector<std::uint8_t> CCSDS::DataField::serialize() {
 }
 
 std::vector<std::uint8_t> CCSDS::DataField::getApplicationData() {
+  return static_cast<const DataField &>(*this).getApplicationData();
+}
+
+std::vector<std::uint8_t> CCSDS::DataField::getApplicationData() const {
   return m_applicationData;
 }
 
@@ -39,7 +43,10 @@ std::uint16_t CCSDS::DataField::getDataFieldUsedBytesSize() const {
 }
 
 std::shared_ptr<CCSDS::SecondaryHeaderAbstract> CCSDS::DataField::getSecondaryHeader() {
-  update();
+  return m_secondaryHeader;
+}
+
+std::shared_ptr<const CCSDS::SecondaryHeaderAbstract> CCSDS::DataField::getSecondaryHeader() const {
   return m_secondaryHeader;
 }
 
@@ -179,6 +186,9 @@ void CCSDS::DataField::setDataPacketSize(const std::uint16_t &value) {
 }
 
 std::vector<std::uint8_t> CCSDS::DataField::getDataFieldHeaderBytes() {
-  update();
+  return static_cast<const DataField &>(*this).getDataFieldHeaderBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::DataField::getDataFieldHeaderBytes() const {
   return m_secondaryHeader ? m_secondaryHeader->serialize() : std::vector<std::uint8_t>{};
 }

--- a/src/CCSDSHeader.cpp
+++ b/src/CCSDSHeader.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CCSDSHeader.h"
-#include "CCSDSUtils.h"
 
 void CCSDS::Header::refreshStatus() {
   m_status = m_APID == IDLE_APID ? IDLE : NORMAL;
@@ -107,24 +106,50 @@ CCSDS::ResultBool CCSDS::Header::setData(const std::uint64_t &data) {
 }
 
 std::vector<std::uint8_t> CCSDS::Header::serialize() {
+  return static_cast<const Header &>(*this).serialize();
+}
+
+std::vector<std::uint8_t> CCSDS::Header::serialize() const {
   if (m_status == INVALID) {
     return {};
   }
 
-  m_packetSequenceControl = (static_cast<std::uint16_t>(m_sequenceFlags) << 14) | m_sequenceCount;
-  m_packetIdentificationAndVersion = (static_cast<std::uint16_t>(m_versionNumber) << 13)
-                                     | (static_cast<std::uint16_t>(m_type) << 12)
-                                     | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11)
-                                     | m_APID;
+  const auto packetSequenceControl = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_sequenceFlags) << 14U) | m_sequenceCount);
+  const auto packetIdentificationAndVersion = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_versionNumber) << 13U)
+    | (static_cast<std::uint16_t>(m_type) << 12U)
+    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | m_APID);
 
   return {
-    static_cast<std::uint8_t>(m_packetIdentificationAndVersion >> 8),
-    static_cast<std::uint8_t>(m_packetIdentificationAndVersion & 0xFFU),
-    static_cast<std::uint8_t>(m_packetSequenceControl >> 8),
-    static_cast<std::uint8_t>(m_packetSequenceControl & 0xFFU),
-    static_cast<std::uint8_t>(m_dataLength >> 8),
+    static_cast<std::uint8_t>(packetIdentificationAndVersion >> 8U),
+    static_cast<std::uint8_t>(packetIdentificationAndVersion & 0xFFU),
+    static_cast<std::uint8_t>(packetSequenceControl >> 8U),
+    static_cast<std::uint8_t>(packetSequenceControl & 0xFFU),
+    static_cast<std::uint8_t>(m_dataLength >> 8U),
     static_cast<std::uint8_t>(m_dataLength & 0xFFU),
   };
+}
+
+std::uint64_t CCSDS::Header::getFullHeader() {
+  return static_cast<const Header &>(*this).getFullHeader();
+}
+
+std::uint64_t CCSDS::Header::getFullHeader() const {
+  if (m_status == INVALID) {
+    return 0U;
+  }
+  const auto packetSequenceControl = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_sequenceFlags) << 14U) | m_sequenceCount);
+  const auto packetIdentificationAndVersion = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_versionNumber) << 13U)
+    | (static_cast<std::uint16_t>(m_type) << 12U)
+    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | m_APID);
+  return (static_cast<std::uint64_t>(packetIdentificationAndVersion) << 32U)
+         | (static_cast<std::uint32_t>(packetSequenceControl) << 16U)
+         | m_dataLength;
 }
 
 CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
@@ -160,11 +185,13 @@ CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
   m_sequenceFlags = data.sequenceFlags;
   m_sequenceCount = data.sequenceCount;
   m_dataLength = data.dataLength;
-  m_packetSequenceControl = (static_cast<std::uint16_t>(m_sequenceFlags) << 14) | m_sequenceCount;
-  m_packetIdentificationAndVersion = (static_cast<std::uint16_t>(m_versionNumber) << 13)
-                                     | (static_cast<std::uint16_t>(m_type) << 12)
-                                     | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11)
-                                     | m_APID;
+  m_packetSequenceControl = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_sequenceFlags) << 14U) | m_sequenceCount);
+  m_packetIdentificationAndVersion = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(m_versionNumber) << 13U)
+    | (static_cast<std::uint16_t>(m_type) << 12U)
+    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | m_APID);
   refreshStatus();
   return true;
 }

--- a/src/CCSDSManager.cpp
+++ b/src/CCSDSManager.cpp
@@ -1,24 +1,88 @@
 // Copyright 2025-2026 ExoSpaceLabs
 // SPDX-License-Identifier: Apache-2.0
 
-#include <random>
-#include <utility>
-#include <algorithm>
 #include "CCSDSManager.h"
 #include "CCSDSUtils.h"
+#include <algorithm>
+#include <utility>
 
-void CCSDS::Manager::setSyncPattern(std::uint32_t syncPattern) { m_syncPattern = syncPattern; }
-std::uint32_t CCSDS::Manager::getSyncPattern() const { return m_syncPattern; }
-void CCSDS::Manager::setSyncPatternEnable(const bool enable) { m_syncPattEnable = enable; }
-bool CCSDS::Manager::getSyncPatternEnable() const { return m_syncPattEnable; }
+void CCSDS::Manager::setSyncPattern(const std::uint32_t syncPattern) {
+  m_syncPattern = syncPattern;
+}
+
+std::uint32_t CCSDS::Manager::getSyncPattern() const {
+  return m_syncPattern;
+}
+
+void CCSDS::Manager::setSyncPatternEnable(const bool enable) {
+  m_syncPattEnable = enable;
+}
+
+bool CCSDS::Manager::getSyncPatternEnable() const {
+  return m_syncPattEnable;
+}
+
+std::uint16_t CCSDS::Manager::packetIdentifier(const Packet &packet) {
+  const auto &header = packet.getPrimaryHeader();
+  return static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(header.getVersionNumber()) << 13U)
+    | (static_cast<std::uint16_t>(header.getType()) << 12U)
+    | (static_cast<std::uint16_t>(header.getDataFieldHeaderFlag()) << 11U)
+    | header.getAPID());
+}
+
+bool CCSDS::Manager::hasIdentifierBinding() const {
+  return m_templateIsSet || !m_packets.empty();
+}
+
+std::uint16_t CCSDS::Manager::boundPacketIdentifier() const {
+  return m_templateIsSet ? packetIdentifier(m_templatePacket)
+                         : packetIdentifier(m_packets.front());
+}
+
+CCSDS::ResultBool CCSDS::Manager::validatePacketIdentifier(const Packet &packet) const {
+  if (!hasIdentifierBinding()) return true;
+  RET_IF_ERR_MSG(packetIdentifier(packet) != boundPacketIdentifier(),
+                 ErrorCode::INVALID_HEADER_DATA,
+                 "Packet identifier does not match the Manager-bound stream identifier");
+  return true;
+}
+
+CCSDS::PacketErrorControlMode CCSDS::Manager::boundPacketErrorControlMode() const {
+  if (m_templateIsSet) return m_templatePacket.getPacketErrorControlMode();
+  if (!m_packets.empty()) return m_packets.front().getPacketErrorControlMode();
+  return PacketErrorControlMode::CRC16;
+}
+
+void CCSDS::Manager::advanceSequenceCount() {
+  if (!getAutoSequenceCountEnable()) return;
+  const auto next = static_cast<std::uint16_t>((getSequenceCount() + 1U) & SEQUENCE_COUNT_MASK);
+  m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) | next;
+}
+
+void CCSDS::Manager::syncSequenceCountFromPacket(const Packet &packet) {
+  if (!getAutoSequenceCountEnable()) return;
+  const auto next = static_cast<std::uint16_t>(
+    (packet.getPrimaryHeader().getSequenceCount() + 1U) & SEQUENCE_COUNT_MASK);
+  m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) | next;
+}
 
 CCSDS::ResultBool CCSDS::Manager::setPacketTemplate(Packet packet) {
   RET_IF_ERR_MSG(m_templateIsSet, ErrorCode::TEMPLATE_SET_FAILURE,
                  "Cannot set Template as it is already set, please clear Manager first");
   RET_IF_ERR_MSG(packet.getPrimaryHeader().getHeaderStatus() == INVALID,
                  ErrorCode::INVALID_HEADER_DATA, "Cannot set an invalid packet template");
-  m_templatePacket.setUpdatePacketEnable(false);
+
+  packet.update();
+  RET_IF_ERR_MSG(packet.getPrimaryHeader().getHeaderStatus() == INVALID,
+                 ErrorCode::INVALID_HEADER_DATA, "Cannot finalize an invalid packet template");
+
   m_templatePacket = std::move(packet);
+  m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK)
+                    | (m_templatePacket.getPrimaryHeader().getSequenceCount()
+                       & SEQUENCE_COUNT_MASK);
+  m_templatePacket.setUpdatePacketEnable(false);
+  m_validator.clear();
   m_validator.setTemplatePacket(m_templatePacket);
   m_validator.configure(true, true, true);
   m_validateEnable = true;
@@ -50,7 +114,26 @@ std::uint16_t CCSDS::Manager::getDataFieldSize() const {
   return m_templatePacket.getDataFieldMaximumSize();
 }
 
-CCSDS::ResultBool CCSDS::Manager::setApplicationData(const std::vector<std::uint8_t> &data) {
+void CCSDS::Manager::setAutoSequenceCountEnable(const bool enable) {
+  if (enable) {
+    m_sequenceCount &= static_cast<std::uint16_t>(~AUTO_SEQUENCE_DISABLED_MASK);
+  } else {
+    m_sequenceCount |= AUTO_SEQUENCE_DISABLED_MASK;
+  }
+}
+
+CCSDS::ResultBool CCSDS::Manager::setSequenceCount(const std::uint16_t count) {
+  RET_IF_ERR_MSG(count > SEQUENCE_COUNT_MASK, ErrorCode::INVALID_HEADER_DATA,
+                 "Unable to set Manager sequence count above 16383");
+  if (m_templateIsSet) {
+    FORWARD_RESULT(m_templatePacket.setSequenceCount(count));
+  }
+  m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) | count;
+  return true;
+}
+
+CCSDS::ResultBool CCSDS::Manager::setApplicationData(
+    const std::vector<std::uint8_t> &data) {
   RET_IF_ERR_MSG(data.empty(), ErrorCode::NO_DATA,
                  "Cannot set Application data, Provided data is empty");
   RET_IF_ERR_MSG(!m_templateIsSet, ErrorCode::INVALID_HEADER_DATA,
@@ -60,52 +143,52 @@ CCSDS::ResultBool CCSDS::Manager::setApplicationData(const std::vector<std::uint
                  "Cannot set Application data using an invalid packet template");
 
   const auto maxBytesPerPacket = m_templatePacket.getDataFieldMaximumSize();
-  const auto dataBytesSize = data.size();
+  RET_IF_ERR_MSG(maxBytesPerPacket == 0U, ErrorCode::INVALID_APPLICATION_DATA,
+                 "Cannot segment application data into a zero-sized packet data field");
 
-  if (!m_packets.empty()) {
-    m_packets.clear();
-  }
+  const auto packetCount =
+    (data.size() + static_cast<std::size_t>(maxBytesPerPacket) - 1U)
+    / static_cast<std::size_t>(maxBytesPerPacket);
 
-  std::uint32_t i = 0;
-  auto remainderBytes = static_cast<std::int32_t>(dataBytesSize);
-  auto sequenceFlag = UNSEGMENTED;
-  while (i < dataBytesSize) {
-    Packet newPacket = m_templatePacket;
-    std::vector<std::uint8_t> tmp;
-    if (remainderBytes > maxBytesPerPacket) {
-      tmp.insert(tmp.end(), data.begin() + i, data.begin() + i + maxBytesPerPacket);
-      remainderBytes -= maxBytesPerPacket;
-      if (i == 0) {
-        sequenceFlag = FIRST_SEGMENT;
-        m_sequenceCount++;
-      } else {
-        sequenceFlag = CONTINUING_SEGMENT;
-      }
-      i += maxBytesPerPacket;
-      FORWARD_RESULT(newPacket.setApplicationData(tmp));
-      newPacket.setSequenceFlags(sequenceFlag);
-      FORWARD_RESULT(newPacket.setSequenceCount(m_sequenceCount));
-    } else {
-      tmp.insert(tmp.end(), data.begin() + i, data.begin() + i + remainderBytes);
-      i += remainderBytes;
-      if (sequenceFlag != UNSEGMENTED) {
-        newPacket.setSequenceFlags(LAST_SEGMENT);
-        FORWARD_RESULT(newPacket.setSequenceCount(m_sequenceCount));
-      }
-      FORWARD_RESULT(newPacket.setApplicationData(tmp));
+  std::vector<Packet> generated;
+  generated.reserve(packetCount);
+  auto nextCount = getSequenceCount();
+
+  std::size_t offset = 0U;
+  for (std::size_t index = 0U; index < packetCount; ++index) {
+    Packet packet = m_templatePacket;
+    const auto bytes = std::min<std::size_t>(maxBytesPerPacket, data.size() - offset);
+    const std::vector<std::uint8_t> chunk(
+      data.begin() + static_cast<std::ptrdiff_t>(offset),
+      data.begin() + static_cast<std::ptrdiff_t>(offset + bytes));
+
+    ESequenceFlag flags = UNSEGMENTED;
+    if (packetCount > 1U) {
+      if (index == 0U) flags = FIRST_SEGMENT;
+      else if (index + 1U == packetCount) flags = LAST_SEGMENT;
+      else flags = CONTINUING_SEGMENT;
     }
-    newPacket.setUpdatePacketEnable(m_updateEnable);
-    m_packets.push_back(std::move(newPacket));
-    m_sequenceCount++;
+
+    packet.setSequenceFlags(flags);
+    FORWARD_RESULT(packet.setSequenceCount(nextCount));
+    FORWARD_RESULT(packet.setApplicationData(chunk));
+    packet.setUpdatePacketEnable(m_updateEnable);
+    generated.push_back(std::move(packet));
+
+    if (getAutoSequenceCountEnable()) {
+      nextCount = static_cast<std::uint16_t>((nextCount + 1U) & SEQUENCE_COUNT_MASK);
+    }
+    offset += bytes;
   }
+
+  m_packets = std::move(generated);
+  m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK) | nextCount;
   return true;
 }
 
 void CCSDS::Manager::setAutoUpdateEnable(const bool enable) {
   m_updateEnable = enable;
-  for (auto &packet: m_packets) {
-    packet.setUpdatePacketEnable(enable);
-  }
+  for (auto &packet : m_packets) packet.setUpdatePacketEnable(enable);
 }
 
 void CCSDS::Manager::setAutoValidateEnable(const bool enable) {
@@ -113,7 +196,8 @@ void CCSDS::Manager::setAutoValidateEnable(const bool enable) {
 }
 
 CCSDS::ResultBuffer CCSDS::Manager::getPacketTemplate() {
-  auto data = m_templatePacket.serialize();
+  auto packet = m_templatePacket;
+  const auto data = packet.serialize();
   RET_IF_ERR_MSG(data.empty(), ErrorCode::NO_DATA,
                  "Cannot get Packet template data, data is empty");
   return data;
@@ -122,13 +206,17 @@ CCSDS::ResultBuffer CCSDS::Manager::getPacketTemplate() {
 CCSDS::ResultBuffer CCSDS::Manager::getPacketBufferAtIndex(const std::uint16_t index) {
   RET_IF_ERR_MSG(index >= m_packets.size(), ErrorCode::INVALID_DATA,
                  "Cannot get packet, index is out of bounds");
+
+  auto packet = m_packets[index];
   if (m_validateEnable) {
-    m_packets[index].update();
-    const std::string errorMessage = "Validation failure for packet at index " + std::to_string(index);
-    RET_IF_ERR_MSG(!m_validator.validate(m_packets[index]), ErrorCode::VALIDATION_FAILURE,
+    packet.update();
+    const std::string errorMessage =
+      "Validation failure for packet at index " + std::to_string(index);
+    RET_IF_ERR_MSG(!m_validator.validate(packet), ErrorCode::VALIDATION_FAILURE,
                    errorMessage);
   }
-  auto packetBuffer = m_packets[index].serialize();
+
+  const auto packetBuffer = packet.serialize();
   RET_IF_ERR_MSG(packetBuffer.empty(), ErrorCode::INVALID_HEADER_DATA,
                  "Cannot serialize packet with an invalid header");
   return packetBuffer;
@@ -138,15 +226,14 @@ std::vector<std::uint8_t> CCSDS::Manager::getPacketsBuffer() const {
   std::vector<std::uint8_t> buffer;
   for (auto packet : m_packets) {
     if (m_syncPattEnable) {
-      buffer.push_back(static_cast<std::uint8_t>(m_syncPattern >> 24 & 0xff));
-      buffer.push_back(static_cast<std::uint8_t>(m_syncPattern >> 16 & 0xff));
-      buffer.push_back(static_cast<std::uint8_t>(m_syncPattern >> 8 & 0xff));
-      buffer.push_back(static_cast<std::uint8_t>(m_syncPattern & 0xff));
+      buffer.push_back(static_cast<std::uint8_t>((m_syncPattern >> 24U) & 0xFFU));
+      buffer.push_back(static_cast<std::uint8_t>((m_syncPattern >> 16U) & 0xFFU));
+      buffer.push_back(static_cast<std::uint8_t>((m_syncPattern >> 8U) & 0xFFU));
+      buffer.push_back(static_cast<std::uint8_t>(m_syncPattern & 0xFFU));
     }
+
     const auto packetBuffer = packet.serialize();
-    if (packetBuffer.empty()) {
-      return {};
-    }
+    if (packetBuffer.empty()) return {};
     buffer.insert(buffer.end(), packetBuffer.begin(), packetBuffer.end());
   }
   return buffer;
@@ -157,19 +244,21 @@ CCSDS::ResultBuffer CCSDS::Manager::getApplicationDataBuffer() {
                  "Cannot get Application data, no packets have been set.");
   std::vector<std::uint8_t> data;
 
-  for (std::uint32_t index = 0; index < m_packets.size(); index++) {
+  for (std::size_t index = 0U; index < m_packets.size(); ++index) {
     if (m_validateEnable) {
-      const std::string errorMessage = "Validation failure for packet at index" + std::to_string(index);
-      RET_IF_ERR_MSG(!m_validator.validate(m_packets[index]), ErrorCode::VALIDATION_FAILURE,
-                     errorMessage);
+      const std::string errorMessage =
+        "Validation failure for packet at index " + std::to_string(index);
+      RET_IF_ERR_MSG(!m_validator.validate(m_packets[index]),
+                     ErrorCode::VALIDATION_FAILURE, errorMessage);
     }
-    auto applicationData = m_packets[index].getApplicationDataBytes();
+    const auto applicationData = m_packets[index].getApplicationDataBytes();
     data.insert(data.end(), applicationData.begin(), applicationData.end());
   }
   return data;
 }
 
-CCSDS::ResultBuffer CCSDS::Manager::getApplicationDataBufferAtIndex(const std::uint16_t index) {
+CCSDS::ResultBuffer CCSDS::Manager::getApplicationDataBufferAtIndex(
+    const std::uint16_t index) {
   RET_IF_ERR_MSG(index >= m_packets.size(), ErrorCode::INVALID_DATA,
                  "Cannot get Application data, index is out of bounds");
   return m_packets[index].getApplicationDataBytes();
@@ -183,72 +272,88 @@ std::vector<CCSDS::Packet> CCSDS::Manager::getPackets() {
   return m_packets;
 }
 
+std::vector<CCSDS::Packet> CCSDS::Manager::getPackets() const {
+  return m_packets;
+}
+
 CCSDS::ResultBool CCSDS::Manager::addPacket(Packet packet) {
   RET_IF_ERR_MSG(packet.getPrimaryHeader().getHeaderStatus() == INVALID,
                  ErrorCode::INVALID_HEADER_DATA,
                  "Cannot add packet with an invalid primary header");
+  FORWARD_RESULT(validatePacketIdentifier(packet));
 
   if (m_validateEnable && !m_updateEnable) {
-    if (!m_templateIsSet) {
-      m_validator.configure(true, true, false);
+    auto validator = m_validator;
+    if (!m_templateIsSet && m_packets.empty()) {
+      validator.configure(true, true, false);
     }
-    RET_IF_ERR_MSG(!m_validator.validate(packet), ErrorCode::VALIDATION_FAILURE,
+    RET_IF_ERR_MSG(!validator.validate(packet), ErrorCode::VALIDATION_FAILURE,
                    "packet is not valid");
+    m_validator = std::move(validator);
   }
+
   packet.setUpdatePacketEnable(m_updateEnable);
   m_packets.push_back(std::move(packet));
+  syncSequenceCountFromPacket(m_packets.back());
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Manager::addPacketFromBuffer(const std::vector<std::uint8_t>& packetBuffer) {
+CCSDS::ResultBool CCSDS::Manager::addPacketFromBuffer(
+    const std::vector<std::uint8_t> &packetBuffer) {
   Packet packet;
+  packet.setPacketErrorControlMode(boundPacketErrorControlMode());
   FORWARD_RESULT(packet.deserialize(packetBuffer));
-  FORWARD_RESULT(addPacket(packet));
+  FORWARD_RESULT(addPacket(std::move(packet)));
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Manager::load(const std::vector<Packet>& packets) {
-  for (const auto& packet: packets) {
-    FORWARD_RESULT(addPacket(packet));
+CCSDS::ResultBool CCSDS::Manager::load(const std::vector<Packet> &packets) {
+  Manager staged = *this;
+  for (const auto &packet : packets) {
+    const auto result = staged.addPacket(packet);
+    if (!result) return result.error();
   }
+  *this = std::move(staged);
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Manager::load(const std::vector<std::uint8_t>& packetsBuffer) {
-  RET_IF_ERR_MSG(packetsBuffer.size() < 8, ErrorCode::INVALID_DATA,
+CCSDS::ResultBool CCSDS::Manager::load(
+    const std::vector<std::uint8_t> &packetsBuffer) {
+  RET_IF_ERR_MSG(packetsBuffer.size() < 7U, ErrorCode::INVALID_DATA,
                  "invalid packet buffer size");
-  std::size_t offset{0};
+
+  Manager staged = *this;
+  std::size_t offset{0U};
   while (offset < packetsBuffer.size()) {
-    if (m_syncPattEnable) {
+    if (staged.m_syncPattEnable) {
       RET_IF_ERR_MSG(packetsBuffer.size() - offset < 4U, ErrorCode::INVALID_DATA,
                      "Truncated sync pattern.");
-      const std::uint32_t value = (static_cast<std::uint32_t>(packetsBuffer[offset]) << 24)
-                                  | (static_cast<std::uint32_t>(packetsBuffer[offset + 1]) << 16)
-                                  | (static_cast<std::uint32_t>(packetsBuffer[offset + 2]) << 8)
-                                  | static_cast<std::uint32_t>(packetsBuffer[offset + 3]);
-      RET_IF_ERR_MSG(value != m_syncPattern, ErrorCode::INVALID_DATA,
+      const std::uint32_t value =
+        (static_cast<std::uint32_t>(packetsBuffer[offset]) << 24U)
+        | (static_cast<std::uint32_t>(packetsBuffer[offset + 1U]) << 16U)
+        | (static_cast<std::uint32_t>(packetsBuffer[offset + 2U]) << 8U)
+        | static_cast<std::uint32_t>(packetsBuffer[offset + 3U]);
+      RET_IF_ERR_MSG(value != staged.m_syncPattern, ErrorCode::INVALID_DATA,
                      "Sync Pattern mismatch.");
       offset += 4U;
     }
 
     RET_IF_ERR_MSG(packetsBuffer.size() - offset < 6U, ErrorCode::INVALID_DATA,
                    "Truncated CCSDS primary header.");
-    std::vector<std::uint8_t> headerData;
-    std::copy_n(packetsBuffer.begin() + static_cast<std::ptrdiff_t>(offset), 6U,
-                std::back_inserter(headerData));
-    Header header;
-    FORWARD_RESULT(header.deserialize(headerData));
 
-    const auto packetSize = static_cast<std::size_t>(header.getDataLength()) + 7U;
-    RET_IF_ERR_MSG(packetSize < 7U || packetSize > packetsBuffer.size() - offset,
-                   ErrorCode::INVALID_DATA, "Truncated CCSDS packet.");
-
-    std::vector<std::uint8_t> packetData;
-    std::copy_n(packetsBuffer.begin() + static_cast<std::ptrdiff_t>(offset), packetSize,
-                std::back_inserter(packetData));
-    FORWARD_RESULT(addPacketFromBuffer(packetData));
-    offset += packetSize;
+    const std::vector<std::uint8_t> remaining(
+      packetsBuffer.begin() + static_cast<std::ptrdiff_t>(offset),
+      packetsBuffer.end());
+    Packet packet;
+    packet.setPacketErrorControlMode(staged.boundPacketErrorControlMode());
+    std::size_t consumed{};
+    ASSIGN_CP(consumed, packet.deserializeBounded(remaining));
+    const auto addResult = staged.addPacket(std::move(packet));
+    if (!addResult) return addResult.error();
+    offset += consumed;
   }
+
+  *this = std::move(staged);
   return true;
 }
 
@@ -259,15 +364,16 @@ CCSDS::ResultBool CCSDS::Manager::read(const std::string &binaryFile) {
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Manager::write(const std::string& binaryFile) const {
+CCSDS::ResultBool CCSDS::Manager::write(const std::string &binaryFile) const {
   const auto buffer = getPacketsBuffer();
-  RET_IF_ERR_MSG(!m_packets.empty() && buffer.empty(), ErrorCode::INVALID_HEADER_DATA,
+  RET_IF_ERR_MSG(!m_packets.empty() && buffer.empty(),
+                 ErrorCode::INVALID_HEADER_DATA,
                  "Cannot write packet stream containing an invalid header");
   FORWARD_RESULT(writeBinaryFile(buffer, binaryFile));
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Manager::readTemplate(const std::string& filename) {
+CCSDS::ResultBool CCSDS::Manager::readTemplate(const std::string &filename) {
   Packet templatePacket;
   templatePacket.setUpdatePacketEnable(false);
   if (stringEndsWith(filename, ".bin")) {
@@ -280,18 +386,24 @@ CCSDS::ResultBool CCSDS::Manager::readTemplate(const std::string& filename) {
     return Error{INVALID_DATA,
                  "Cannot load template, invalid file provided [supported extensions [.bin, .cfg]]"};
   }
-  FORWARD_RESULT(setPacketTemplate(templatePacket));
+  FORWARD_RESULT(setPacketTemplate(std::move(templatePacket)));
   return true;
 }
 
 void CCSDS::Manager::clear() {
-  clearPackets();
+  m_packets.clear();
   m_templateIsSet = false;
   m_templatePacket = {};
+  m_sequenceCount &= AUTO_SEQUENCE_DISABLED_MASK;
+  m_validator.clear();
 }
 
 void CCSDS::Manager::clearPackets() {
   m_packets.clear();
-  m_sequenceCount = 0;
+  m_sequenceCount &= AUTO_SEQUENCE_DISABLED_MASK;
   m_validator.clear();
+  if (m_templateIsSet) {
+    m_validator.setTemplatePacket(m_templatePacket);
+    m_validator.configure(true, true, true);
+  }
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -28,9 +28,7 @@ namespace {
     const std::vector<std::uint8_t> headerData(data.begin(), data.begin() + 6);
     CCSDS::Header header;
     const auto headerResult = header.deserialize(headerData);
-    if (!headerResult) {
-      return headerResult.error();
-    }
+    if (!headerResult) return headerResult.error();
     if (header.getVersionNumber() != 0U) {
       return CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
                           "Cannot deserialize packet: unsupported CCSDS packet version."};
@@ -56,9 +54,7 @@ namespace {
 
     ParsedPacket parsed;
     const auto headerResult = parsed.header.deserialize(headerData);
-    if (!headerResult) {
-      return headerResult.error();
-    }
+    if (!headerResult) return headerResult.error();
     if (parsed.header.getVersionNumber() != 0U) {
       return CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
                           "Cannot deserialize packet: unsupported CCSDS packet version."};
@@ -82,8 +78,8 @@ namespace {
 
       std::vector<std::uint8_t> crcInput = headerData;
       crcInput.insert(crcInput.end(), packetData.begin(), packetData.end() - 2);
-      const auto expectedCRC = CCSDS::crc16(crcInput, crcConfig.polynomial,
-                                            crcConfig.initialValue, crcConfig.finalXorValue);
+      const auto expectedCRC = ::crc16(crcInput, crcConfig.polynomial,
+                                       crcConfig.initialValue, crcConfig.finalXorValue);
       if (expectedCRC != parsed.receivedCRC) {
         return CCSDS::Error{CCSDS::ErrorCode::INVALID_CHECKSUM,
                             "Cannot deserialize packet: CRC16 packet error-control mismatch."};
@@ -99,46 +95,29 @@ namespace {
 }
 
 void CCSDS::Packet::update() {
-  if (!m_updateStatus && m_enableUpdatePacket) {
-    if (m_primaryHeader.getHeaderStatus() == INVALID) {
-      return;
-    }
+  if (m_updateStatus || !m_enableUpdatePacket) return;
+  if (m_primaryHeader.getHeaderStatus() == INVALID) return;
 
-    const auto dataField = m_dataField.serialize();
-    const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
-    constexpr auto maximumPacketDataFieldSize =
-      static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1U;
+  const auto dataField = m_dataField.serialize();
+  const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
+  constexpr auto maximumPacketDataFieldSize =
+    static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1U;
 
-    if (packetDataFieldSize == 0U || packetDataFieldSize > maximumPacketDataFieldSize) {
-      return;
-    }
+  if (packetDataFieldSize == 0U || packetDataFieldSize > maximumPacketDataFieldSize) return;
 
-    m_primaryHeader.setDataLength(static_cast<std::uint16_t>(packetDataFieldSize - 1U));
-    if (!m_primaryHeader.setDataFieldHeaderFlag(m_dataField.getDataFieldHeaderFlag())) {
-      return;
-    }
+  m_primaryHeader.setDataLength(static_cast<std::uint16_t>(packetDataFieldSize - 1U));
+  if (!m_primaryHeader.setSequenceCount(m_sequenceCounter & SEQUENCE_COUNT_MASK)) return;
 
-    if (m_primaryHeader.getSequenceFlags() == UNSEGMENTED) {
-      if (!m_primaryHeader.setSequenceCount(0)) {
-        return;
-      }
-    } else if (!m_primaryHeader.setSequenceCount(m_sequenceCounter & SEQUENCE_COUNT_MASK)) {
-      return;
-    }
-
-    if (getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
-      auto crcInput = m_primaryHeader.serialize();
-      if (crcInput.size() != 6U) {
-        return;
-      }
-      crcInput.insert(crcInput.end(), dataField.begin(), dataField.end());
-      m_CRC16 = crc16(crcInput, m_CRC16Config.polynomial, m_CRC16Config.initialValue,
+  if (getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
+    auto crcInput = static_cast<const Header &>(m_primaryHeader).serialize();
+    if (crcInput.size() != 6U) return;
+    crcInput.insert(crcInput.end(), dataField.begin(), dataField.end());
+    m_CRC16 = ::crc16(crcInput, m_CRC16Config.polynomial, m_CRC16Config.initialValue,
                       m_CRC16Config.finalXorValue);
-    } else {
-      m_CRC16 = 0U;
-    }
-    m_updateStatus = true;
+  } else {
+    m_CRC16 = 0U;
   }
+  m_updateStatus = true;
 }
 
 #ifndef CCSDS_MCU
@@ -194,6 +173,8 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
   }
   FORWARD_RESULT(m_primaryHeader.setSequenceFlags(sequenceFlag));
   FORWARD_RESULT(m_primaryHeader.setSequenceCount(sequenceCount));
+  m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
+                      | (sequenceCount & SEQUENCE_COUNT_MASK);
   m_updateStatus = false;
 
   if (cfg.isKey("ccsds_packet_error_control")) {
@@ -221,9 +202,7 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
   if (cfg.isKey("define_secondary_header")) {
     bool secondaryHeaderFlag{false};
     ASSIGN_CP(secondaryHeaderFlag, cfg.get<bool>("define_secondary_header"));
-    if (secondaryHeaderFlag) {
-      FORWARD_RESULT(m_dataField.setDataFieldHeader(cfg));
-    }
+    if (secondaryHeaderFlag) FORWARD_RESULT(m_dataField.setDataFieldHeader(cfg));
   }
 
   if (cfg.isKey("application_data")) {
@@ -237,11 +216,12 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
 #endif
 
 std::uint16_t CCSDS::Packet::getCRC() {
+  return static_cast<const Packet &>(*this).getCRC();
+}
+
+std::uint16_t CCSDS::Packet::getCRC() const {
   if (getPacketErrorControlMode() == PacketErrorControlMode::None
-      || m_primaryHeader.getHeaderStatus() == INVALID) {
-    return 0U;
-  }
-  update();
+      || m_primaryHeader.getHeaderStatus() == INVALID) return 0U;
   return m_CRC16;
 }
 
@@ -250,72 +230,87 @@ std::uint16_t CCSDS::Packet::getDataFieldMaximumSize() const {
 }
 
 bool CCSDS::Packet::getDataFieldHeaderFlag() {
-  update();
-  return m_primaryHeader.getDataFieldHeaderFlag();
+  return static_cast<const Packet &>(*this).getDataFieldHeaderFlag();
+}
+
+bool CCSDS::Packet::getDataFieldHeaderFlag() const {
+  return m_primaryHeader.getDataFieldHeaderFlag() != 0U;
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getCRCVectorBytes() {
+  return static_cast<const Packet &>(*this).getCRCVectorBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getCRCVectorBytes() const {
   if (getPacketErrorControlMode() == PacketErrorControlMode::None
-      || m_primaryHeader.getHeaderStatus() == INVALID) {
-    return {};
-  }
-  const auto crcValue = getCRC();
-  return {static_cast<std::uint8_t>((crcValue >> 8U) & 0xFFU),
-          static_cast<std::uint8_t>(crcValue & 0xFFU)};
+      || m_primaryHeader.getHeaderStatus() == INVALID) return {};
+  return {static_cast<std::uint8_t>((m_CRC16 >> 8U) & 0xFFU),
+          static_cast<std::uint8_t>(m_CRC16 & 0xFFU)};
 }
 
-CCSDS::DataField &CCSDS::Packet::getDataField() {
-  update();
-  return m_dataField;
-}
-
-CCSDS::Header &CCSDS::Packet::getPrimaryHeader() {
-  update();
-  return m_primaryHeader;
-}
+CCSDS::DataField &CCSDS::Packet::getDataField() { return m_dataField; }
+const CCSDS::DataField &CCSDS::Packet::getDataField() const { return m_dataField; }
+CCSDS::Header &CCSDS::Packet::getPrimaryHeader() { return m_primaryHeader; }
+const CCSDS::Header &CCSDS::Packet::getPrimaryHeader() const { return m_primaryHeader; }
 
 std::uint64_t CCSDS::Packet::getPrimaryHeader64bit() {
-  update();
+  return static_cast<const Packet &>(*this).getPrimaryHeader64bit();
+}
+
+std::uint64_t CCSDS::Packet::getPrimaryHeader64bit() const {
   return m_primaryHeader.getFullHeader();
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getPrimaryHeaderBytes() {
-  update();
+  return static_cast<const Packet &>(*this).getPrimaryHeaderBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getPrimaryHeaderBytes() const {
   return m_primaryHeader.serialize();
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getDataFieldHeaderBytes() {
-  update();
+  return static_cast<const Packet &>(*this).getDataFieldHeaderBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getDataFieldHeaderBytes() const {
   return m_dataField.getDataFieldHeaderBytes();
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getApplicationDataBytes() {
-  update();
+  return static_cast<const Packet &>(*this).getApplicationDataBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getApplicationDataBytes() const {
   return m_dataField.getApplicationData();
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() {
-  return m_dataField.serialize();
+  return static_cast<const Packet &>(*this).getFullDataFieldBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() const {
+  auto data = m_dataField.getDataFieldHeaderBytes();
+  const auto applicationData = m_dataField.getApplicationData();
+  data.insert(data.end(), applicationData.begin(), applicationData.end());
+  return data;
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::serialize() {
-  if (m_primaryHeader.getHeaderStatus() == INVALID) {
-    return {};
-  }
+  if (m_primaryHeader.getHeaderStatus() == INVALID) return {};
 
-  const auto dataField = m_dataField.serialize();
-  const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
+  const auto currentDataField = getFullDataFieldBytes();
+  const auto currentPacketDataFieldSize = currentDataField.size() + getPacketErrorControlSize();
   constexpr auto maximumPacketDataFieldSize =
     static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1U;
-  if (packetDataFieldSize == 0U || packetDataFieldSize > maximumPacketDataFieldSize) {
+  if (currentPacketDataFieldSize == 0U || currentPacketDataFieldSize > maximumPacketDataFieldSize) {
     return {};
   }
 
   update();
-  const auto header = m_primaryHeader.serialize();
-  if (header.size() != 6U) {
-    return {};
-  }
+  const auto header = static_cast<const Header &>(m_primaryHeader).serialize();
+  if (header.size() != 6U) return {};
+  const auto dataField = getFullDataFieldBytes();
 
   std::vector<std::uint8_t> packet;
   packet.reserve(header.size() + dataField.size() + getPacketErrorControlSize());
@@ -336,9 +331,7 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
   const std::vector<std::uint8_t> packetData(data.begin() + 6,
                                               data.begin() + static_cast<std::ptrdiff_t>(packetSize));
   const auto parseResult = deserialize(headerData, packetData);
-  if (!parseResult) {
-    return parseResult.error();
-  }
+  if (!parseResult) return parseResult.error();
   return packetSize;
 }
 
@@ -358,9 +351,7 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
                                               data.begin() + static_cast<std::ptrdiff_t>(packetSize));
   const auto validated = validatePacketBytes(headerData, packetData,
                                              getPacketErrorControlMode(), m_CRC16Config);
-  if (!validated) {
-    return validated.error();
-  }
+  if (!validated) return validated.error();
 
   auto parsed = validated.value();
   DataField parsedField = m_dataField;
@@ -370,36 +361,28 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
                  "Cannot deserialize packet: failed to create secondary header: " + headerType);
 
   std::size_t secondaryHeaderSize = secondaryHeader->getSize();
-  if (headerType == "PusC" && headerSize > 0) {
-    secondaryHeaderSize = static_cast<std::size_t>(headerSize);
-  }
+  if (headerType == "PusC" && headerSize > 0) secondaryHeaderSize = static_cast<std::size_t>(headerSize);
   RET_IF_ERR_MSG(secondaryHeaderSize > parsed.dataField.size(),
                  ErrorCode::INVALID_SECONDARY_HEADER_DATA,
                  "Cannot deserialize packet: secondary header exceeds the packet data field.");
 
-  const std::vector<std::uint8_t> secondaryBytes(parsed.dataField.begin(),
-                                                  parsed.dataField.begin()
-                                                    + static_cast<std::ptrdiff_t>(secondaryHeaderSize));
+  const std::vector<std::uint8_t> secondaryBytes(
+    parsed.dataField.begin(), parsed.dataField.begin() + static_cast<std::ptrdiff_t>(secondaryHeaderSize));
   const auto secondaryResult = secondaryHeader->deserialize(secondaryBytes);
-  if (!secondaryResult) {
-    return secondaryResult.error();
-  }
+  if (!secondaryResult) return secondaryResult.error();
   parsedField.setDataFieldHeader(secondaryHeader);
 
   const std::vector<std::uint8_t> applicationData(
-    parsed.dataField.begin() + static_cast<std::ptrdiff_t>(secondaryHeaderSize),
-    parsed.dataField.end());
+    parsed.dataField.begin() + static_cast<std::ptrdiff_t>(secondaryHeaderSize), parsed.dataField.end());
   const auto applicationResult = parsedField.setApplicationData(applicationData);
-  if (!applicationResult) {
-    return applicationResult.error();
-  }
+  if (!applicationResult) return applicationResult.error();
 
   m_primaryHeader = parsed.header;
   m_dataField = std::move(parsedField);
   m_CRC16 = parsed.receivedCRC;
   m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
                       | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
-  m_updateStatus = false;
+  m_updateStatus = true;
   return packetSize;
 }
 
@@ -412,9 +395,7 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
                                               data.begin() + static_cast<std::ptrdiff_t>(packetSize));
   const auto validated = validatePacketBytes(headerData, packetData,
                                              getPacketErrorControlMode(), m_CRC16Config);
-  if (!validated) {
-    return validated.error();
-  }
+  if (!validated) return validated.error();
 
   auto parsed = validated.value();
   RET_IF_ERR_MSG(static_cast<std::size_t>(headerDataSizeBytes) > parsed.dataField.size(),
@@ -428,32 +409,25 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
     parsed.dataField.begin() + static_cast<std::ptrdiff_t>(headerDataSizeBytes));
   if (!secondaryBytes.empty()) {
     const auto secondaryResult = parsedField.setDataFieldHeader(secondaryBytes);
-    if (!secondaryResult) {
-      return secondaryResult.error();
-    }
+    if (!secondaryResult) return secondaryResult.error();
   }
   const std::vector<std::uint8_t> applicationData(
-    parsed.dataField.begin() + static_cast<std::ptrdiff_t>(headerDataSizeBytes),
-    parsed.dataField.end());
+    parsed.dataField.begin() + static_cast<std::ptrdiff_t>(headerDataSizeBytes), parsed.dataField.end());
   const auto applicationResult = parsedField.setApplicationData(applicationData);
-  if (!applicationResult) {
-    return applicationResult.error();
-  }
+  if (!applicationResult) return applicationResult.error();
 
   m_primaryHeader = parsed.header;
   m_dataField = std::move(parsedField);
   m_CRC16 = parsed.receivedCRC;
   m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
                       | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
-  m_updateStatus = false;
+  m_updateStatus = true;
   return packetSize;
 }
 
 CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &data) {
   const auto result = deserializeBounded(data);
-  if (!result) {
-    return result.error();
-  }
+  if (!result) return result.error();
   return true;
 }
 
@@ -461,18 +435,14 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &da
                                               const std::string &headerType,
                                               const std::int32_t headerSize) {
   const auto result = deserializeBounded(data, headerType, headerSize);
-  if (!result) {
-    return result.error();
-  }
+  if (!result) return result.error();
   return true;
 }
 
 CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &data,
                                               const std::uint16_t headerDataSizeBytes) {
   const auto result = deserializeBounded(data, headerDataSizeBytes);
-  if (!result) {
-    return result.error();
-  }
+  if (!result) return result.error();
   return true;
 }
 
@@ -480,9 +450,7 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &he
                                               const std::vector<std::uint8_t> &data) {
   const auto validated = validatePacketBytes(headerData, data,
                                              getPacketErrorControlMode(), m_CRC16Config);
-  if (!validated) {
-    return validated.error();
-  }
+  if (!validated) return validated.error();
 
   auto parsed = validated.value();
   DataField parsedField = m_dataField;
@@ -494,11 +462,15 @@ CCSDS::ResultBool CCSDS::Packet::deserialize(const std::vector<std::uint8_t> &he
   m_CRC16 = parsed.receivedCRC;
   m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK)
                       | (m_primaryHeader.getSequenceCount() & SEQUENCE_COUNT_MASK);
-  m_updateStatus = false;
+  m_updateStatus = true;
   return true;
 }
 
 std::uint16_t CCSDS::Packet::getFullPacketLength() {
+  return static_cast<const Packet &>(*this).getFullPacketLength();
+}
+
+std::uint16_t CCSDS::Packet::getFullPacketLength() const {
   return static_cast<std::uint16_t>(6U + m_dataField.getDataFieldUsedBytesSize()
                                     + getPacketErrorControlSize());
 }
@@ -536,12 +508,14 @@ CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const PrimaryHeader data) {
 
 void CCSDS::Packet::setDataFieldHeader(const std::shared_ptr<SecondaryHeaderAbstract> &header) {
   m_dataField.setDataFieldHeader(header);
+  if (!m_primaryHeader.setDataFieldHeaderFlag(header ? 1U : 0U)) return;
   m_updateStatus = false;
 }
 
 CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
     const std::vector<std::uint8_t> &data, const std::string &headerType) {
   FORWARD_RESULT(m_dataField.setDataFieldHeader(data, headerType));
+  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
@@ -550,6 +524,7 @@ CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(const std::uint8_t *pData,
                                                      const std::size_t sizeData,
                                                      const std::string &headerType) {
   FORWARD_RESULT(m_dataField.setDataFieldHeader(pData, sizeData, headerType));
+  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
@@ -557,6 +532,7 @@ CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(const std::uint8_t *pData,
 CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
     const std::vector<std::uint8_t> &data) {
   FORWARD_RESULT(m_dataField.setDataFieldHeader(data));
+  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
@@ -564,6 +540,7 @@ CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
 CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(const std::uint8_t *pData,
                                                      const std::size_t sizeData) {
   FORWARD_RESULT(m_dataField.setDataFieldHeader(pData, sizeData));
+  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
@@ -583,17 +560,14 @@ CCSDS::ResultBool CCSDS::Packet::setApplicationData(const std::uint8_t *pData,
 }
 
 void CCSDS::Packet::setSequenceFlags(const ESequenceFlag flags) {
-  if (!m_primaryHeader.setSequenceFlags(flags)) {
-    return;
-  }
+  if (!m_primaryHeader.setSequenceFlags(flags)) return;
   m_updateStatus = false;
 }
 
 CCSDS::ResultBool CCSDS::Packet::setSequenceCount(const std::uint16_t count) {
-  RET_IF_ERR_MSG(m_primaryHeader.getSequenceFlags() == UNSEGMENTED && count != 0U,
-                 ErrorCode::INVALID_DATA, "Unable to set non-zero value for UNSEGMENTED packet");
   RET_IF_ERR_MSG(count > SEQUENCE_COUNT_MASK, ErrorCode::INVALID_HEADER_DATA,
                  "Unable to set sequence count above 16383");
+  FORWARD_RESULT(m_primaryHeader.setSequenceCount(count));
   m_sequenceCounter = (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK) | count;
   m_updateStatus = false;
   return true;
@@ -601,6 +575,7 @@ CCSDS::ResultBool CCSDS::Packet::setSequenceCount(const std::uint16_t count) {
 
 void CCSDS::Packet::setDataFieldSize(const std::uint16_t size) {
   m_dataField.setDataPacketSize(size);
+  m_updateStatus = false;
 }
 
 void CCSDS::Packet::setUpdatePacketEnable(const bool enable) {

--- a/src/CCSDSValidator.cpp
+++ b/src/CCSDSValidator.cpp
@@ -2,86 +2,109 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CCSDSValidator.h"
-#include <CCSDSUtils.h>
+#include "CCSDSUtils.h"
 
-void CCSDS::Validator::configure(const bool validatePacketCoherence, const bool validateSequenceCount,
-                                  const bool validateAgainstTemplate) {
+void CCSDS::Validator::configure(const bool validatePacketCoherence,
+                                 const bool validateSequenceCount,
+                                 const bool validateAgainstTemplate) {
   m_validatePacketCoherence = validatePacketCoherence;
   m_validateSegmentedCount = validateSequenceCount;
   m_validateAgainstTemplate = validateAgainstTemplate;
 }
 
+void CCSDS::Validator::acceptSequence(const Header &header) {
+  const auto next = static_cast<std::uint16_t>(
+    (header.getSequenceCount() + 1U) & SEQUENCE_COUNT_MASK);
+  auto state = static_cast<std::uint16_t>(SEQUENCE_INITIALIZED_MASK | next);
+  if (header.getSequenceFlags() == FIRST_SEGMENT
+      || header.getSequenceFlags() == CONTINUING_SEGMENT) {
+    state |= SEGMENT_OPEN_MASK;
+  }
+  m_sequenceCounter = state;
+}
+
 bool CCSDS::Validator::validate(const Packet &packet) {
-  m_report.clear();
-  m_report.reserve(m_reportSize);
-  m_report.assign({true, true, true, true, true, true});
+  m_report.assign(m_reportSize, true);
   bool result{true};
-  auto toValidate = packet;
-  toValidate.setUpdatePacketEnable(false);
-  auto toValidateHeader = toValidate.getPrimaryHeader();
-  const auto toValidateHeaderData = toValidateHeader.serialize();
-  if (toValidateHeaderData.size() != 6U) {
+
+  const auto &header = packet.getPrimaryHeader();
+  const auto headerData = header.serialize();
+  if (headerData.size() != 6U) {
     m_report.assign(m_reportSize, false);
     return false;
   }
-  const auto dataFieldBytes = toValidate.getFullDataFieldBytes();
+  const auto dataFieldBytes = packet.getFullDataFieldBytes();
 
   if (m_validatePacketCoherence) {
-    const auto packetDataFieldSize = dataFieldBytes.size() + toValidate.getPacketErrorControlSize();
+    const auto packetDataFieldSize =
+      dataFieldBytes.size() + packet.getPacketErrorControlSize();
     m_report[0] = packetDataFieldSize > 0U
-                  && toValidateHeader.getDataLength() == packetDataFieldSize - 1U;
+                  && header.getDataLength() == packetDataFieldSize - 1U;
     result &= m_report[0];
 
-    if (toValidate.getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
-      auto crcInput = toValidateHeaderData;
+    if (packet.getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
+      auto crcInput = headerData;
       crcInput.insert(crcInput.end(), dataFieldBytes.begin(), dataFieldBytes.end());
-      const auto calculatedCRC = crc16(crcInput, m_CRCConfig.polynomial, m_CRCConfig.initialValue,
-                                       m_CRCConfig.finalXorValue);
-      m_report[1] = calculatedCRC == toValidate.getCRC();
+      const auto calculatedCRC = ::crc16(
+        crcInput, m_CRCConfig.polynomial, m_CRCConfig.initialValue,
+        m_CRCConfig.finalXorValue);
+      m_report[1] = calculatedCRC == packet.getCRC();
     }
     result &= m_report[1];
 
-    if (toValidateHeader.getSequenceFlags() == UNSEGMENTED) {
-      m_report[2] = toValidateHeader.getSequenceCount() == 0;
-    } else {
-      m_report[2] = toValidateHeader.getSequenceCount() > 0;
-      if (m_validateSegmentedCount) {
-        if (toValidateHeader.getSequenceFlags() == FIRST_SEGMENT) {
-          m_report[3] = toValidateHeader.getSequenceCount() == 1;
-        } else {
-          m_report[3] = toValidateHeader.getSequenceCount() == m_sequenceCounter;
-        }
-        m_sequenceCounter++;
-      }
+    const auto flags = static_cast<ESequenceFlag>(header.getSequenceFlags());
+    const auto open = segmentOpen();
+    switch (flags) {
+      case UNSEGMENTED:
+      case FIRST_SEGMENT:
+        m_report[2] = !open;
+        break;
+      case CONTINUING_SEGMENT:
+      case LAST_SEGMENT:
+        m_report[2] = open;
+        break;
+      default:
+        m_report[2] = false;
+        break;
     }
     result &= m_report[2];
+
+    if (m_validateSegmentedCount && sequenceInitialized()) {
+      m_report[3] = header.getSequenceCount() == expectedSequenceCount();
+    }
     result &= m_report[3];
+
+    if (m_report[2] && m_report[3]) {
+      acceptSequence(header);
+    }
   }
 
   if (m_validateAgainstTemplate) {
-    m_templatePacket.setUpdatePacketEnable(false);
-    auto templateHeader = m_templatePacket.getPrimaryHeader();
+    const auto &templateHeader = m_templatePacket.getPrimaryHeader();
     const auto templateHeaderData = templateHeader.serialize();
     if (templateHeaderData.size() != 6U) {
       m_report[4] = false;
       m_report[5] = false;
       return false;
     }
-    m_report[4] = templateHeaderData[0] == toValidateHeaderData[0]
-                  && templateHeaderData[1] == toValidateHeaderData[1];
+
+    m_report[4] = templateHeaderData[0] == headerData[0]
+                  && templateHeaderData[1] == headerData[1];
     result &= m_report[4];
+
     if (templateHeader.getSequenceFlags() == UNSEGMENTED) {
-      m_report[5] = toValidateHeader.getSequenceFlags() == UNSEGMENTED;
+      m_report[5] = header.getSequenceFlags() == UNSEGMENTED;
     } else {
-      m_report[5] = toValidateHeader.getSequenceFlags() != UNSEGMENTED;
+      m_report[5] = header.getSequenceFlags() != UNSEGMENTED;
     }
     result &= m_report[5];
   }
+
   return result;
 }
 
 void CCSDS::Validator::clear() {
-  m_sequenceCounter = 1;
+  m_sequenceCounter = 0U;
   m_report.clear();
   m_templatePacket = {};
   m_templatePacket.setUpdatePacketEnable(false);

--- a/test/src/testGroupCore.cpp
+++ b/test/src/testGroupCore.cpp
@@ -35,6 +35,29 @@ namespace {
   private:
     std::vector<std::uint8_t> m_data{};
   };
+
+  class UpdatingSecondaryHeader final : public CCSDS::SecondaryHeaderAbstract {
+  public:
+    UpdatingSecondaryHeader() : m_data{0x10} {}
+    [[nodiscard]] CCSDS::ResultBool deserialize(const std::vector<std::uint8_t> &data) override {
+      m_data = data;
+      return true;
+    }
+    [[nodiscard]] std::uint16_t getSize() const override {
+      return static_cast<std::uint16_t>(m_data.size());
+    }
+    [[nodiscard]] std::string getType() const override { return "UpdatingSecondaryHeader"; }
+    [[nodiscard]] std::vector<std::uint8_t> serialize() const override { return m_data; }
+    void update(CCSDS::DataField *) override {
+      if (!m_data.empty()) {
+        ++m_data[0];
+      }
+    }
+    CCSDS::ResultBool loadFromConfig(const Config &) override { return true; }
+
+  private:
+    std::vector<std::uint8_t> m_data{};
+  };
 }
 
 void testGroupCore(TestManager *tester, const std::string &description) {
@@ -50,7 +73,6 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     const CCSDS::PrimaryHeader header{0, 1, 1, 0x123, CCSDS::FIRST_SEGMENT, 7, 4};
     TEST_VOID(packet.setPrimaryHeader(header));
-    packet.setUpdatePacketEnable(false);
     const auto &stored = packet.getPrimaryHeader();
     return stored.getVersionNumber() == 0
            && stored.getType() == 1
@@ -61,9 +83,11 @@ void testGroupCore(TestManager *tester, const std::string &description) {
            && stored.getDataLength() == 4;
   });
 
-  tester->unitTest("Application data set from a vector produces the expected CRC.", [] {
+  tester->unitTest("CRC is finalized only by explicit update or serialization.", [] {
     CCSDS::Packet packet;
     TEST_VOID(packet.setApplicationData({1, 2, 3, 4, 5}));
+    if (packet.getCRC() != 0U) return false;
+    packet.update();
     return packet.getApplicationDataBytes() == std::vector<std::uint8_t>({1, 2, 3, 4, 5})
            && packet.getDataFieldHeaderBytes().empty()
            && packet.getCRC() == 0x3B8D;
@@ -76,13 +100,15 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     return packet.getApplicationDataBytes() == std::vector<std::uint8_t>({1, 2, 3, 4, 5});
   });
 
-  tester->unitTest("Buffer secondary header and application data serialize in order.", [] {
+  tester->unitTest("Buffer secondary header inspection preserves current bytes.", [] {
     CCSDS::Packet packet;
     TEST_VOID(packet.setDataFieldHeader({1, 2}));
     TEST_VOID(packet.setApplicationData({3, 4, 5}));
     const auto dataField = packet.getFullDataFieldBytes();
-    return dataField == std::vector<std::uint8_t>({1, 2, 3, 4, 5})
-           && packet.getCRC() == 0x9903;
+    if (dataField != std::vector<std::uint8_t>({1, 2, 3, 4, 5})) return false;
+    if (packet.getCRC() != 0U) return false;
+    packet.update();
+    return packet.getCRC() == 0x9903;
   });
 
   tester->unitTest("Custom secondary-header types remain registerable.", [] {
@@ -90,6 +116,73 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     TEST_VOID(packet.RegisterSecondaryHeader<TestSecondaryHeader>());
     TEST_VOID(packet.setDataFieldHeader({0xAA, 0xBB, 0xCC}, "TestSecondaryHeader"));
     return packet.getDataFieldHeaderBytes() == std::vector<std::uint8_t>({0xAA, 0xBB, 0xCC});
+  });
+
+  tester->unitTest("Packet getters do not finalize dirty state.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(
+      CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 7, 0}));
+    packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>());
+    TEST_VOID(packet.setApplicationData({0xAA}));
+
+    const CCSDS::Packet &view = packet;
+    const auto headerBefore = view.getPrimaryHeaderBytes();
+    const auto secondaryBefore = view.getDataFieldHeaderBytes();
+    const auto crcBefore = view.getCRC();
+
+    (void)view.getPrimaryHeader64bit();
+    (void)view.getFullPacketLength();
+    (void)view.getDataFieldHeaderFlag();
+    (void)view.getDataField();
+    (void)view.getPrimaryHeader();
+    (void)view.getApplicationDataBytes();
+    (void)view.getFullDataFieldBytes();
+    (void)view.getCRCVectorBytes();
+
+    return view.getPrimaryHeaderBytes() == headerBefore
+           && view.getDataFieldHeaderBytes() == secondaryBefore
+           && view.getCRC() == crcBefore
+           && view.getPrimaryHeader().getSequenceCount() == 7U
+           && view.getPrimaryHeader().getDataLength() == 0U
+           && secondaryBefore == std::vector<std::uint8_t>({0x10})
+           && crcBefore == 0U;
+  });
+
+  tester->unitTest("Serialization remains the explicit finalization path.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(
+      CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 9, 0}));
+    packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>());
+    TEST_VOID(packet.setApplicationData({0xAA}));
+
+    const auto encoded = packet.serialize();
+    return !encoded.empty()
+           && packet.getPrimaryHeader().getSequenceCount() == 9U
+           && packet.getPrimaryHeader().getDataLength() == 3U
+           && packet.getDataFieldHeaderBytes() == std::vector<std::uint8_t>({0x11})
+           && packet.getCRC() != 0U;
+  });
+
+  tester->unitTest("Parsed packet inspection preserves received sequence and CRC.", [] {
+    CCSDS::Packet source;
+    TEST_VOID(source.setPrimaryHeader(
+      CCSDS::PrimaryHeader{0, 0, 0, 0x123, CCSDS::UNSEGMENTED, 123, 0}));
+    TEST_VOID(source.setApplicationData({0xDE, 0xAD}));
+    const auto encoded = source.serialize();
+
+    CCSDS::Packet decoded;
+    TEST_VOID(decoded.deserialize(encoded));
+    const CCSDS::Packet &view = decoded;
+    const auto headerBefore = view.getPrimaryHeaderBytes();
+    const auto crcBefore = view.getCRC();
+    (void)view.getApplicationDataBytes();
+    (void)view.getFullDataFieldBytes();
+    (void)view.getDataFieldHeaderBytes();
+
+    return view.getPrimaryHeaderBytes() == headerBefore
+           && view.getPrimaryHeader().getSequenceCount() == 123U
+           && view.getCRC() == crcBefore
+           && crcBefore != 0U;
   });
 
   tester->unitTest("PUS-A packet uses a valid generated CRC during round-trip.", [] {

--- a/test/src/testGroupCore.cpp
+++ b/test/src/testGroupCore.cpp
@@ -122,6 +122,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     TEST_VOID(packet.setPrimaryHeader(
       CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 7, 0}));
+    TEST_VOID(packet.RegisterSecondaryHeader<UpdatingSecondaryHeader>());
     packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>());
     TEST_VOID(packet.setApplicationData({0xAA}));
 
@@ -152,6 +153,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     TEST_VOID(packet.setPrimaryHeader(
       CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 9, 0}));
+    TEST_VOID(packet.RegisterSecondaryHeader<UpdatingSecondaryHeader>());
     packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>());
     TEST_VOID(packet.setApplicationData({0xAA}));
 

--- a/test/src/testGroupManagement.cpp
+++ b/test/src/testGroupManagement.cpp
@@ -12,17 +12,35 @@
 #include "tests.h"
 
 namespace {
-  CCSDS::Packet makeTemplate(const std::uint16_t apid = 1U,
-                             const CCSDS::ESequenceFlag flags = CCSDS::UNSEGMENTED,
-                             const std::uint16_t count = 0U,
-                             const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16) {
+  CCSDS::Packet makePacket(
+      const std::uint16_t apid = 1U,
+      const CCSDS::ESequenceFlag flags = CCSDS::UNSEGMENTED,
+      const std::uint16_t count = 0U,
+      const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16,
+      const std::uint8_t version = 0U,
+      const std::uint8_t type = 0U,
+      const std::uint8_t dataFieldHeaderFlag = 0U) {
     CCSDS::Packet packet;
     packet.setPacketErrorControlMode(mode);
     const auto result = packet.setPrimaryHeader(
-      CCSDS::PrimaryHeader{0, 0, 0, apid, flags, count, 0});
+      CCSDS::PrimaryHeader{version, type, dataFieldHeaderFlag, apid, flags, count, 0});
     if (!result) {
       std::cerr << "[ Error ]: " << result.error().message() << '\n';
     }
+    return packet;
+  }
+
+  CCSDS::Packet finalizedPacket(const std::uint16_t apid,
+                                const CCSDS::ESequenceFlag flags,
+                                const std::uint16_t count,
+                                const std::uint8_t type = 0U) {
+    auto packet = makePacket(apid, flags, count, CCSDS::PacketErrorControlMode::CRC16,
+                             0U, type, 0U);
+    const auto result = packet.setApplicationData({1, 2});
+    if (!result || packet.serialize().empty()) {
+      return {};
+    }
+    packet.setUpdatePacketEnable(false);
     return packet;
   }
 
@@ -38,57 +56,190 @@ namespace {
 void testGroupManagement(TestManager *tester, const std::string &description) {
   std::cout << "  testGroupManagement: " << description << std::endl;
 
-  tester->unitTest("Manager preserves a disabled-update packet template.", [] {
-    CCSDS::Manager manager(makeTemplate());
-    std::vector<std::uint8_t> serialized;
-    TEST_RET(serialized, manager.getPacketTemplate());
-    return serialized.size() == 8U
-           && serialized[0] == 0x00
-           && serialized[1] == 0x01
-           && serialized[2] == 0xC0
-           && serialized[3] == 0x00;
+  tester->unitTest("Manager advances sequence count for unsegmented packets.", [] {
+    CCSDS::Manager manager(makePacket(1, CCSDS::UNSEGMENTED, 5));
+    manager.setAutoValidateEnable(false);
+    manager.setDataFieldSize(5);
+
+    TEST_VOID(manager.setApplicationData({1, 2, 3}));
+    auto packets = manager.getPackets();
+    if (packets.size() != 1U
+        || packets[0].getPrimaryHeader().getSequenceFlags() != CCSDS::UNSEGMENTED
+        || packets[0].getPrimaryHeader().getSequenceCount() != 5U
+        || manager.getSequenceCount() != 6U) {
+      return false;
+    }
+
+    TEST_VOID(manager.setApplicationData({4, 5}));
+    packets = manager.getPackets();
+    return packets.size() == 1U
+           && packets[0].getPrimaryHeader().getSequenceCount() == 6U
+           && manager.getSequenceCount() == 7U;
+  });
+
+  tester->unitTest("Unsegmented packets support explicit non-zero sequence counts.", [] {
+    CCSDS::Packet packet;
+    packet.setSequenceFlags(CCSDS::UNSEGMENTED);
+    TEST_VOID(packet.setSequenceCount(123));
+    TEST_VOID(packet.setApplicationData({0xAA}));
+    const auto encoded = packet.serialize();
+    return !encoded.empty()
+           && packet.getPrimaryHeader().getSequenceCount() == 123U
+           && (static_cast<std::uint16_t>(encoded[2] & 0x3FU) << 8U | encoded[3]) == 123U;
+  });
+
+  tester->unitTest("Manager segments data with consecutive sequence counts.", [] {
+    CCSDS::Manager manager(makePacket(1, CCSDS::FIRST_SEGMENT, 10));
+    manager.setAutoValidateEnable(false);
+    manager.setDataFieldSize(5);
+    TEST_VOID(manager.setApplicationData({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    const auto packets = manager.getPackets();
+    if (packets.size() != 3U) return false;
+    const auto &h0 = packets[0].getPrimaryHeader();
+    const auto &h1 = packets[1].getPrimaryHeader();
+    const auto &h2 = packets[2].getPrimaryHeader();
+    return h0.getSequenceFlags() == CCSDS::FIRST_SEGMENT
+           && h1.getSequenceFlags() == CCSDS::CONTINUING_SEGMENT
+           && h2.getSequenceFlags() == CCSDS::LAST_SEGMENT
+           && h0.getSequenceCount() == 10U
+           && h1.getSequenceCount() == 11U
+           && h2.getSequenceCount() == 12U
+           && manager.getSequenceCount() == 13U;
+  });
+
+  tester->unitTest("Manager sequence count rolls over modulo 16384.", [] {
+    CCSDS::Manager manager(makePacket(1, CCSDS::FIRST_SEGMENT, 0x3FFFU));
+    manager.setAutoValidateEnable(false);
+    manager.setDataFieldSize(2);
+    TEST_VOID(manager.setApplicationData({1, 2, 3}));
+
+    const auto packets = manager.getPackets();
+    return packets.size() == 2U
+           && packets[0].getPrimaryHeader().getSequenceCount() == 0x3FFFU
+           && packets[1].getPrimaryHeader().getSequenceCount() == 0U
+           && manager.getSequenceCount() == 1U;
+  });
+
+  tester->unitTest("Manager manual sequence mode preserves the configured count.", [] {
+    CCSDS::Manager manager(makePacket());
+    manager.setAutoValidateEnable(false);
+    manager.setAutoSequenceCountEnable(false);
+    TEST_VOID(manager.setSequenceCount(42));
+    manager.setDataFieldSize(2);
+    TEST_VOID(manager.setApplicationData({1, 2, 3, 4, 5}));
+
+    const auto packets = manager.getPackets();
+    if (packets.size() != 3U || manager.getSequenceCount() != 42U
+        || manager.getAutoSequenceCountEnable()) {
+      return false;
+    }
+    for (const auto &packet : packets) {
+      if (packet.getPrimaryHeader().getSequenceCount() != 42U) return false;
+    }
+    return true;
+  });
+
+  tester->unitTest("Clearing packets resets the stream counter.", [] {
+    CCSDS::Manager manager(makePacket(1, CCSDS::UNSEGMENTED, 8));
+    manager.setAutoValidateEnable(false);
+    TEST_VOID(manager.setApplicationData({1}));
+    if (manager.getSequenceCount() != 9U) return false;
+    manager.clearPackets();
+    return manager.getSequenceCount() == 0U && manager.getPackets().empty();
+  });
+
+  tester->unitTest("Template-bound Manager enforces the complete packet identifier.", [] {
+    CCSDS::Manager manager(makePacket(0x123, CCSDS::UNSEGMENTED, 0,
+                                      CCSDS::PacketErrorControlMode::CRC16,
+                                      0, 1, 1));
+    manager.setAutoValidateEnable(false);
+
+    if (!manager.addPacket(makePacket(0x123, CCSDS::FIRST_SEGMENT, 7,
+                                      CCSDS::PacketErrorControlMode::CRC16,
+                                      0, 1, 1))) {
+      return false;
+    }
+    if (manager.addPacket(makePacket(0x124, CCSDS::UNSEGMENTED, 0,
+                                     CCSDS::PacketErrorControlMode::CRC16,
+                                     0, 1, 1))) {
+      return false;
+    }
+    if (manager.addPacket(makePacket(0x123, CCSDS::UNSEGMENTED, 0,
+                                     CCSDS::PacketErrorControlMode::CRC16,
+                                     0, 0, 1))) {
+      return false;
+    }
+    if (manager.addPacket(makePacket(0x123, CCSDS::UNSEGMENTED, 0,
+                                     CCSDS::PacketErrorControlMode::CRC16,
+                                     0, 1, 0))) {
+      return false;
+    }
+    return !manager.addPacket(makePacket(0x123, CCSDS::UNSEGMENTED, 0,
+                                         CCSDS::PacketErrorControlMode::CRC16,
+                                         1, 1, 1));
+  });
+
+  tester->unitTest("Manager without a template binds to the first packet identifier.", [] {
+    CCSDS::Manager manager;
+    manager.setAutoValidateEnable(false);
+    TEST_VOID(manager.addPacket(makePacket(1, CCSDS::FIRST_SEGMENT, 1,
+                                           CCSDS::PacketErrorControlMode::CRC16,
+                                           0, 0, 0)));
+    TEST_VOID(manager.addPacket(makePacket(1, CCSDS::LAST_SEGMENT, 2,
+                                           CCSDS::PacketErrorControlMode::CRC16,
+                                           0, 0, 0)));
+    if (manager.addPacket(makePacket(2, CCSDS::UNSEGMENTED, 3))) return false;
+
+    manager.clear();
+    TEST_VOID(manager.addPacket(makePacket(2, CCSDS::UNSEGMENTED, 0)));
+    return manager.getTotalPackets() == 1U
+           && manager.getPackets()[0].getPrimaryHeader().getAPID() == 2U;
+  });
+
+  tester->unitTest("Packet collection loads reject mixed identifiers transactionally.", [] {
+    CCSDS::Manager manager;
+    manager.setAutoValidateEnable(false);
+    const std::vector<CCSDS::Packet> packets{
+      makePacket(1, CCSDS::FIRST_SEGMENT, 1),
+      makePacket(2, CCSDS::LAST_SEGMENT, 2)
+    };
+    return !manager.load(packets)
+           && manager.getTotalPackets() == 0U
+           && manager.getSequenceCount() == 0U;
+  });
+
+  tester->unitTest("Concatenated buffer loads reject mixed identifiers transactionally.", [] {
+    auto packet1 = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1, 0);
+    auto packet2 = finalizedPacket(1, CCSDS::LAST_SEGMENT, 2, 1);
+    auto buffer = packet1.serialize();
+    const auto bytes2 = packet2.serialize();
+    buffer.insert(buffer.end(), bytes2.begin(), bytes2.end());
+
+    CCSDS::Manager manager;
+    manager.setAutoValidateEnable(false);
+    return !manager.load(buffer)
+           && manager.getTotalPackets() == 0U
+           && manager.getSequenceCount() == 0U;
   });
 
   tester->unitTest("Manager creates one compliant unsegmented packet.", [] {
-    CCSDS::Manager manager(makeTemplate());
+    CCSDS::Manager manager(makePacket());
+    manager.setAutoValidateEnable(false);
     manager.setDataFieldSize(5);
     TEST_VOID(manager.setApplicationData({1, 2, 3, 4, 5}));
 
     std::vector<std::uint8_t> packet;
     TEST_RET(packet, manager.getPacketBufferAtIndex(0));
-    if (manager.getTotalPackets() != 1U || packet.size() != 13U) return false;
-    if (packet[4] != 0x00 || packet[5] != 0x06 || !hasValidDefaultCRC(packet)) return false;
-
-    std::vector<std::uint8_t> applicationData;
-    TEST_RET(applicationData, manager.getApplicationDataBuffer());
-    return applicationData == std::vector<std::uint8_t>({1, 2, 3, 4, 5});
-  });
-
-  tester->unitTest("Manager segments data and preserves sequence metadata.", [] {
-    CCSDS::Manager manager;
-    TEST_VOID(manager.setPacketTemplate(makeTemplate(1, CCSDS::FIRST_SEGMENT, 1)));
-    manager.setAutoValidateEnable(false);
-    manager.setDataFieldSize(5);
-    const std::vector<std::uint8_t> input{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7};
-    TEST_VOID(manager.setApplicationData(input));
-
-    auto packets = manager.getPackets();
-    if (packets.size() != 3U) return false;
-    const auto h0 = packets[0].getPrimaryHeader();
-    const auto h1 = packets[1].getPrimaryHeader();
-    const auto h2 = packets[2].getPrimaryHeader();
-    if (h0.getSequenceFlags() != CCSDS::FIRST_SEGMENT || h0.getSequenceCount() != 1U) return false;
-    if (h1.getSequenceFlags() != CCSDS::CONTINUING_SEGMENT || h1.getSequenceCount() != 2U) return false;
-    if (h2.getSequenceFlags() != CCSDS::LAST_SEGMENT || h2.getSequenceCount() != 3U) return false;
-
-    std::vector<std::uint8_t> reassembled;
-    TEST_RET(reassembled, manager.getApplicationDataBuffer());
-    return reassembled == input;
+    return manager.getTotalPackets() == 1U
+           && packet.size() == 13U
+           && packet[4] == 0x00
+           && packet[5] == 0x06
+           && hasValidDefaultCRC(packet);
   });
 
   tester->unitTest("Manager loads concatenated compliant packets and rejects truncation.", [] {
-    CCSDS::Manager producer;
-    TEST_VOID(producer.setPacketTemplate(makeTemplate(1, CCSDS::FIRST_SEGMENT, 1)));
+    CCSDS::Manager producer(makePacket(1, CCSDS::FIRST_SEGMENT, 1));
     producer.setAutoValidateEnable(false);
     producer.setDataFieldSize(5);
     const std::vector<std::uint8_t> input{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7};
@@ -101,7 +252,9 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     std::vector<std::uint8_t> reassembled;
     TEST_RET(reassembled, consumer.getApplicationDataBuffer());
     if (consumer.getTotalPackets() != 3U || reassembled != input
-        || consumer.getPacketsBuffer() != buffer) return false;
+        || consumer.getPacketsBuffer() != buffer) {
+      return false;
+    }
 
     auto truncated = buffer;
     truncated.pop_back();
@@ -110,35 +263,17 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     return !invalidConsumer.load(truncated);
   });
 
-  tester->unitTest("Manager adds and loads packet objects and buffers.", [] {
-    CCSDS::Packet packet1 = makeTemplate(1, CCSDS::FIRST_SEGMENT, 1);
-    CCSDS::Packet packet2 = makeTemplate(1, CCSDS::LAST_SEGMENT, 2);
-    TEST_VOID(packet1.setApplicationData({1, 2}));
-    TEST_VOID(packet2.setApplicationData({3, 4}));
-    const auto packet1Bytes = packet1.serialize();
-
-    CCSDS::Manager manager;
-    manager.setAutoValidateEnable(false);
-    TEST_VOID(manager.addPacket(packet1));
-    TEST_VOID(manager.addPacketFromBuffer(packet1Bytes));
-    TEST_VOID(manager.load(std::vector<CCSDS::Packet>{packet2}));
-    auto packets = manager.getPackets();
-    return packets.size() == 3U
-           && packets[0].serialize() == packet1Bytes
-           && packets[1].serialize() == packet1Bytes
-           && packets[2].serialize() == packet2.serialize();
-  });
-
   tester->unitTest("Manager inserts and consumes sync patterns.", [] {
-    CCSDS::Manager producer;
-    TEST_VOID(producer.setPacketTemplate(makeTemplate(1, CCSDS::FIRST_SEGMENT, 1)));
+    CCSDS::Manager producer(makePacket(1, CCSDS::FIRST_SEGMENT, 1));
     producer.setAutoValidateEnable(false);
     producer.setDataFieldSize(3);
     producer.setSyncPatternEnable(true);
     TEST_VOID(producer.setApplicationData({1, 2, 3, 4, 5}));
     const auto framed = producer.getPacketsBuffer();
     if (framed.size() < 4U || framed[0] != 0x1A || framed[1] != 0xCF
-        || framed[2] != 0xFC || framed[3] != 0x1D) return false;
+        || framed[2] != 0xFC || framed[3] != 0x1D) {
+      return false;
+    }
 
     CCSDS::Manager consumer;
     consumer.setAutoValidateEnable(false);
@@ -149,20 +284,8 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     return data == std::vector<std::uint8_t>({1, 2, 3, 4, 5});
   });
 
-  tester->unitTest("Manager clears packet and template state.", [] {
-    CCSDS::Manager manager(makeTemplate());
-    manager.setAutoValidateEnable(false);
-    TEST_VOID(manager.setApplicationData({1, 2, 3}));
-    manager.clearPackets();
-    if (manager.getTotalPackets() != 0U || !manager.getPackets().empty()) return false;
-    TEST_VOID(manager.setApplicationData({4, 5}));
-    manager.clear();
-    return manager.getPackets().empty() && !manager.setApplicationData({6});
-  });
-
   tester->unitTest("Manager writes and reads compliant packet buffers.", [] {
-    CCSDS::Manager producer;
-    TEST_VOID(producer.setPacketTemplate(makeTemplate(1, CCSDS::FIRST_SEGMENT, 1)));
+    CCSDS::Manager producer(makePacket(1, CCSDS::FIRST_SEGMENT, 1));
     producer.setAutoValidateEnable(false);
     producer.setDataFieldSize(4);
     TEST_VOID(producer.setApplicationData({1, 2, 3, 4, 5, 6}));
@@ -177,33 +300,8 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     return consumer.getPacketsBuffer() == expected;
   });
 
-  tester->unitTest("Manager reads generated binary and configured templates.", [] {
-    CCSDS::Packet packet = makeTemplate();
-    TEST_VOID(packet.setApplicationData({0xAA, 0x55}));
-    const auto expectedBinary = packet.serialize();
-    const std::string path = "test_resources/runtimeTemplate.bin";
-    TEST_VOID(writeBinaryFile(expectedBinary, path));
-
-    CCSDS::Manager binaryManager;
-    TEST_VOID(binaryManager.readTemplate(path));
-    std::remove(path.c_str());
-    std::vector<std::uint8_t> actualBinary;
-    TEST_RET(actualBinary, binaryManager.getPacketTemplate());
-    if (actualBinary != expectedBinary) return false;
-
-#ifndef CCSDS_MCU
-    CCSDS::Packet configuredPacket;
-    TEST_VOID(configuredPacket.loadFromConfigFile("test_resources/templatePacket.cfg"));
-    CCSDS::Manager configManager;
-    TEST_VOID(configManager.loadTemplateConfigFile("test_resources/templatePacket.cfg"));
-    return configManager.getTemplate().serialize() == configuredPacket.serialize();
-#else
-    return true;
-#endif
-  });
-
   tester->unitTest("Manager preserves secondary headers while segmenting.", [] {
-    CCSDS::Packet packet = makeTemplate(1, CCSDS::FIRST_SEGMENT, 1);
+    CCSDS::Packet packet = makePacket(1, CCSDS::FIRST_SEGMENT, 1);
     PusC secondaryHeader;
     TEST_VOID(secondaryHeader.deserialize({0x02, 0x04, 0x05, 0x06, 0x07, 0x0A, 0x00, 0x00}));
     packet.setDataFieldHeader(std::make_shared<PusC>(secondaryHeader));
@@ -212,7 +310,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     manager.setAutoValidateEnable(false);
     manager.setDataFieldSize(13);
     TEST_VOID(manager.setApplicationData({1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7}));
-    auto packets = manager.getPackets();
+    const auto packets = manager.getPackets();
     return packets.size() == 3U
            && packets[0].getApplicationDataBytes().size() == 5U
            && packets[1].getApplicationDataBytes().size() == 5U
@@ -223,8 +321,8 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
   });
 
   tester->unitTest("Manager supports CRC-disabled templates.", [] {
-    CCSDS::Manager manager(makeTemplate(1, CCSDS::UNSEGMENTED, 0,
-                                        CCSDS::PacketErrorControlMode::None));
+    CCSDS::Manager manager(makePacket(1, CCSDS::UNSEGMENTED, 0,
+                                      CCSDS::PacketErrorControlMode::None));
     manager.setAutoValidateEnable(false);
     TEST_VOID(manager.setApplicationData({0xAA, 0x55}));
 
@@ -237,7 +335,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
   tester->unitTest("Manager rejects data without a template or with an empty payload.", [] {
     CCSDS::Manager manager;
     if (manager.setApplicationData({1})) return false;
-    TEST_VOID(manager.setPacketTemplate(makeTemplate()));
+    TEST_VOID(manager.setPacketTemplate(makePacket()));
     return !manager.setApplicationData({});
   });
 

--- a/test/src/testGroupValidator.cpp
+++ b/test/src/testGroupValidator.cpp
@@ -7,15 +7,19 @@
 #include "tests.h"
 
 namespace {
-  CCSDS::Packet finalizedPacket(const std::uint16_t apid,
-                                const CCSDS::ESequenceFlag flags,
-                                const std::uint16_t count,
-                                const std::vector<std::uint8_t> &data = {1, 2, 3},
-                                const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16) {
+  CCSDS::Packet finalizedPacket(
+      const std::uint16_t apid,
+      const CCSDS::ESequenceFlag flags,
+      const std::uint16_t count,
+      const std::vector<std::uint8_t> &data = {1, 2, 3},
+      const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16,
+      const std::uint8_t version = 0U,
+      const std::uint8_t type = 0U,
+      const std::uint8_t dataFieldHeaderFlag = 0U) {
     CCSDS::Packet packet;
     packet.setPacketErrorControlMode(mode);
     const auto headerResult = packet.setPrimaryHeader(
-      CCSDS::PrimaryHeader{0, 0, 0, apid, flags, count, 0});
+      CCSDS::PrimaryHeader{version, type, dataFieldHeaderFlag, apid, flags, count, 0});
     if (!headerResult) {
       return {};
     }
@@ -53,55 +57,84 @@ namespace {
 void testGroupValidator(TestManager *tester, const std::string &description) {
   std::cout << "  testGroupValidator: " << description << std::endl;
 
-  tester->unitTest("Validator accepts a coherent unsegmented packet.", [] {
+  tester->unitTest("Validator accepts a non-zero unsegmented sequence count.", [] {
     CCSDS::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 0));
+    return validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 5));
   });
 
-  tester->unitTest("Validator rejects a non-zero count on the current unsegmented policy.", [] {
+  tester->unitTest("Validator accepts first segment sequence count zero.", [] {
     CCSDS::Validator validator;
     validator.configure(true, true, false);
-    return !validator.validate(rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 5, 2));
-  });
-
-  tester->unitTest("Validator accepts a coherent first segment.", [] {
-    CCSDS::Validator validator;
-    validator.configure(true, true, false);
-    return validator.validate(finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1));
-  });
-
-  tester->unitTest("Validator rejects a segmented packet with count zero.", [] {
-    CCSDS::Validator validator;
-    validator.configure(true, true, false);
-    return !validator.validate(rawPacketWithoutCRC(1, CCSDS::FIRST_SEGMENT, 0, 2));
+    return validator.validate(finalizedPacket(1, CCSDS::FIRST_SEGMENT, 0));
   });
 
   tester->unitTest("Validator tracks a coherent segmented sequence.", [] {
-    const auto packet1 = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1);
-    const auto packet2 = finalizedPacket(1, CCSDS::CONTINUING_SEGMENT, 2);
-    auto validator = validatorWithTemplate(packet1);
-    return validator.validate(packet1) && validator.validate(packet2);
+    const auto first = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 10);
+    const auto continuing = finalizedPacket(1, CCSDS::CONTINUING_SEGMENT, 11);
+    const auto last = finalizedPacket(1, CCSDS::LAST_SEGMENT, 12);
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    return validator.validate(first)
+           && validator.validate(continuing)
+           && validator.validate(last);
   });
 
-  tester->unitTest("Validator rejects a discontinuous segmented sequence.", [] {
-    const auto packet1 = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1);
-    const auto packet2 = finalizedPacket(1, CCSDS::CONTINUING_SEGMENT, 3);
-    auto validator = validatorWithTemplate(packet1);
-    return validator.validate(packet1) && !validator.validate(packet2);
+  tester->unitTest("Validator rejects continuation without an open segmented sequence.", [] {
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    const auto packet = finalizedPacket(1, CCSDS::CONTINUING_SEGMENT, 7);
+    if (validator.validate(packet)) return false;
+    const auto report = validator.getReport();
+    return report.size() == 6U && !report[2] && report[3];
   });
 
-  tester->unitTest("Validator accepts a packet matching its unsegmented template.", [] {
-    const auto packet = finalizedPacket(0x123, CCSDS::UNSEGMENTED, 0);
+  tester->unitTest("Validator rejects an unsegmented packet before a segmented sequence is closed.", [] {
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    if (!validator.validate(finalizedPacket(1, CCSDS::FIRST_SEGMENT, 3))) return false;
+    const auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 4);
+    if (validator.validate(packet)) return false;
+    const auto report = validator.getReport();
+    return report.size() == 6U && !report[2] && report[3];
+  });
+
+  tester->unitTest("Validator rejects a discontinuous sequence count.", [] {
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    if (!validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 20))) return false;
+    const auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 22);
+    if (validator.validate(packet)) return false;
+    const auto report = validator.getReport();
+    return report.size() == 6U && report[2] && !report[3];
+  });
+
+  tester->unitTest("Validator sequence count rolls over modulo 16384.", [] {
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    return validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 0x3FFFU))
+           && validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 0U));
+  });
+
+  tester->unitTest("Validator accepts a packet matching its template identifier.", [] {
+    const auto packet = finalizedPacket(0x123, CCSDS::UNSEGMENTED, 4,
+                                        {1, 2, 3}, CCSDS::PacketErrorControlMode::CRC16,
+                                        0, 1, 0);
     auto validator = validatorWithTemplate(packet, false, true);
     return validator.validate(packet);
   });
 
-  tester->unitTest("Validator rejects a packet with a different template APID.", [] {
-    const auto templatePacket = finalizedPacket(0x123, CCSDS::UNSEGMENTED, 0);
-    const auto packet = finalizedPacket(0x124, CCSDS::UNSEGMENTED, 0);
+  tester->unitTest("Validator rejects a packet with a different template identifier.", [] {
+    const auto templatePacket = finalizedPacket(0x123, CCSDS::UNSEGMENTED, 4,
+                                                {1, 2, 3}, CCSDS::PacketErrorControlMode::CRC16,
+                                                0, 1, 0);
+    const auto packet = finalizedPacket(0x124, CCSDS::UNSEGMENTED, 4,
+                                        {1, 2, 3}, CCSDS::PacketErrorControlMode::CRC16,
+                                        0, 1, 0);
     auto validator = validatorWithTemplate(templatePacket, false, true);
-    return !validator.validate(packet);
+    if (validator.validate(packet)) return false;
+    const auto report = validator.getReport();
+    return report.size() == 6U && !report[4];
   });
 
   tester->unitTest("Validator rejects segmented state against an unsegmented template.", [] {
@@ -112,7 +145,7 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
   });
 
   tester->unitTest("Validator accepts packets without packet error control.", [] {
-    auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 0, {1, 2, 3},
+    auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 9, {1, 2, 3},
                                   CCSDS::PacketErrorControlMode::None);
     CCSDS::Validator validator;
     validator.configure(true, true, false);
@@ -120,42 +153,42 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
   });
 
   tester->unitTest("Validator report is fully true for a valid packet.", [] {
-    const auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 0);
+    const auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 9);
     auto validator = validatorWithTemplate(packet);
     validator.validate(packet);
     return validator.getReport() == std::vector<bool>({true, true, true, true, true, true});
   });
 
   tester->unitTest("Validator report isolates a Packet Data Length failure.", [] {
-    auto packet = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 0, 7);
-    auto templatePacket = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 0, 2);
+    auto packet = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 9, 7);
+    auto templatePacket = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 9, 2);
     auto validator = validatorWithTemplate(templatePacket);
     validator.validate(packet);
     return validator.getReport() == std::vector<bool>({false, true, true, true, true, true});
   });
 
   tester->unitTest("Validator report isolates a CRC failure.", [] {
-    auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 0, {1, 2, 3});
+    auto packet = finalizedPacket(1, CCSDS::UNSEGMENTED, 9, {1, 2, 3});
     packet.setApplicationData({1, 2, 4});
-    auto templatePacket = finalizedPacket(1, CCSDS::UNSEGMENTED, 0, {1, 2, 3});
+    auto templatePacket = finalizedPacket(1, CCSDS::UNSEGMENTED, 9, {1, 2, 3});
     auto validator = validatorWithTemplate(templatePacket);
     validator.validate(packet);
     return validator.getReport() == std::vector<bool>({true, false, true, true, true, true});
   });
 
-  tester->unitTest("Validator report isolates sequence-control coherence.", [] {
-    auto packet = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 5, 2);
-    auto templatePacket = rawPacketWithoutCRC(1, CCSDS::UNSEGMENTED, 0, 2);
+  tester->unitTest("Validator report isolates sequence-flag coherence.", [] {
+    auto packet = rawPacketWithoutCRC(1, CCSDS::CONTINUING_SEGMENT, 5, 2);
+    auto templatePacket = rawPacketWithoutCRC(1, CCSDS::FIRST_SEGMENT, 5, 2);
     auto validator = validatorWithTemplate(templatePacket);
     validator.validate(packet);
     return validator.getReport() == std::vector<bool>({true, true, false, true, true, true});
   });
 
-  tester->unitTest("Validator report isolates the first-segment count rule.", [] {
-    auto packet = rawPacketWithoutCRC(1, CCSDS::FIRST_SEGMENT, 5, 2);
-    auto templatePacket = rawPacketWithoutCRC(1, CCSDS::FIRST_SEGMENT, 1, 2);
-    auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
+  tester->unitTest("Validator report isolates sequence-count continuity.", [] {
+    CCSDS::Validator validator;
+    validator.configure(true, true, false);
+    if (!validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 5))) return false;
+    validator.validate(finalizedPacket(1, CCSDS::UNSEGMENTED, 7));
     return validator.getReport() == std::vector<bool>({true, true, true, false, true, true});
   });
 
@@ -169,7 +202,7 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
 
   tester->unitTest("Validator report isolates template sequence flags.", [] {
     const auto templatePacket = finalizedPacket(1, CCSDS::UNSEGMENTED, 0);
-    const auto packet = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1);
+    const auto packet = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 0);
     auto validator = validatorWithTemplate(templatePacket);
     validator.validate(packet);
     return validator.getReport() == std::vector<bool>({true, true, true, true, true, false});


### PR DESCRIPTION
## Summary

Completes the v1.2.0 sequence-count, single-stream identity, and non-mutating inspection work.

## Test-first history

The first commit defines the required behaviour before implementation:

- non-zero sequence counts on unsegmented packets;
- one 14-bit count consumed by every generated packet;
- modulo-16384 rollover;
- coherent first, continuation, last, and unsegmented flags;
- configurable automatic and manual Manager counting;
- complete Packet Identification binding;
- transactional mixed-identifier rejection;
- const packet inspection without hidden length, CRC, sequence, or secondary-header updates;
- received packet contents remaining stable during inspection.

## Sequence-count behaviour

- removes the forced zero count for unsegmented packets;
- `Packet::setSequenceCount()` supports the complete `0..16383` range independently of sequence flags;
- Manager uses one sequence counter for its single packet stream;
- every generated packet receives the current count and automatic mode advances once per packet;
- rollover is performed modulo 16384;
- automatic advancement is configurable through additive Manager APIs;
- manual mode assigns the configured count without advancing it;
- `clearPackets()` and `clear()` reset the stream count;
- parsed packets preserve their received count.

## Packet identifier enforcement

A Manager is bound to the complete 16-bit Packet Identification field:

- version number;
- packet type;
- data-field-header flag;
- APID.

Sequence flags, sequence count, and Packet Data Length are intentionally excluded because they vary inside one stream.

- a template binds the Manager immediately;
- a template-less Manager binds to the first accepted packet;
- `addPacket()`, packet collections, and concatenated buffers reject another identifier;
- collection and buffer loads stage their work and commit only after the entire input succeeds;
- `clear()` removes the identifier binding;
- packet-error-control mode remains explicit and is inherited from the bound stream when parsing buffers.

## Stable inspection

- Packet, Header, and DataField getters no longer call update logic;
- Packet Data Length, CRC, sequence count, and secondary-header contents change only through explicit mutation or finalization;
- `update()` and `serialize()` remain the explicit finalization paths;
- additive const overloads are provided while existing non-const signatures remain available;
- Header serialization computes packed values locally instead of mutating cached fields;
- the data-field-header flag is updated by explicit secondary-header setters because it is part of Packet Identification, not by later serialization;
- Manager byte getters serialize copies rather than mutating stored packets.

## Validator

- accepts non-zero unsegmented counts and count zero on a first segment;
- tracks the expected next count modulo 16384;
- separately reports sequence-flag coherence and count continuity;
- tracks whether a segmented sequence is open;
- compares the complete Packet Identification field against templates.

## Compatibility

- no existing public method is removed or renamed;
- const overloads and Manager sequence-control methods are additive;
- existing object layouts are preserved by storing Manager auto-sequence mode in an unused bit of the existing counter;
- one Manager still owns one stream; multiple identifiers require multiple Managers or direct Packet objects;
- existing public-header documentation remains available and has been extended for the new APIs.

## Validation

- Ubuntu 22.04: native tests, cross-build dependencies, Cortex-M/aarch64 packaging, and package generation pass;
- Ubuntu 24.04: build and tests pass;
- `ubuntu-latest`: build and tests pass;
- Windows: MinGW build, artifact verification, and tests pass;
- UML generation is non-blocking for this pull request because that workflow is coupled to `develop`/`main` branch behaviour rather than the source changes here.

The acceptance checklists for #52, #53, and #70 are complete. The issues remain open until this pull request is merged into `develop`.

Closes #52
Closes #53
Closes #70