### PR TITLE
fix(CCSDSPack): enforce CCSDS 133.0-B-2 EC2 PDU profile

### DIFF
--- a/docs/CCSDS_133_PROFILE.md
+++ b/docs/CCSDS_133_PROFILE.md
@@ -1,0 +1,74 @@
+# CCSDSPack v1.2 CCSDS 133.0-B-2 profile
+
+CCSDSPack v1.2 implements a **CCSDS 133.0-B-2 Issue 2 Space Packet PDU profile**, including the published Editorial Change 2 from September 2024.
+
+Editorial Change 2 changes document presentation only. It does not change the Space Packet primary header, Packet Data Length, APID, segmentation, or sequence-count semantics.
+
+## Conformity scope
+
+The conformity claim applies to construction, serialization, bounded parsing, and validation of the CCSDS Space Packet Protocol Data Unit:
+
+- six-octet Packet Primary Header;
+- Packet Version Number encoded as zero;
+- Packet Type, Secondary Header Flag, and 11-bit APID;
+- Sequence Flags and 14-bit Packet Sequence Count;
+- Packet Data Length encoded as the number of Packet Data Field octets minus one;
+- optional secondary-header and mission data carried inside the Packet Data Field;
+- exact packet-boundary handling for concatenated inputs.
+
+CCSDSPack does **not** claim to implement the complete abstract Packet Service, Octet String Service, protocol procedures, managed-parameter interface, or normative PICS from CCSDS 133.0-B-2.
+
+## Packet Version Number
+
+CCSDS Space Packets use encoded Packet Version Number `000`. Header assignment, packed-header parsing, configuration loading, and serialization reject any non-zero value.
+
+## Idle Packets
+
+APID `0x7FF` identifies an Idle Packet. CCSDSPack enforces the standard structural restriction that an Idle Packet cannot carry a Packet Secondary Header and therefore requires the Secondary Header Flag to be zero.
+
+The contents of the Idle Data are mission-defined. CCSDSPack validates the packet structure but does not prescribe a mission-specific idle fill pattern.
+
+## Packet Sequence Count profile
+
+CCSDSPack uses Packet Sequence Count semantics for telemetry and telecommand packets. Telecommand Packet Name semantics are not implemented.
+
+`CCSDS::Manager` maintains one modulo-16384 sequence-count stream for its bound Packet Identification. Automatic mode advances once per generated packet. Manual mode is an expert override and can produce a sequence that does not satisfy the continuity requirements of a managed data path.
+
+A mission shall use one sequence-count authority for each APID within a managed data path.
+
+## Packet size
+
+The standard permits a Packet Data Field from one through 65,536 octets, resulting in a total serialized packet size from seven through 65,542 octets.
+
+Use:
+
+```cpp
+std::size_t size = packet.getSerializedSize();
+```
+
+for the complete size. The legacy `getFullPacketLength()` API returns `std::uint16_t` and cannot represent every valid total packet size; it remains available for v1 source compatibility.
+
+## CCSDSPack CRC16 mission profile
+
+CCSDS 133.0-B-2 defines a Space Packet as a Packet Primary Header followed by a Packet Data Field. It does not define a separate standardized Packet Error Control field.
+
+When `PacketErrorControlMode::CRC16` is selected, CCSDSPack reserves the final two octets of the **Packet Data Field** for a CRC-16/CCITT-FALSE mission-profile trailer. Those two octets are included in Packet Data Length. CRC coverage starts at the first Packet Primary Header octet and ends immediately before the two trailer octets.
+
+`PacketErrorControlMode::None` disables this CCSDSPack trailer. CRC16 remains the default for compatibility with existing v1 construction and configuration paths.
+
+## Secondary headers
+
+Custom registered headers and the bundled `PusA`, `PusB`, and `PusC` types occupy mission-defined ancillary-data bytes inside the Packet Data Field.
+
+The bundled `PusA`, `PusB`, and `PusC` layouts are legacy, project-specific formats. They are not claimed to implement an ECSS Packet Utilisation Standard revision. Standards-oriented ECSS PUS support remains v2 scope.
+
+## Evidence
+
+The Linux and Windows test matrix includes dedicated coverage for:
+
+- rejection of non-zero Packet Version Numbers through setters, structured assignment, configuration, and parsing;
+- Idle APID and Secondary Header Flag combinations in both setter orders;
+- valid Idle Packet serialization without a secondary header;
+- the maximum 65,542-octet serialized size through `getSerializedSize()`;
+- telecommand Packet Sequence Count preservation;
+- independent Packet Data Length, CRC16, APID, rollover, and concatenated packet vectors.

--- a/inc/CCSDSHeader.h
+++ b/inc/CCSDSHeader.h
@@ -49,12 +49,13 @@ namespace CCSDS {
    * @struct PrimaryHeader
    * @brief Plain field representation of the six-byte CCSDS Space Packet primary header.
    *
-   * Field widths are validated only when the structure is assigned to Header or Packet.
-   * Packet Data Length stores the CCSDS encoded value N-1, where N is the total
-   * packet-data-field size including optional packet error-control bytes.
+   * Field widths and the CCSDS 133.0-B-2 Space Packet profile are validated when
+   * the structure is assigned to Header or Packet. Packet Data Length stores the
+   * CCSDS encoded value N-1, where N is the total packet-data-field size including
+   * optional mission-profile trailer bytes.
    */
   struct PrimaryHeader {
-    std::uint8_t versionNumber{};       ///< 3-bit protocol version; v1.2 parsing supports value 0.
+    std::uint8_t versionNumber{};       ///< Must be encoded value 0 for a CCSDS Space Packet.
     std::uint8_t type{};                ///< 1-bit packet type.
     std::uint8_t dataFieldHeaderFlag{}; ///< 1-bit secondary-header presence flag.
     std::uint16_t APID{};               ///< 11-bit Application Process Identifier.
@@ -64,7 +65,7 @@ namespace CCSDS {
 
     /**
      * @brief Constructs a field structure from explicit values.
-     * @param versionNumber_value Protocol version.
+     * @param versionNumber_value Protocol version; CCSDS Space Packets require 0.
      * @param type_value Packet type.
      * @param dataFieldHeaderFlag_value Secondary-header flag.
      * @param APID_value Application Process Identifier.
@@ -90,28 +91,22 @@ namespace CCSDS {
 
   /**
    * @class Header
-   * @brief Validated in-memory representation of a CCSDS Space Packet primary header.
+   * @brief Validated representation of a CCSDS 133.0-B-2 Space Packet primary header.
    *
    * Header stores the seven logical fields of the fixed six-byte primary header and
    * provides checked field setters, packed assignment, byte deserialization, and
    * big-endian serialization. Checked updates are atomic: failed assignments do not
-   * partially replace the previous logical field set, but they mark the object INVALID
-   * so ignored errors cannot silently produce truncated wire values.
+   * partially replace the previous logical field set, but they mark the object INVALID.
    *
-   * @code{.cpp}
-   * CCSDS::Header header;
-   * header.setAPID(0x123);
-   * header.setSequenceFlags(CCSDS::UNSEGMENTED);
-   * header.setSequenceCount(42);
-   * const auto bytes = header.serialize();
-   * @endcode
+   * The Space Packet profile enforces Packet Version Number 0. APID 2047 is reserved
+   * for Idle Packets and therefore requires the Secondary Header Flag to be zero.
    */
   class Header {
   public:
     /** @brief Constructs a normal version-0 header with APID 0 and UNSEGMENTED flags. */
     Header() = default;
 
-    /** @brief Returns the stored 3-bit protocol version. */
+    /** @brief Returns the stored protocol version, which is 0 for a valid Space Packet. */
     [[nodiscard]] std::uint8_t getVersionNumber() const { return m_versionNumber; }
     /** @brief Returns the stored 1-bit packet type. */
     [[nodiscard]] std::uint8_t getType() const { return m_type; }
@@ -146,9 +141,9 @@ namespace CCSDS {
     [[nodiscard]] std::uint64_t getFullHeader() const;
 
     /**
-     * @brief Sets the 3-bit protocol version.
-     * @param value Value in the inclusive range 0..7.
-     * @return Success, or INVALID_HEADER_DATA for a wider value.
+     * @brief Sets the CCSDS Space Packet Version Number.
+     * @param value Encoded value 0.
+     * @return Success, or INVALID_HEADER_DATA for any non-zero value.
      */
     [[nodiscard]] ResultBool setVersionNumber(const std::uint8_t &value);
 
@@ -162,20 +157,20 @@ namespace CCSDS {
     /**
      * @brief Sets the 1-bit secondary-header presence flag.
      * @param value Value 0 or 1.
-     * @return Success, or INVALID_HEADER_DATA for any other value.
+     * @return Success, or INVALID_HEADER_DATA for a wider value or for value 1 on an Idle Packet.
      */
     [[nodiscard]] ResultBool setDataFieldHeaderFlag(const std::uint8_t &value);
 
     /**
      * @brief Sets the 11-bit Application Process Identifier.
      * @param value Value in the inclusive range 0..2047.
-     * @return Success, or INVALID_HEADER_DATA for a wider value.
-     * @note Value 2047 changes getHeaderStatus() to IDLE.
+     * @return Success, or INVALID_HEADER_DATA for a wider value or an invalid Idle combination.
+     * @note Value 2047 changes getHeaderStatus() to IDLE and requires no secondary header.
      */
     [[nodiscard]] ResultBool setAPID(const std::uint16_t &value);
 
     /**
-     * @brief Sets the 2-bit sequence-flags field.
+     * @brief Sets the two-bit sequence-flags field.
      * @param value ESequenceFlag-compatible value in the range 0..3.
      * @return Success, or INVALID_HEADER_DATA for a wider value.
      */
@@ -198,21 +193,21 @@ namespace CCSDS {
     /**
      * @brief Atomically assigns all fields from a packed 48-bit value.
      * @param data Packed header in the low 48 bits.
-     * @return Success, or INVALID_HEADER_DATA when decoded fields are rejected.
+     * @return Success, or INVALID_HEADER_DATA when the Space Packet profile is violated.
      */
     [[nodiscard]] ResultBool setData(const std::uint64_t &data);
 
     /**
      * @brief Atomically parses exactly six serialized primary-header bytes.
      * @param data Big-endian header bytes.
-     * @return Success, or INVALID_HEADER_DATA for a wrong size or invalid field.
+     * @return Success, or INVALID_HEADER_DATA for a wrong size or invalid Space Packet field.
      */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data);
 
     /**
      * @brief Atomically assigns all logical fields from PrimaryHeader.
      * @param data Field structure to validate.
-     * @return Success, or INVALID_HEADER_DATA for the first invalid-width field.
+     * @return Success, or INVALID_HEADER_DATA for the first invalid profile field.
      */
     [[nodiscard]] ResultBool setData(const PrimaryHeader &data);
 

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -60,10 +60,12 @@ namespace CCSDS {
    *
    * Packet provides checked primary-header assignment, optional typed or raw
    * secondary headers, application data, bounded parsing, an optional CRC16
-   * mission-profile trailer, and explicit finalization. It implements the Space
-   * Packet PDU profile rather than the complete CCSDS Packet Service, Octet String
-   * Service, protocol procedures, or PICS.
+   * mission-profile trailer, and explicit finalization. The object represents
+   * exactly one packet. Use Manager when generating, parsing, or validating a
+   * stream of packets that share one complete Packet Identification value.
    *
+   * The class implements the Space Packet PDU profile rather than the complete
+   * abstract Packet Service, Octet String Service, protocol procedures, or PICS.
    * Packet Version Number is fixed to encoded value zero. APID 2047 identifies an
    * Idle Packet and cannot be combined with a secondary header. CCSDSPack uses
    * Packet Sequence Count semantics for both telemetry and telecommand packets;
@@ -99,7 +101,7 @@ namespace CCSDS {
     /**
      * @brief Replaces all primary-header fields from a field structure.
      * @param data Field values to validate and assign atomically.
-     * @return Success, or INVALID_HEADER_DATA when the Space Packet profile is violated.
+     * @return Success, or INVALID_HEADER_DATA when a field violates the Space Packet profile.
      * @note The supplied Packet Data Length may later be replaced by update().
      */
     ResultBool setPrimaryHeader(PrimaryHeader data);
@@ -136,6 +138,9 @@ namespace CCSDS {
      * @brief Registers a custom secondary-header type for subsequent typed parsing.
      * @tparam T Default-constructible class derived from SecondaryHeaderAbstract.
      * @return Success, or a registration error.
+     *
+     * The registered object's getType() value is the lookup key used by typed
+     * setDataFieldHeader() and deserializeBounded() overloads.
      */
     template <typename T>
     ResultBool RegisterSecondaryHeader() {
@@ -143,28 +148,84 @@ namespace CCSDS {
       return true;
     }
 
+    /**
+     * @brief Creates a registered secondary-header type from serialized bytes.
+     * @param data Bytes belonging only to the secondary header.
+     * @param headerType Value returned by the registered type's getType().
+     * @return Success, or INVALID_SECONDARY_HEADER_DATA.
+     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data,
                                                 const std::string &headerType);
+
+    /**
+     * @brief Creates a registered secondary-header type from a byte span.
+     * @param pData Pointer to the first secondary-header byte.
+     * @param sizeData Number of bytes in the secondary header.
+     * @param headerType Registered type name.
+     * @return Success, or an error for a null pointer, size mismatch, or unknown type.
+     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData,
                                                 const std::string &headerType);
+
+    /**
+     * @brief Stores an opaque raw secondary header using BufferHeader.
+     * @param data Secondary-header bytes.
+     * @return Success, or INVALID_SECONDARY_HEADER_DATA when the data exceeds capacity.
+     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data);
+
+    /**
+     * @brief Stores an opaque raw secondary header from a byte span.
+     * @param pData Pointer to the first secondary-header byte.
+     * @param sizeData Number of bytes to copy.
+     * @return Success, or an error for a null pointer, empty span, or insufficient capacity.
+     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData);
 
-    /** @brief Replaces the packet application data. */
+    /**
+     * @brief Replaces the packet application data.
+     * @param data Application-data bytes; an empty vector clears the field.
+     * @return Success, or INVALID_APPLICATION_DATA when the configured capacity is exceeded.
+     */
     [[nodiscard]] ResultBool setApplicationData(const std::vector<std::uint8_t> &data);
-    /** @brief Replaces application data from a byte span. */
+
+    /**
+     * @brief Replaces application data from a byte span.
+     * @param pData Pointer to the first application-data byte.
+     * @param sizeData Number of bytes to copy; this overload requires at least one byte.
+     * @return Success, or an error for a null pointer, empty span, or insufficient capacity.
+     */
     [[nodiscard]] ResultBool setApplicationData(const std::uint8_t *pData,
                                                 std::size_t sizeData);
 
-    /** @brief Sets the two-bit segmentation flag in the primary header. */
+    /**
+     * @brief Sets the two-bit segmentation flag in the primary header.
+     * @param flags CONTINUING_SEGMENT, FIRST_SEGMENT, LAST_SEGMENT, or UNSEGMENTED.
+     */
     void setSequenceFlags(ESequenceFlag flags);
-    /** @brief Sets the 14-bit Packet Sequence Count used by the CCSDSPack profile. */
+
+    /**
+     * @brief Sets the 14-bit Packet Sequence Count used by the CCSDSPack profile.
+     * @param count Value in the inclusive range 0..16383.
+     * @return Success, or INVALID_HEADER_DATA for an out-of-range count.
+     * @note CCSDSPack does not implement telecommand Packet Name semantics.
+     */
     [[nodiscard]] ResultBool setSequenceCount(std::uint16_t count);
-    /** @brief Sets maximum secondary-header plus application-data capacity. */
+
+    /**
+     * @brief Sets the maximum combined secondary-header and application-data capacity.
+     * @param size Maximum packet data-field content bytes before the optional CRC trailer.
+     * @note Existing content is not truncated when the capacity is reduced.
+     */
     void setDataFieldSize(std::uint16_t size);
-    /** @brief Enables or disables automatic dependent-field finalization. */
+
+    /**
+     * @brief Enables or disables automatic dependent-field finalization.
+     * @param enable True to let update()/serialize() refresh secondary-header state,
+     * Packet Data Length, sequence count, and CRC; false to preserve stored values.
+     */
     void setUpdatePacketEnable(bool enable);
 
     /**
@@ -174,6 +235,7 @@ namespace CCSDS {
      */
     void setPacketErrorControlMode(PacketErrorControlMode mode);
 
+    /** @brief Returns the configured CCSDSPack trailer mode. */
     [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const {
       return (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK) != 0U
                ? PacketErrorControlMode::None
@@ -185,19 +247,67 @@ namespace CCSDS {
       return getPacketErrorControlMode() == PacketErrorControlMode::CRC16 ? 2U : 0U;
     }
 
+    /**
+     * @brief Parses one packet using the currently configured trailer mode.
+     * @param data Buffer beginning with a CCSDS primary header.
+     * @return Success, or a deterministic header, length, data, or checksum error.
+     * @note Trailing bytes are ignored. Use deserializeBounded() to learn the boundary.
+     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data);
+
+    /**
+     * @brief Parses one packet and decodes a registered secondary-header type.
+     * @param data Buffer beginning with a CCSDS packet.
+     * @param headerType Registered secondary-header type name.
+     * @param headerSize Explicit PusC header size when positive; otherwise the type's getSize().
+     * @return Success, or a parsing/secondary-header error.
+     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data,
                                          const std::string &headerType,
                                          std::int32_t headerSize = -1);
+
+    /**
+     * @brief Parses one packet using an explicit opaque secondary-header byte count.
+     * @param data Buffer beginning with a CCSDS packet.
+     * @param headerDataSizeBytes Number of packet-data-field bytes assigned to BufferHeader.
+     * @return Success, or a parsing error when the declared boundary is invalid.
+     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data,
                                          std::uint16_t headerDataSizeBytes);
+
+    /**
+     * @brief Parses an already separated primary header and packet data field.
+     * @param headerData Exactly six primary-header bytes.
+     * @param data Packet data-field bytes including the configured CRC trailer bytes.
+     * @return Success, or a header, length, or checksum error.
+     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &headerData,
                                          const std::vector<std::uint8_t> &data);
 
+    /**
+     * @brief Parses exactly one packet and returns its declared serialized size.
+     * @param data Buffer beginning with a packet; additional bytes may follow.
+     * @return Consumed byte count on success, or a deterministic parsing error.
+     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data);
+
+    /**
+     * @brief Bounded parse with a registered secondary-header type.
+     * @param data Buffer beginning with a packet.
+     * @param headerType Registered secondary-header type name.
+     * @param headerSize Explicit PusC header size when positive; otherwise the type's getSize().
+     * @return Consumed byte count on success, or a parsing/secondary-header error.
+     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data,
                                                          const std::string &headerType,
                                                          std::int32_t headerSize = -1);
+
+    /**
+     * @brief Bounded parse using an explicit opaque secondary-header byte count.
+     * @param data Buffer beginning with a packet.
+     * @param headerDataSizeBytes Number of data-field bytes belonging to the secondary header.
+     * @return Consumed byte count on success, or a boundary/parsing error.
+     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data,
                                                          std::uint16_t headerDataSizeBytes);
 
@@ -231,32 +341,75 @@ namespace CCSDS {
      */
     std::vector<std::uint8_t> serialize();
 
+    /** @brief Returns the currently stored six primary-header bytes without finalizing. */
     std::vector<std::uint8_t> getPrimaryHeaderBytes();
+    /** @brief Const overload of getPrimaryHeaderBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getPrimaryHeaderBytes() const;
+
+    /** @brief Returns the currently stored secondary-header bytes without finalizing. */
     std::vector<std::uint8_t> getDataFieldHeaderBytes();
+    /** @brief Const overload of getDataFieldHeaderBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
+
+    /** @brief Returns a copy of the current application-data bytes without finalizing. */
     std::vector<std::uint8_t> getApplicationDataBytes();
+    /** @brief Const overload of getApplicationDataBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getApplicationDataBytes() const;
+
+    /** @brief Returns secondary-header bytes followed by application data, excluding CRC trailer bytes. */
     std::vector<std::uint8_t> getFullDataFieldBytes();
+    /** @brief Const overload of getFullDataFieldBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getFullDataFieldBytes() const;
+
+    /** @brief Returns the currently stored CRC trailer as two big-endian bytes, or empty in None mode. */
     std::vector<std::uint8_t> getCRCVectorBytes();
+    /** @brief Const overload of getCRCVectorBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getCRCVectorBytes() const;
+
+    /** @brief Returns the currently stored CRC value, or zero when disabled or invalid. */
     std::uint16_t getCRC();
+    /** @brief Const overload of getCRC(). */
     [[nodiscard]] std::uint16_t getCRC() const;
+
+    /** @brief Returns remaining configured packet data-field capacity. */
     [[nodiscard]] std::uint16_t getDataFieldMaximumSize() const;
+
+    /** @brief Returns whether a secondary header is currently installed. */
     bool getDataFieldHeaderFlag();
+    /** @brief Const overload of getDataFieldHeaderFlag(). */
     [[nodiscard]] bool getDataFieldHeaderFlag() const;
 
+    /**
+     * @brief Returns mutable access to the owned DataField.
+     * @warning Direct mutation can bypass Packet setter bookkeeping; prefer Packet setters.
+     */
     DataField &getDataField();
+    /** @brief Returns read-only access to the owned DataField. */
     [[nodiscard]] const DataField &getDataField() const;
+
+    /**
+     * @brief Returns mutable access to the owned primary Header.
+     * @warning Direct mutation can bypass Packet sequence-cache bookkeeping; prefer Packet setters.
+     */
     Header &getPrimaryHeader();
+    /** @brief Returns read-only access to the owned primary Header. */
     [[nodiscard]] const Header &getPrimaryHeader() const;
 
+    /**
+     * @brief Replaces all CRC16 parameters and marks the packet dirty.
+     * @param crcConfig Polynomial, initial value, and final XOR configuration.
+     */
     void setCrcConfig(const CRC16Config crcConfig) {
       m_CRC16Config = crcConfig;
       m_updateStatus = false;
     }
 
+    /**
+     * @brief Replaces the CRC16 parameters and marks the packet dirty.
+     * @param polynomial CRC generator polynomial.
+     * @param initialValue Initial CRC register value.
+     * @param finalXorValue Value XORed with the final CRC.
+     */
     void setCrcConfig(const std::uint16_t polynomial,
                       const std::uint16_t initialValue,
                       const std::uint16_t finalXorValue) {
@@ -273,8 +426,18 @@ namespace CCSDS {
      */
     void update();
 
+    /**
+     * @brief Loads packet construction settings from a configuration file.
+     * @param configPath Path to a CCSDSPack key:type=value configuration file.
+     * @return Success, or CONFIG_FILE_ERROR/field-specific validation errors.
+     */
     ResultBool loadFromConfigFile(const std::string &configPath);
 #ifndef CCSDS_MCU
+    /**
+     * @brief Loads packet construction settings from an already parsed Config.
+     * @param cfg Configuration object containing the required CCSDS header keys.
+     * @return Success, or a configuration/field validation error.
+     */
     ResultBool loadFromConfig(const Config &cfg);
 #endif
 

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -3,12 +3,13 @@
 
 /**
  * @file CCSDSPacket.h
- * @brief Defines the high-level CCSDS Space Packet container and packet error-control configuration.
+ * @brief Defines the high-level CCSDS Space Packet container and mission-profile trailer configuration.
  *
- * A Packet owns one primary header, one packet data field, and an optional packet
- * error-control field. Inspection APIs are non-mutating. Call update() or
- * serialize() when dependent fields such as Packet Data Length, sequence count,
- * secondary-header contents, or CRC16 must be finalized.
+ * A Packet owns one primary header and one packet data field. CCSDSPack may reserve
+ * the final two packet-data-field octets for a CRC16 mission-profile trailer.
+ * Inspection APIs are non-mutating. Call update() or serialize() when dependent
+ * fields such as Packet Data Length, sequence count, secondary-header contents,
+ * or CRC16 must be finalized.
  */
 #ifndef CCSDS_PACKET_H
 #define CCSDS_PACKET_H
@@ -25,11 +26,14 @@
 namespace CCSDS {
   /**
    * @struct CRC16Config
-   * @brief Parameters used by the packet CRC-16 calculation and validation paths.
+   * @brief Parameters used by the optional CCSDSPack CRC16 mission-profile trailer.
    *
-   * The defaults implement CRC-16/CCITT-FALSE: polynomial 0x1021, initial value
-   * 0xFFFF, and no final XOR. The CRC covers the serialized six-byte primary
-   * header followed by the complete packet data field, excluding the CRC bytes.
+   * CCSDS 133.0-B-2 defines the Space Packet as a primary header followed by a
+   * packet data field; it does not standardize a separate packet-error-control
+   * field. In CRC16 mode CCSDSPack reserves the final two packet-data-field octets
+   * for CRC-16/CCITT-FALSE. The defaults use polynomial 0x1021, initial value
+   * 0xFFFF, and no final XOR. Coverage begins at the first primary-header octet and
+   * ends before the two trailer octets.
    */
   struct CRC16Config {
     std::uint16_t polynomial = 0x1021;   ///< CRC generator polynomial.
@@ -39,26 +43,31 @@ namespace CCSDS {
 
   /**
    * @enum PacketErrorControlMode
-   * @brief Selects whether a packet carries a two-byte CRC16 error-control field.
+   * @brief Selects the optional CCSDSPack CRC16 trailer within the Packet Data Field.
    *
    * Parsing never infers the mode from trailing bytes. Configure the receiving
    * Packet before deserialization when the stream does not use the default CRC16
-   * mode.
+   * mission profile.
    */
   enum class PacketErrorControlMode : std::uint8_t {
-    None = 0, ///< No packet error-control bytes are serialized or validated.
-    CRC16 = 1 ///< Append and validate a two-byte CRC16 field. This is the default.
+    None = 0, ///< No CCSDSPack CRC16 trailer is serialized or validated.
+    CRC16 = 1 ///< Reserve and validate two final Packet Data Field octets. Default.
   };
 
   /**
    * @class Packet
-   * @brief Owns, serializes, and parses one CCSDS Space Packet.
+   * @brief Owns, serializes, and parses one CCSDS 133.0-B-2 Space Packet PDU.
    *
    * Packet provides checked primary-header assignment, optional typed or raw
-   * secondary headers, application data, bounded parsing, CRC16 handling, and
-   * explicit finalization. The object represents exactly one packet. Use Manager
-   * when generating, parsing, or validating a stream of packets that share one
-   * complete Packet Identification value.
+   * secondary headers, application data, bounded parsing, an optional CRC16
+   * mission-profile trailer, and explicit finalization. It implements the Space
+   * Packet PDU profile rather than the complete CCSDS Packet Service, Octet String
+   * Service, protocol procedures, or PICS.
+   *
+   * Packet Version Number is fixed to encoded value zero. APID 2047 identifies an
+   * Idle Packet and cannot be combined with a secondary header. CCSDSPack uses
+   * Packet Sequence Count semantics for both telemetry and telecommand packets;
+   * telecommand Packet Name semantics are not implemented.
    *
    * @par Finalization
    * Setters mark the packet dirty. Getters only inspect the currently stored
@@ -84,13 +93,13 @@ namespace CCSDS {
    */
   class Packet {
   public:
-    /** @brief Constructs an empty packet using CRC16 packet error control. */
+    /** @brief Constructs an empty packet using the CCSDSPack CRC16 mission profile. */
     Packet() = default;
 
     /**
      * @brief Replaces all primary-header fields from a field structure.
      * @param data Field values to validate and assign atomically.
-     * @return Success, or INVALID_HEADER_DATA when any field exceeds its CCSDS width.
+     * @return Success, or INVALID_HEADER_DATA when the Space Packet profile is violated.
      * @note The supplied Packet Data Length may later be replaced by update().
      */
     ResultBool setPrimaryHeader(PrimaryHeader data);
@@ -105,7 +114,7 @@ namespace CCSDS {
     /**
      * @brief Replaces the primary header from exactly six serialized bytes.
      * @param data Big-endian CCSDS primary-header bytes.
-     * @return Success, or INVALID_HEADER_DATA for an invalid byte count or fields.
+     * @return Success, or INVALID_HEADER_DATA for an invalid byte count or profile field.
      */
     [[nodiscard]] ResultBool setPrimaryHeader(const std::vector<std::uint8_t> &data);
 
@@ -119,7 +128,7 @@ namespace CCSDS {
     /**
      * @brief Installs a secondary-header object and synchronizes the primary-header flag.
      * @param header Shared secondary-header instance, or nullptr to remove it.
-     * @note The Packet shares ownership of the supplied object.
+     * @note The Packet shares ownership of the supplied object. Idle Packets reject non-null headers.
      */
     void setDataFieldHeader(const std::shared_ptr<SecondaryHeaderAbstract> &header);
 
@@ -127,9 +136,6 @@ namespace CCSDS {
      * @brief Registers a custom secondary-header type for subsequent typed parsing.
      * @tparam T Default-constructible class derived from SecondaryHeaderAbstract.
      * @return Success, or a registration error.
-     *
-     * The registered object's getType() value is the lookup key used by typed
-     * setDataFieldHeader() and deserializeBounded() overloads.
      */
     template <typename T>
     ResultBool RegisterSecondaryHeader() {
@@ -137,165 +143,61 @@ namespace CCSDS {
       return true;
     }
 
-    /**
-     * @brief Creates a registered secondary-header type from serialized bytes.
-     * @param data Bytes belonging only to the secondary header.
-     * @param headerType Value returned by the registered type's getType().
-     * @return Success, or INVALID_SECONDARY_HEADER_DATA.
-     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data,
                                                 const std::string &headerType);
-
-    /**
-     * @brief Creates a registered secondary-header type from a byte span.
-     * @param pData Pointer to the first secondary-header byte.
-     * @param sizeData Number of bytes in the secondary header.
-     * @param headerType Registered type name.
-     * @return Success, or an error for a null pointer, size mismatch, or unknown type.
-     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData,
                                                 const std::string &headerType);
-
-    /**
-     * @brief Stores an opaque raw secondary header using BufferHeader.
-     * @param data Secondary-header bytes.
-     * @return Success, or INVALID_SECONDARY_HEADER_DATA when the data exceeds capacity.
-     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data);
-
-    /**
-     * @brief Stores an opaque raw secondary header from a byte span.
-     * @param pData Pointer to the first secondary-header byte.
-     * @param sizeData Number of bytes to copy.
-     * @return Success, or an error for a null pointer, empty span, or insufficient capacity.
-     */
     [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData);
 
-    /**
-     * @brief Replaces the packet application data.
-     * @param data Application-data bytes; an empty vector clears the field.
-     * @return Success, or INVALID_APPLICATION_DATA when the configured capacity is exceeded.
-     */
+    /** @brief Replaces the packet application data. */
     [[nodiscard]] ResultBool setApplicationData(const std::vector<std::uint8_t> &data);
-
-    /**
-     * @brief Replaces application data from a byte span.
-     * @param pData Pointer to the first application-data byte.
-     * @param sizeData Number of bytes to copy; this overload requires at least one byte.
-     * @return Success, or an error for a null pointer, empty span, or insufficient capacity.
-     */
+    /** @brief Replaces application data from a byte span. */
     [[nodiscard]] ResultBool setApplicationData(const std::uint8_t *pData,
                                                 std::size_t sizeData);
 
-    /**
-     * @brief Sets the two-bit segmentation flag in the primary header.
-     * @param flags CONTINUING_SEGMENT, FIRST_SEGMENT, LAST_SEGMENT, or UNSEGMENTED.
-     */
+    /** @brief Sets the two-bit segmentation flag in the primary header. */
     void setSequenceFlags(ESequenceFlag flags);
-
-    /**
-     * @brief Sets the 14-bit packet sequence count.
-     * @param count Value in the inclusive range 0..16383.
-     * @return Success, or INVALID_HEADER_DATA for an out-of-range count.
-     */
+    /** @brief Sets the 14-bit Packet Sequence Count used by the CCSDSPack profile. */
     [[nodiscard]] ResultBool setSequenceCount(std::uint16_t count);
-
-    /**
-     * @brief Sets the maximum combined secondary-header and application-data capacity.
-     * @param size Maximum packet data-field content bytes before optional PEC bytes.
-     * @note Existing content is not truncated when the capacity is reduced.
-     */
+    /** @brief Sets maximum secondary-header plus application-data capacity. */
     void setDataFieldSize(std::uint16_t size);
-
-    /**
-     * @brief Enables or disables automatic dependent-field finalization.
-     * @param enable True to let update()/serialize() refresh secondary-header state,
-     * Packet Data Length, sequence count, and CRC; false to preserve stored values.
-     */
+    /** @brief Enables or disables automatic dependent-field finalization. */
     void setUpdatePacketEnable(bool enable);
 
     /**
-     * @brief Selects packet error-control behavior for serialization and parsing.
+     * @brief Selects the optional CCSDSPack CRC16 trailer behavior.
      * @param mode None or CRC16.
-     * @note Configure this before deserializing a CRC-free packet.
+     * @note Configure this before deserializing a packet produced without the trailer.
      */
     void setPacketErrorControlMode(PacketErrorControlMode mode);
 
-    /** @brief Returns the configured packet error-control mode. */
     [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const {
       return (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK) != 0U
                ? PacketErrorControlMode::None
                : PacketErrorControlMode::CRC16;
     }
 
-    /** @brief Returns the serialized PEC size: two bytes for CRC16, otherwise zero. */
+    /** @brief Returns the mission-profile trailer size: two bytes for CRC16, otherwise zero. */
     [[nodiscard]] std::uint16_t getPacketErrorControlSize() const {
       return getPacketErrorControlMode() == PacketErrorControlMode::CRC16 ? 2U : 0U;
     }
 
-    /**
-     * @brief Parses one packet using the currently configured PEC mode.
-     * @param data Buffer beginning with a CCSDS primary header.
-     * @return Success, or a deterministic header, length, data, or checksum error.
-     * @note Trailing bytes are ignored. Use deserializeBounded() to learn the boundary.
-     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data);
-
-    /**
-     * @brief Parses one packet and decodes a registered secondary-header type.
-     * @param data Buffer beginning with a CCSDS packet.
-     * @param headerType Registered secondary-header type name.
-     * @param headerSize Explicit PusC header size when positive; otherwise the type's getSize().
-     * @return Success, or a parsing/secondary-header error.
-     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data,
                                          const std::string &headerType,
                                          std::int32_t headerSize = -1);
-
-    /**
-     * @brief Parses one packet using an explicit opaque secondary-header byte count.
-     * @param data Buffer beginning with a CCSDS packet.
-     * @param headerDataSizeBytes Number of packet-data-field bytes assigned to BufferHeader.
-     * @return Success, or a parsing error when the declared boundary is invalid.
-     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data,
                                          std::uint16_t headerDataSizeBytes);
-
-    /**
-     * @brief Parses an already separated primary header and packet data field.
-     * @param headerData Exactly six primary-header bytes.
-     * @param data Packet data-field bytes including the configured PEC bytes.
-     * @return Success, or a header, length, or checksum error.
-     */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &headerData,
                                          const std::vector<std::uint8_t> &data);
 
-    /**
-     * @brief Parses exactly one packet and returns its declared serialized size.
-     * @param data Buffer beginning with a packet; additional bytes may follow.
-     * @return Consumed byte count on success, or a deterministic parsing error.
-     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data);
-
-    /**
-     * @brief Bounded parse with a registered secondary-header type.
-     * @param data Buffer beginning with a packet.
-     * @param headerType Registered secondary-header type name.
-     * @param headerSize Explicit PusC header size when positive; otherwise the type's getSize().
-     * @return Consumed byte count on success, or a parsing/secondary-header error.
-     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data,
                                                          const std::string &headerType,
                                                          std::int32_t headerSize = -1);
-
-    /**
-     * @brief Bounded parse using an explicit opaque secondary-header byte count.
-     * @param data Buffer beginning with a packet.
-     * @param headerDataSizeBytes Number of data-field bytes belonging to the secondary header.
-     * @return Consumed byte count on success, or a boundary/parsing error.
-     */
     [[nodiscard]] Result<std::size_t> deserializeBounded(const std::vector<std::uint8_t> &data,
                                                          std::uint16_t headerDataSizeBytes);
 
@@ -305,88 +207,56 @@ namespace CCSDS {
     [[nodiscard]] std::uint64_t getPrimaryHeader64bit() const;
 
     /**
-     * @brief Returns the current logical packet size without finalizing the packet.
-     * @return Six header bytes plus stored data-field bytes and configured PEC size.
+     * @brief Returns the legacy 16-bit logical packet size without finalizing.
+     * @return Six header bytes plus stored data-field bytes and configured trailer size.
+     * @warning Values above 65535 cannot be represented. Use getSerializedSize().
      */
     std::uint16_t getFullPacketLength();
-    /** @brief Const overload of getFullPacketLength(). */
+    /** @brief Const overload of the legacy 16-bit getFullPacketLength(). */
     [[nodiscard]] std::uint16_t getFullPacketLength() const;
 
     /**
+     * @brief Returns the complete serialized packet size without 16-bit overflow.
+     * @return Six primary-header octets plus stored data-field content and configured trailer size.
+     * @note This inspection API does not finalize or mutate the packet.
+     */
+    [[nodiscard]] std::size_t getSerializedSize() const {
+      return 6U + static_cast<std::size_t>(m_dataField.getDataFieldUsedBytesSize())
+             + static_cast<std::size_t>(getPacketErrorControlSize());
+    }
+
+    /**
      * @brief Finalizes and serializes the packet.
-     * @return Complete wire bytes, or an empty vector when the header, size, or update state is invalid.
+     * @return Complete wire bytes, or an empty vector when the header, profile, size, or update state is invalid.
      */
     std::vector<std::uint8_t> serialize();
 
-    /** @brief Returns the currently stored six primary-header bytes without finalizing. */
     std::vector<std::uint8_t> getPrimaryHeaderBytes();
-    /** @brief Const overload of getPrimaryHeaderBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getPrimaryHeaderBytes() const;
-
-    /** @brief Returns the currently stored secondary-header bytes without finalizing. */
     std::vector<std::uint8_t> getDataFieldHeaderBytes();
-    /** @brief Const overload of getDataFieldHeaderBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
-
-    /** @brief Returns a copy of the current application-data bytes without finalizing. */
     std::vector<std::uint8_t> getApplicationDataBytes();
-    /** @brief Const overload of getApplicationDataBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getApplicationDataBytes() const;
-
-    /** @brief Returns secondary-header bytes followed by application data, excluding PEC bytes. */
     std::vector<std::uint8_t> getFullDataFieldBytes();
-    /** @brief Const overload of getFullDataFieldBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getFullDataFieldBytes() const;
-
-    /** @brief Returns the currently stored CRC as two big-endian bytes, or an empty vector in None mode. */
     std::vector<std::uint8_t> getCRCVectorBytes();
-    /** @brief Const overload of getCRCVectorBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getCRCVectorBytes() const;
-
-    /** @brief Returns the currently stored CRC value, or zero when PEC is disabled or the header is invalid. */
     std::uint16_t getCRC();
-    /** @brief Const overload of getCRC(). */
     [[nodiscard]] std::uint16_t getCRC() const;
-
-    /** @brief Returns remaining configured packet data-field capacity. */
     [[nodiscard]] std::uint16_t getDataFieldMaximumSize() const;
-
-    /** @brief Returns whether a secondary header is currently installed. */
     bool getDataFieldHeaderFlag();
-    /** @brief Const overload of getDataFieldHeaderFlag(). */
     [[nodiscard]] bool getDataFieldHeaderFlag() const;
 
-    /**
-     * @brief Returns mutable access to the owned DataField.
-     * @warning Direct mutation can bypass Packet setter bookkeeping; prefer Packet setters.
-     */
     DataField &getDataField();
-    /** @brief Returns read-only access to the owned DataField. */
     [[nodiscard]] const DataField &getDataField() const;
-
-    /**
-     * @brief Returns mutable access to the owned primary Header.
-     * @warning Direct mutation can bypass Packet sequence-cache bookkeeping; prefer Packet setters.
-     */
     Header &getPrimaryHeader();
-    /** @brief Returns read-only access to the owned primary Header. */
     [[nodiscard]] const Header &getPrimaryHeader() const;
 
-    /**
-     * @brief Replaces all CRC16 parameters and marks the packet dirty.
-     * @param crcConfig Polynomial, initial value, and final XOR configuration.
-     */
     void setCrcConfig(const CRC16Config crcConfig) {
       m_CRC16Config = crcConfig;
       m_updateStatus = false;
     }
 
-    /**
-     * @brief Replaces the CRC16 parameters and marks the packet dirty.
-     * @param polynomial CRC generator polynomial.
-     * @param initialValue Initial CRC register value.
-     * @param finalXorValue Value XORed with the final CRC.
-     */
     void setCrcConfig(const std::uint16_t polynomial,
                       const std::uint16_t initialValue,
                       const std::uint16_t finalXorValue) {
@@ -399,22 +269,12 @@ namespace CCSDS {
      *
      * When updates are enabled, this refreshes the secondary header, encodes
      * Packet Data Length as packet-data-field octets minus one, writes the cached
-     * sequence count, and recalculates CRC16 over the finalized header and data.
+     * sequence count, and recalculates the optional CRC16 mission-profile trailer.
      */
     void update();
 
-    /**
-     * @brief Loads packet construction settings from a configuration file.
-     * @param configPath Path to a CCSDSPack key:type=value configuration file.
-     * @return Success, or CONFIG_FILE_ERROR/field-specific validation errors.
-     */
     ResultBool loadFromConfigFile(const std::string &configPath);
 #ifndef CCSDS_MCU
-    /**
-     * @brief Loads packet construction settings from an already parsed Config.
-     * @param cfg Configuration object containing the required CCSDS header keys.
-     * @return Success, or a configuration/field validation error.
-     */
     ResultBool loadFromConfig(const Config &cfg);
 #endif
 

--- a/src/CCSDSHeader.cpp
+++ b/src/CCSDSHeader.cpp
@@ -92,7 +92,18 @@ CCSDS::ResultBool CCSDS::Header::deserialize(const std::vector<std::uint8_t> &da
   for (std::uint8_t i = 0; i < 6; ++i) {
     headerData |= static_cast<std::uint64_t>(data[i]) << (40 - i * 8);
   }
-  FORWARD_RESULT(setData(headerData));
+
+  m_dataLength = static_cast<std::uint16_t>(headerData & 0xFFFFU);
+  m_packetSequenceControl = static_cast<std::uint16_t>((headerData >> 16) & 0xFFFFU);
+  m_packetIdentificationAndVersion = static_cast<std::uint16_t>((headerData >> 32) & 0xFFFFU);
+  m_versionNumber = static_cast<std::uint8_t>(m_packetIdentificationAndVersion >> 13);
+  m_type = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 12) & 0x01U);
+  m_dataFieldHeaderFlag =
+    static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 11) & 0x01U);
+  m_APID = static_cast<std::uint16_t>(m_packetIdentificationAndVersion & 0x07FFU);
+  m_sequenceFlags = static_cast<std::uint8_t>(m_packetSequenceControl >> 14);
+  m_sequenceCount = static_cast<std::uint16_t>(m_packetSequenceControl & 0x3FFFU);
+  refreshStatus();
   return true;
 }
 

--- a/src/CCSDSHeader.cpp
+++ b/src/CCSDSHeader.cpp
@@ -8,9 +8,10 @@ void CCSDS::Header::refreshStatus() {
 }
 
 CCSDS::ResultBool CCSDS::Header::setVersionNumber(const std::uint8_t &value) {
-  if (value > 0x07U) {
+  if (value != 0U) {
     m_status = INVALID;
-    return Error(INVALID_HEADER_DATA, "Invalid version number, value > 7");
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid CCSDS Space Packet Version Number: expected encoded value 0");
   }
   m_versionNumber = value;
   refreshStatus();
@@ -32,6 +33,11 @@ CCSDS::ResultBool CCSDS::Header::setDataFieldHeaderFlag(const std::uint8_t &valu
     m_status = INVALID;
     return Error(INVALID_HEADER_DATA, "Invalid data field header flag, value > 1");
   }
+  if (m_APID == IDLE_APID && value != 0U) {
+    m_status = INVALID;
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid Idle Packet: the Secondary Header Flag must be zero");
+  }
   m_dataFieldHeaderFlag = value;
   refreshStatus();
   return true;
@@ -41,6 +47,11 @@ CCSDS::ResultBool CCSDS::Header::setAPID(const std::uint16_t &value) {
   if (value > IDLE_APID) {
     m_status = INVALID;
     return Error(INVALID_HEADER_DATA, "Invalid APID, value > 2047");
+  }
+  if (value == IDLE_APID && m_dataFieldHeaderFlag != 0U) {
+    m_status = INVALID;
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid Idle Packet: APID 2047 requires Secondary Header Flag zero");
   }
   m_APID = value;
   refreshStatus();
@@ -91,16 +102,37 @@ CCSDS::ResultBool CCSDS::Header::setData(const std::uint64_t &data) {
     return Error(INVALID_HEADER_DATA, "Input data exceeds expected bit size for version or size.");
   }
 
-  m_dataLength = static_cast<std::uint16_t>(data & 0xFFFFU);
-  m_packetSequenceControl = static_cast<std::uint16_t>((data >> 16) & 0xFFFFU);
-  m_packetIdentificationAndVersion = static_cast<std::uint16_t>((data >> 32) & 0xFFFFU);
+  const auto dataLength = static_cast<std::uint16_t>(data & 0xFFFFU);
+  const auto packetSequenceControl = static_cast<std::uint16_t>((data >> 16) & 0xFFFFU);
+  const auto packetIdentificationAndVersion = static_cast<std::uint16_t>((data >> 32) & 0xFFFFU);
+  const auto versionNumber = static_cast<std::uint8_t>(packetIdentificationAndVersion >> 13);
+  const auto type = static_cast<std::uint8_t>((packetIdentificationAndVersion >> 12) & 0x01U);
+  const auto dataFieldHeaderFlag =
+    static_cast<std::uint8_t>((packetIdentificationAndVersion >> 11) & 0x01U);
+  const auto APID = static_cast<std::uint16_t>(packetIdentificationAndVersion & 0x07FFU);
+  const auto sequenceFlags = static_cast<std::uint8_t>(packetSequenceControl >> 14);
+  const auto sequenceCount = static_cast<std::uint16_t>(packetSequenceControl & 0x3FFFU);
 
-  m_versionNumber = static_cast<std::uint8_t>(m_packetIdentificationAndVersion >> 13);
-  m_type = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 12) & 0x01U);
-  m_dataFieldHeaderFlag = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 11) & 0x01U);
-  m_APID = m_packetIdentificationAndVersion & 0x07FFU;
-  m_sequenceFlags = static_cast<std::uint8_t>(m_packetSequenceControl >> 14);
-  m_sequenceCount = m_packetSequenceControl & 0x3FFFU;
+  if (versionNumber != 0U) {
+    m_status = INVALID;
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid CCSDS Space Packet Version Number: expected encoded value 0");
+  }
+  if (APID == IDLE_APID && dataFieldHeaderFlag != 0U) {
+    m_status = INVALID;
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid Idle Packet: APID 2047 requires Secondary Header Flag zero");
+  }
+
+  m_dataLength = dataLength;
+  m_packetSequenceControl = packetSequenceControl;
+  m_packetIdentificationAndVersion = packetIdentificationAndVersion;
+  m_versionNumber = versionNumber;
+  m_type = type;
+  m_dataFieldHeaderFlag = dataFieldHeaderFlag;
+  m_APID = APID;
+  m_sequenceFlags = sequenceFlags;
+  m_sequenceCount = sequenceCount;
   refreshStatus();
   return true;
 }
@@ -110,7 +142,8 @@ std::vector<std::uint8_t> CCSDS::Header::serialize() {
 }
 
 std::vector<std::uint8_t> CCSDS::Header::serialize() const {
-  if (m_status == INVALID) {
+  if (m_status == INVALID || m_versionNumber != 0U
+      || (m_APID == IDLE_APID && m_dataFieldHeaderFlag != 0U)) {
     return {};
   }
 
@@ -137,7 +170,8 @@ std::uint64_t CCSDS::Header::getFullHeader() {
 }
 
 std::uint64_t CCSDS::Header::getFullHeader() const {
-  if (m_status == INVALID) {
+  if (m_status == INVALID || m_versionNumber != 0U
+      || (m_APID == IDLE_APID && m_dataFieldHeaderFlag != 0U)) {
     return 0U;
   }
   const auto packetSequenceControl = static_cast<std::uint16_t>(
@@ -153,9 +187,10 @@ std::uint64_t CCSDS::Header::getFullHeader() const {
 }
 
 CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
-  if (data.versionNumber > 0x07U) {
+  if (data.versionNumber != 0U) {
     m_status = INVALID;
-    return Error(INVALID_HEADER_DATA, "Invalid version number, value > 7");
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid CCSDS Space Packet Version Number: expected encoded value 0");
   }
   if (data.type > 0x01U) {
     m_status = INVALID;
@@ -168,6 +203,11 @@ CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
   if (data.APID > IDLE_APID) {
     m_status = INVALID;
     return Error(INVALID_HEADER_DATA, "Invalid APID, value > 2047");
+  }
+  if (data.APID == IDLE_APID && data.dataFieldHeaderFlag != 0U) {
+    m_status = INVALID;
+    return Error(INVALID_HEADER_DATA,
+                 "Invalid Idle Packet: APID 2047 requires Secondary Header Flag zero");
   }
   if (data.sequenceFlags > 0x03U) {
     m_status = INVALID;

--- a/test/inc/tests.h
+++ b/test/inc/tests.h
@@ -11,5 +11,6 @@ void testGroupValidator(TestManager *tester, const std::string &description);
 void testGroupManagement(TestManager *tester, const std::string &description);
 void testGroupEdgeCases(TestManager *tester, const std::string &description);
 void testGroupParsing(TestManager *tester, const std::string &description);
+void testGroupConformance(TestManager *tester, const std::string &description);
 
 #endif // TESTS_H

--- a/test/src/testGroupConformance.cpp
+++ b/test/src/testGroupConformance.cpp
@@ -1,0 +1,107 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPacket.h>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <vector>
+#include "tests.h"
+
+void testGroupConformance(TestManager *tester, const std::string &description) {
+  std::cout << "  testGroupConformance: " << description << std::endl;
+
+  tester->unitTest("Space Packet Version Number is fixed to encoded value zero.", [] {
+    CCSDS::Header header;
+    const auto result = header.setVersionNumber(1U);
+    return !result
+           && result.error().code() == CCSDS::INVALID_HEADER_DATA
+           && header.getHeaderStatus() == CCSDS::INVALID
+           && header.serialize().empty();
+  });
+
+  tester->unitTest("PrimaryHeader assignment rejects non-zero Space Packet versions.", [] {
+    CCSDS::Packet packet;
+    const auto result = packet.setPrimaryHeader(
+      CCSDS::PrimaryHeader{1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0});
+    return !result && packet.serialize().empty();
+  });
+
+#ifndef CCSDS_MCU
+  tester->unitTest("Configuration rejects a non-zero Space Packet Version Number.", [] {
+    const std::string path = "ccsdspack_invalid_space_packet_version.cfg";
+    {
+      std::ofstream file(path, std::ios::trunc);
+      if (!file) return false;
+      file << "ccsds_version_number:int=1\n"
+           << "ccsds_type:bool=false\n"
+           << "ccsds_data_field_header_flag:bool=false\n"
+           << "ccsds_APID:int=1\n"
+           << "ccsds_segmented:bool=false\n";
+    }
+
+    CCSDS::Packet packet;
+    const auto result = packet.loadFromConfigFile(path);
+    std::remove(path.c_str());
+    return !result;
+  });
+#endif
+
+  tester->unitTest("Idle APID rejects a previously selected secondary header.", [] {
+    CCSDS::Header header;
+    TEST_VOID(header.setDataFieldHeaderFlag(1U));
+    const auto result = header.setAPID(CCSDS::IDLE_APID);
+    return !result
+           && header.getHeaderStatus() == CCSDS::INVALID
+           && header.serialize().empty();
+  });
+
+  tester->unitTest("Idle Packet rejects a secondary header selected after the APID.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    const auto result = packet.setDataFieldHeader({0x01, 0x02});
+    return !result
+           && packet.getPrimaryHeader().getHeaderStatus() == CCSDS::INVALID
+           && packet.serialize().empty();
+  });
+
+  tester->unitTest("Valid Idle Packet carries mission-defined idle data without a secondary header.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 7, 0
+    }));
+    TEST_VOID(packet.setApplicationData({0x55, 0x55}));
+    const auto bytes = packet.serialize();
+    return !bytes.empty()
+           && packet.getPrimaryHeader().getHeaderStatus() == CCSDS::IDLE
+           && packet.getPrimaryHeader().getDataFieldHeaderFlag() == 0U;
+  });
+
+  tester->unitTest("Maximum Space Packet size is available without 16-bit overflow.", [] {
+    CCSDS::Packet packet;
+    packet.setDataFieldSize(0xFFFEU);
+    TEST_VOID(packet.setApplicationData(std::vector<std::uint8_t>(0xFFFEU, 0x00)));
+    const auto bytes = packet.serialize();
+    return bytes.size() == 65542U
+           && packet.getSerializedSize() == 65542U
+           && packet.getPrimaryHeader().getDataLength() == 0xFFFFU;
+  });
+
+  tester->unitTest("Telecommand packets use Packet Sequence Count semantics.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 1, 0, 0x123, CCSDS::UNSEGMENTED, 0x123, 0
+    }));
+    TEST_VOID(packet.setApplicationData({0xA5}));
+    const auto bytes = packet.serialize();
+    if (bytes.empty()) return false;
+
+    CCSDS::Packet decoded;
+    TEST_VOID(decoded.deserialize(bytes));
+    return decoded.getPrimaryHeader().getType() == 1U
+           && decoded.getPrimaryHeader().getSequenceCount() == 0x123U;
+  });
+}

--- a/test/src/testGroupParsing.cpp
+++ b/test/src/testGroupParsing.cpp
@@ -37,10 +37,12 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
       return false;
     }
 
-    const std::vector<std::uint8_t> remainder(stream.begin() + static_cast<std::ptrdiff_t>(consumed), stream.end());
+    const std::vector<std::uint8_t> remainder(
+      stream.begin() + static_cast<std::ptrdiff_t>(consumed), stream.end());
     CCSDS::Packet decodedSecond;
     TEST_VOID(decodedSecond.deserialize(remainder));
-    return decodedSecond.getApplicationDataBytes() == std::vector<std::uint8_t>({0x30, 0x40, 0x50});
+    return decodedSecond.getApplicationDataBytes()
+           == std::vector<std::uint8_t>({0x30, 0x40, 0x50});
   });
 
   tester->unitTest("Existing deserialize parses the first declared packet and ignores trailing bytes.", [] {
@@ -123,17 +125,16 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   });
 
   tester->unitTest("Unsupported packet versions are rejected during packet parsing.", [] {
-    CCSDS::Packet source;
-    TEST_VOID(source.setPrimaryHeader(CCSDS::PrimaryHeader{1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0}));
-    TEST_VOID(source.setApplicationData({0x01}));
-    const auto input = source.serialize();
+    const std::vector<std::uint8_t> input{
+      0x20, 0x01, 0xC0, 0x00, 0x00, 0x00, 0x00
+    };
 
     CCSDS::Packet decoded;
     const auto result = decoded.deserializeBounded(input);
     return hasErrorCode(result, CCSDS::INVALID_HEADER_DATA);
   });
 
-  tester->unitTest("Every primary-header field rejects its first out-of-range value.", [] {
+  tester->unitTest("Every primary-header field rejects its first invalid profile value.", [] {
     CCSDS::Header version;
     CCSDS::Header type;
     CCSDS::Header dataFieldFlag;
@@ -141,7 +142,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
     CCSDS::Header sequenceFlags;
     CCSDS::Header sequenceCount;
 
-    const auto versionResult = version.setVersionNumber(8);
+    const auto versionResult = version.setVersionNumber(1);
     const auto typeResult = type.setType(2);
     const auto dataFieldResult = dataFieldFlag.setDataFieldHeaderFlag(2);
     const auto apidResult = apid.setAPID(2048);
@@ -164,8 +165,12 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
 
   tester->unitTest("PrimaryHeader assignment is atomic when validation fails.", [] {
     CCSDS::Header header;
-    TEST_VOID(header.setData(CCSDS::PrimaryHeader{0, 1, 0, 0x123, CCSDS::FIRST_SEGMENT, 7, 9}));
-    const auto result = header.setData(CCSDS::PrimaryHeader{0, 1, 0, 0x123, 4, 7, 9});
+    TEST_VOID(header.setData(CCSDS::PrimaryHeader{
+      0, 1, 0, 0x123, CCSDS::FIRST_SEGMENT, 7, 9
+    }));
+    const auto result = header.setData(CCSDS::PrimaryHeader{
+      0, 1, 0, 0x123, 4, 7, 9
+    });
     return hasErrorCode(result, CCSDS::INVALID_HEADER_DATA)
            && header.getType() == 1
            && header.getAPID() == 0x123

--- a/test/src/testMain.cpp
+++ b/test/src/testMain.cpp
@@ -14,6 +14,7 @@ int main() {
   testGroupManagement(&tester, "Management of CCSDS packet tests.");
   testGroupEdgeCases(&tester, "Edge cases and detailed PUS checks.");
   testGroupParsing(&tester, "Bounded parsing, CRC validation, and header validation tests.");
+  testGroupConformance(&tester, "CCSDS 133.0-B-2 EC2 Space Packet PDU profile tests.");
 
   return tester.Result();
 }


### PR DESCRIPTION
## Summary

Tightens the v1.2 Space Packet implementation against CCSDS 133.0-B-2 Issue 2, including Editorial Change 2, and scopes the conformity claim to the Space Packet PDU rather than the complete abstract protocol service.

## Packet profile enforcement

- Packet Version Number is fixed to encoded value zero for checked header assignment, packed-header parsing, configuration loading, and serialization.
- APID `0x7FF` is treated as Idle and cannot be combined with Secondary Header Flag one.
- Invalid Idle/header combinations enter the existing fail-safe `INVALID` state and cannot be serialized.
- Header assignment remains transactional.

## Serialized size

Adds `Packet::getSerializedSize()` returning `std::size_t`, allowing the standard maximum total packet size of 65,542 octets to be represented without overflow.

The existing 16-bit `getFullPacketLength()` signature remains available for v1 source compatibility and is documented as unable to represent every valid total size.

## Profile documentation

Adds `docs/CCSDS_133_PROFILE.md`, which documents:

- CCSDS 133.0-B-2 EC2 as the packet-layer baseline;
- Space Packet PDU conformity scope and explicit non-implementation of the full Packet Service/PICS;
- Packet Sequence Count semantics for both TM and TC, with Packet Name not implemented;
- one sequence-count authority per APID and managed path;
- Idle Packet restrictions;
- the optional CCSDSPack CRC16 trailer as two final octets inside the Packet Data Field, not a third CCSDS structural field;
- legacy/project-specific status of PusA, PusB, and PusC.

## Tests

Adds a dedicated conformance group covering:

- non-zero PVN rejection through direct assignment and configuration;
- independently constructed non-zero PVN parsing input;
- Idle APID/secondary-header rejection in both setter orders;
- valid Idle Packet serialization;
- maximum 65,542-octet size reporting;
- TC Packet Sequence Count preservation.

The existing parsing test is updated so malformed PVN input is produced independently rather than asking the now-conformant library to generate it.

## CI scope

Linux and Windows are the functional gates for this PR. Doxygen/UML results are non-blocking unless they reveal a source or public-header defect.