### PR TITLE
fix(CCSDSPack): #46 enforce CCSDS 133.0-B-2 EC2 PDU profile

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,8 +41,21 @@ jobs:
           ls -l bin/
 
       - name: Run tests (native)
+        shell: bash
         run: |
-          cd bin && ./CCSDSPack_tester
+          set +e
+          cd bin
+          ./CCSDSPack_tester 2>&1 | tee CCSDSPack_tester.log
+          status=${PIPESTATUS[0]}
+          exit "$status"
+
+      - name: Upload native test failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-test-log-${{ matrix.os }}-${{ github.sha }}
+          path: bin/CCSDSPack_tester.log
+          if-no-files-found: error
 
       - name: Run CLI integration tests
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,14 +49,12 @@ jobs:
           status=${PIPESTATUS[0]}
           exit "$status"
 
-      - name: Upload native test failure diagnostics
+      - name: Upload native test failure log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: linux-test-log-${{ matrix.os }}-${{ github.sha }}
-          path: |
-            bin/CCSDSPack_tester.log
-            test/src/testGroupEdgeCases.cpp
+          path: bin/CCSDSPack_tester.log
           if-no-files-found: error
 
       - name: Run CLI integration tests
@@ -95,21 +93,35 @@ jobs:
 
       - name: Cleanup and generate packages (22.04 only)
         if: matrix.os == 'ubuntu-22.04'
+        shell: bash
         run: |
-          mkdir -p build packages
-          # 1) Native x86_64 .deb
-          rm -rf bin/* build/*
-          ./package.sh -p DEB
+          set +e
+          {
+            mkdir -p build packages
+            # 1) Native x86_64 .deb
+            rm -rf bin/* build/*
+            ./package.sh -p DEB
 
-          # 2) Bare-metal Cortex-M7 TGZ
-          rm -rf bin/* build/*
-          ./package.sh -t cmake/toolchains/arm-none-eabi.cmake -p MCU -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
+            # 2) Bare-metal Cortex-M7 TGZ
+            rm -rf bin/* build/*
+            ./package.sh -t cmake/toolchains/arm-none-eabi.cmake -p MCU -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
 
-          # 3) aarch64 .deb
-          rm -rf bin/* build/*
-          ./package.sh -t cmake/toolchains/aarch64-linux-gnu.cmake -p DEB
+            # 3) aarch64 .deb
+            rm -rf bin/* build/*
+            ./package.sh -t cmake/toolchains/aarch64-linux-gnu.cmake -p DEB
 
-          ls -la packages
+            ls -la packages
+          } 2>&1 | tee packaging.log
+          status=${PIPESTATUS[0]}
+          exit "$status"
+
+      - name: Upload packaging failure log
+        if: matrix.os == 'ubuntu-22.04' && failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packaging-log-${{ github.sha }}
+          path: packaging.log
+          if-no-files-found: error
 
       #- name: Upload package artifact
       #  if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,12 +49,14 @@ jobs:
           status=${PIPESTATUS[0]}
           exit "$status"
 
-      - name: Upload native test failure log
+      - name: Upload native test failure diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: linux-test-log-${{ matrix.os }}-${{ github.sha }}
-          path: bin/CCSDSPack_tester.log
+          path: |
+            bin/CCSDSPack_tester.log
+            test/src/testGroupEdgeCases.cpp
           if-no-files-found: error
 
       - name: Run CLI integration tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,8 +48,17 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Running CCSDSPack_tester.exe from build\bin\"
-          cd build\bin
-          .\CCSDSPack_tester.exe
+          Set-Location build\bin
+          .\CCSDSPack_tester.exe 2>&1 | Tee-Object -FilePath CCSDSPack_tester.log
+          exit $LASTEXITCODE
+
+      - name: Upload test failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-test-log-${{ github.sha }}
+          path: build/bin/CCSDSPack_tester.log
+          if-no-files-found: error
 
       - name: Run CLI integration tests
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -1,320 +1,171 @@
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <div style="text-align: center;">
     <img alt="ccsds_pack_logo" src="docs/imgs/Logo.png" width="400" />
 </div>
 
 # CCSDSPack [[ExoSpaceLabs](https://github.com/ExoSpaceLabs)]
-**CCSDSPack** is a lightweight C++ library for creating, parsing, managing, and validating
-packet formats based on the [CCSDS Space Packet](https://public.ccsds.org/) primary-header structure.
 
-The **v1.x.x** release series provides CCSDS-oriented packet manipulation, configurable secondary
-headers, application-data handling, CRC16 support, segmentation utilities, and command-line tools.
+**CCSDSPack** is a C++17 library for creating, parsing, managing, and validating CCSDS Space Packet protocol data units.
+
+The v1.2 packet layer targets **CCSDS 133.0-B-2, Issue 2, including Editorial Change 2 (September 2024)** through a documented Space Packet PDU profile.
 
 > [!IMPORTANT]
-> CCSDSPack v1.x.x is **not certified as compliant with ECSS Packet Utilisation Standard (PUS)**
-> revisions. The bundled `PusA`, `PusB`, and `PusC` classes are legacy project-specific secondary
-> header formats and must not be interpreted as official ECSS PUS implementations.
+> The v1.2 conformity claim is limited to the **Space Packet PDU profile**. CCSDSPack does not implement the complete abstract Packet Service, Octet String Service, all protocol procedures, or a Protocol Implementation Conformance Statement.
 
+> [!IMPORTANT]
+> The bundled `PusA`, `PusB`, and `PusC` classes are legacy project-specific secondary-header formats. They are not official ECSS Packet Utilisation Standard implementations.
 
-## Table of Contents
-- [Status](#status)
-- [Features](#features)
-- [Documentation](#documentation)
-- [Install](#install)
-    - [Source](#source)
-        - [Linux](#linux)
-        - [Windows](#windows)
-    - [Package](#package)
-    - [Docker](#docker)
-- [Examples](#examples)
-
----
 ## Status
-The following tables show the current overall build and regression test status of the library.
 
 | Linux | Windows |
-|-------|---------|
-| ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/linux.yml?branch=main)| ![Build Status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/windows.yml?branch=main) | 
+|---|---|
+| ![Linux](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/linux.yml?branch=main) | ![Windows](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/windows.yml?branch=main) |
 
-Specific distribution build and regression status are shown below
+| Platform | CI |
+|---|---|
+| Ubuntu 22.04 | ![Ubuntu 22.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-22-04) |
+| Ubuntu 24.04 | ![Ubuntu 24.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-24-04) |
+| Ubuntu latest | ![Ubuntu latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-latest) |
+| Windows latest | ![Windows latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml/badge.svg?job=windows-latest) |
 
-| OS      | Distribution  |  status |
-|---------|---------------|--------------|
-| Linux   | ubuntu-22.04  | ![Ubuntu 22.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-22-04)     |
-|         | ubuntu-24.04  | ![Ubuntu 24.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-24-04)    |
-|         | ubuntu-latest | ![Ubuntu Latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-latest)      |
-| Windows | latest        | ![Windows Latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml/badge.svg?job=windows-latest)      |
----
+## Protocol profile
+
+A serialized Space Packet contains:
+
+```text
+6-octet Packet Primary Header
++ Packet Data Field
+```
+
+The Packet Data Field contains optional secondary-header bytes followed by mission application data. When the CCSDSPack CRC16 profile is enabled, its final two octets are reserved for the CRC trailer:
+
+```text
+Packet Data Field = optional secondary header
+                  + application data
+                  + optional CCSDSPack CRC16 trailer
+```
+
+The CRC trailer is a **CCSDSPack mission-profile convention inside the Packet Data Field**. CCSDS 133.0-B-2 does not define it as a third Space Packet structural field.
+
+Detailed scope, limitations, and migration behavior are documented in [CCSDS 133.0-B-2 EC2 Space Packet PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md).
+
+### Primary-header rules
+
+CCSDSPack v1.2 enforces the following Packet-level rules:
+
+- Packet Version Number is `000`;
+- telemetry and telecommand Packet Types are supported;
+- the complete 11-bit APID range is supported;
+- APID `0x7FF` is reserved for Idle Packets;
+- Idle Packets have no secondary header and contain mission-defined idle user data;
+- Packet Data Length is the number of octets after the primary header minus one;
+- Sequence Flags use the CCSDS first, continuation, last, and unsegmented values;
+- Packet Sequence Count advances modulo 16384 in automatic Manager mode.
+
+CCSDSPack uses Packet Sequence Count semantics for both telemetry and telecommand packets. The optional telecommand Packet Name interpretation is not implemented.
+
+### Packet size
+
+The Packet Data Field can contain 1 through 65,536 octets, giving a total serialized packet size of 7 through 65,542 octets.
+
+Use:
+
+```cpp
+std::size_t packetSize = packet.getSerializedSize();
+```
+
+for the complete range. The legacy `getFullPacketLength()` API returns `std::uint16_t` and saturates at `UINT16_MAX` rather than wrapping.
+
+### Packet error control
+
+`PacketErrorControlMode` supports:
+
+- `PacketErrorControlMode::CRC16`, the existing v1 default;
+- `PacketErrorControlMode::None`.
+
+In CRC16 mode, CCSDSPack reserves the final two Packet Data Field octets for CRC-16/CCITT-FALSE and includes those octets in Packet Data Length. The receiver must configure the expected mode before parsing.
 
 ## Features
 
-- Support for packet types using the CCSDS Space Packet primary-header layout
-- Custom serialization with support for `std::vector`, `std::shared_ptr`, and user-defined types
-- End-to-end encoding / decoding and validation
-- Easy to test and integrate
-- Built-in extensibility for secondary headers with clear abstraction
-- User-friendly installation and usage within your code.
-- Example Executables (encoder, decoder and validator) see [Executables](docs/EXECUTABLES.md)
-- Optimised for fast execution.
-- Pre-built .deb package downloadable from [Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases).
-- Pre-built docker image with library installed, see [docker](#docker).
-- Exceptionless library, variant based error management enabling the usage within embedded systems see [Error management](docs/ERROR.md).
-- Baremetal build for targeted devices see [Cross-Build Guide](docs/CROSSBUILD.md).
----
+- CCSDS 133.0-B-2 EC2 Space Packet PDU construction and parsing;
+- exact bounded parsing with consumed-byte reporting;
+- concatenated packet-stream handling;
+- optional project-specific CRC16 trailer;
+- complete 11-bit APID handling and Idle Packet validation;
+- modulo-16384 sequence counting and segmentation utilities;
+- one complete Packet Identification binding per Manager;
+- custom and opaque secondary-header support;
+- exception-free `Result` and `Error` handling;
+- Linux and Windows builds;
+- optional bare-metal and cross-build targets;
+- encoder, decoder, validator, and regression-test executables;
+- installed CMake package and shared-library consumer test.
+
 ## Documentation
-Full API documentation is available and hosted here:  [CCSDSPack Documentation](https://exospacelabs.github.io/CCSDSPack/html/)
 
+- [Generated API reference](https://exospacelabs.github.io/CCSDSPack/html/)
+- [CCSDS 133.0-B-2 EC2 PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md)
+- [v1.2 current behavior](docs/V1_2_CURRENT_BEHAVIOUR.md)
+- [CLI reference](docs/CLI.md)
+- [Configuration reference](docs/CONFIG.md)
+- [Error handling](docs/ERROR.md)
+- [Packages](docs/PACKAGES.md)
+- [Cross-build guide](docs/CROSSBUILD.md)
+- [Examples](docs/EXAMPLES.md)
 
-C++ library for CCSDS-oriented packet generation, extraction, validation, and analysis.
+## Build from source
 
-![ccsds packet image](docs/imgs/Packet_management.png)
+Requirements:
 
-### Manager
-Features Provided by the CCSDS::Manager class(Assuming the Packet identifier data is known):
+- CMake 3.16 or newer;
+- a C++17 compiler;
+- GCC 8.5 or newer on supported Linux configurations.
 
-* Generate CCSDS packets with desired data (Segmented and Unsegmented).
-* Validate Packets coherence / against template (packet with set identifier).
-* Update Error Control and data specific parameters (CRC16, Counters, Flags Length...).
-* Include / remove / change Sync Pattern.
-* Read / Write a binary file and extract CCSDS packets.
-
-### The CCSDS packet protocol
-
-![ccsds packet image](docs/imgs/ccsdsPacket.png)
-
-- **Primary Header** — Fixed size, always present. Defines APID, packet type, data length, and other control flags.
-- **Secondary Header** — Optional; v1.x.x supports custom and legacy project-specific header formats.
-- **Application Data** — Mission-specific payload bytes.
-- **Error Control Field (optional)** — CRC or checksum for integrity verification.
-
----
-
-### Legacy Secondary Headers in v1.x.x
-
-CCSDSPack v1.x.x includes three built-in secondary-header implementations named `PusA`, `PusB`,
-and `PusC`.
-
-These names are retained for compatibility with the v1 API and configuration files. Their encoded
-layouts are **project-specific** and are not claimed to implement official ECSS PUS-A, PUS-C, or any
-other ECSS Packet Utilisation Standard revision.
-
-#### `PusA`
-
-A fixed-size legacy secondary header containing:
-
-- version,
-- service type,
-- service subtype,
-- source ID,
-- application-data length.
-
-![Legacy PusA secondary header](docs/imgs/pus-a.png)
-
-#### `PusB`
-
-A fixed-size legacy event-oriented secondary header containing:
-
-- version,
-- service type,
-- service subtype,
-- source ID,
-- event ID,
-- application-data length.
-
-![Legacy PusB secondary header](docs/imgs/pus-b.png)
-
-`PusB` is a CCSDSPack-specific format. It does not represent an official ECSS PUS revision or
-standard secondary-header type.
-
-#### `PusC`
-
-A variable-size legacy secondary header containing:
-
-- version,
-- service type,
-- service subtype,
-- source ID,
-- a variable byte sequence used as a time-code field,
-- application-data length.
-
-![Legacy PusC secondary header](docs/imgs/pus-c.png)
-
-The variable time-code field is treated as application-configured bytes and is not validated as a
-specific CCSDS or ECSS time-code format.
-
-#### v2 transition
-
-Standards-compliant CCSDS and ECSS PUS behaviour is planned for CCSDSPack v2.0.0. This includes
-correct packet-length semantics, packet error-control handling, sequence-count behaviour, and
-separate standards-based TC and TM secondary headers.
-
----
-
-### Other Documents
-Please check out the documentation on [ccsds documentation](https://public.ccsds.org/Publications/default.aspx). Recommended documents are within the Blue and Green
-books.
-
-The following documents are useful protocol references. Their inclusion does not imply that
-CCSDSPack v1.x.x implements every requirement in these standards:
-
-* [CCSDS 133.0-B-2](https://public.ccsds.org/Pubs/133x0b2e2.pdf) - Space Packet Protocol
-* [CCSDS 133.1-B-3](https://public.ccsds.org/Pubs/133x1b3e1.pdf) - Encapsulation Packet Protocol
-* [CCSDS 524.1-B-1](https://public.ccsds.org/Pubs/524x1b1.pdf) - Mission Operations--MAL Space Packet Transport Binding and Binary Encoding
-
----
-
-## Install
-1) Source  - use the cmake and make commands to compile the whole project and install it.
-2) Package - Install using prebuilt .deb package from [Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases). Further info on [Packages](docs/PACKAGES.md).
-3) Docker  - Docker image available from github hosted repo [Container](https://github.com/ExoSpaceLabs/CCSDSPack/pkgs/container/ccsdspack), also see [docker](#docker) section.
-
-### Source
-CMake flags:
-
-The following flags can be provided to cmake when building the project to enable or disable build of
-specific provided features. such as tester, which may or may not be of interest.
-
-| CMake Flag (default value) | Description                                                                  |
-|----------------------------|------------------------------------------------------------------------------|
-| -DCCSDSPACK_BUILD_MCU=OFF  | build the project as a static library for microcontrollers. *                |
-| -DENABLE_TESTER=ON         | build tester, that performs regression tests of the library.                 | 
-| -DENABLE_ENCODER=ON        | build encoder executable that encodes a file using ccsds packets             |
-| -DENABLE_DECODER=ON        | build decoder executable that decodes a binary file containing ccsds packets |
-| -DENABLE_VALIDATOR=ON      | build validator executable that validates packets.                           |
-
-*Used when compiling library for baremetal, refer to the [Cross-Build Guide](docs/CROSSBUILD.md) for usage.
-
-see executable enabler example usage during cmake setup below.
-
----
-
-#### Linux
-
-Install dependencies (GCC ≥ 8.5.0, CMake ≥ 3.20,  C++17 or newer)
 ```bash
-
-sudo apt update
-sudo apt install -y cmake make g++ 
-```
-Clone Repo:
-```bash
-
 git clone https://github.com/ExoSpaceLabs/CCSDSPack.git
 cd CCSDSPack
+cmake -S . -B build
+cmake --build build
 ```
 
-Configure CMake and build
-```bash
-
-cd build && cmake .. && make
-#cmake .. -DBUILD_TESTER=OFF
-```
-Assuming build has been successful the tester can be run from the build directory. So if
-you are still within the build dir just run the following commands:
-```bash
-
-cd ../bin && ./CCSDSPack_tester 
-```
-The library is advised to be installed using the following commands under /usr/local
-```bash
-
-make install
-```
-Note: this might require privileged `sudo` command as per permission restrictions.
-
----
-#### Windows
-tested on Windows-2019 and Windows-latest (see GitHub [Actions](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml))
-
-Install dependencies:
-
-```shell
-
-choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
-choco install ninja -y
-choco install mingw -y
-```
-
-Configure CMake and build using MinGW (Assuming the repo has been cloned)
-```shell
-
-cd build
-cmake -G "MinGW Makefiles" ..
-cmake --build . -- 
-```
-The tester can already be executed using the following commands:
-```shell
-
-cd build/bin && ./CCSDSPack_tester.exe
-```
-Note: CMake will deploy test files to bin directory, if the tester is not executed from the
-bin directory some tests will fail.
-
----
-
-### Package
-Pre-built package releases can be downloaded from [Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases).
-However, it is recommended to use the [latest-release](https://github.com/ExoSpaceLabs/CCSDSPack/releases/latest).
+Run the regression tester from the configured binary directory:
 
 ```bash
-
-curl -LO https://github.com/ExoSpaceLabs/CCSDSPack/releases/download/v<version>/ccsdspack-v<version>-<system>-<architecture>.deb
-sudo dpkg -i ccsdspack-v<version>-<system>-<architecture>.deb
+./bin/CCSDSPack_tester
 ```
 
-If the required system is not prebuilt or available on the above list, it can be generated by
-following instructions in [Packages](docs/PACKAGES.md) document. Where detailed information
-is provided for library inclusion in private projects.
+Install the library and exported CMake package:
 
-### Docker
-Prebuilt Docker images of CCSDSPack are published on [GHCR](https://github.com/ExoSpaceLabs/CCSDSPack/pkgs/container/ccsdspack).  
-They provide a ready-to-use environment with the library and command-line tools already installed,
-so you don’t need to compile from source or manage dependencies manually (almost none in this case).
-
-Pull a specific release image or the latest version:
 ```bash
-
- docker pull ghcr.io/exospacelabs/ccsdspack:v<version>
- # OR
- docker pull ghcr.io/exospacelabs/ccsdspack:latest
-```
-**Example usage:**
-
-Pull version 1.1.1 of the container
-```bash
-
-docker pull ghcr.io/exospacelabs/ccsdspack:v1.1.1
+cmake --install build
 ```
 
-Or pull the latest version:
-```bash
+### Build options
 
-docker pull ghcr.io/exospacelabs/ccsdspack:latest
+| CMake option | Default | Description |
+|---|---:|---|
+| `CCSDSPACK_BUILD_MCU` | `OFF` | Build the MCU static-library profile |
+| `ENABLE_TESTER` | `ON` | Build `CCSDSPack_tester` |
+| `ENABLE_ENCODER` | `ON` | Build `ccsds_encoder` |
+| `ENABLE_DECODER` | `ON` | Build `ccsds_decoder` |
+| `ENABLE_VALIDATOR` | `ON` | Build `ccsds_validator` |
+
+### Windows with MinGW
+
+```powershell
+cmake -S . -B build -G "MinGW Makefiles"
+cmake --build build
 ```
 
-Test the library by running the `CCSDSPack_tester` executable as follows.
-```bash
+The Windows workflow copies the shared-library DLL beside the test and external-consumer executables before running them.
 
-docker run --rm ghcr.io/exospacelabs/ccsdspack:latest /usr/bin/CCSDSPack_tester
-```
-The container includes the executables:
+## CMake integration
 
-- `ccsds_encoder`
-- `ccsds_decoder`
-- `ccsds_validator`
-- `CCSDSPack_tester`
-
-With a mounted volume, you can encode, decode, and validate packets against files on your host.
-For exploratory use, start an interactive shell inside the container:
-```bash
-
-docker run -it --rm ghcr.io/exospacelabs/ccsdspack:latest /bin/bash
-```
-
-___
-## Examples
-
-### CMake Integration
-You can easily integrate **CCSDSPack** into your CMake-based project. Once installed, use `find_package` to locate it and link against the exported target.
+After installing CCSDSPack:
 
 ```cmake
 find_package(CCSDSPack CONFIG REQUIRED)
@@ -323,108 +174,91 @@ add_executable(my_app main.cpp)
 target_link_libraries(my_app PRIVATE ccsdspack::CCSDSPack)
 ```
 
-If the library is installed in a non-standard location, you can specify the path using `CMAKE_PREFIX_PATH`:
-```bash
-cmake .. -DCMAKE_PREFIX_PATH=/path/to/install/prefix
-```
-
-### Encoder:
-
-Encode a specific file into the application data of CCSDS packets and save streamed packets
-data to a desired file.
-
-Requirements:
-* a file to encode
-* configuration file which holds the template packet data and settings
+For a non-standard install prefix:
 
 ```bash
-
-ccsds_encoder -i <file_to_encode> -o <encoded_binaryFile> -c <config_file>
-```
-### Decoder:
-
-Decode a previously encoded binary file holding serialized CCSDS packets, extract application
-data and recreate original file.
-
-Requirements:
-* an encoded binary file
-* configuration file used to encode the packets holding template packet data and settings
-
-```bash
-
-ccsds_decoder -i <encoded_binaryFile> -o <decoded_file> -c <config_file>
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/install/prefix
 ```
 
-Note: If the decoded file is named with the original file extension it will be usable as the original file,
+## C++ example
 
-For more detailed info and other examples (e.g. Validator usage) see [Executables](docs/EXECUTABLES.md).
+```cpp
+#include <CCSDSPack.h>
+#include <cstdint>
+#include <vector>
 
-The configuration file description and usage can be found under [Config file](docs/CONFIG.md).
+int main() {
+  CCSDS::Packet packetTemplate;
+  const auto headerResult = packetTemplate.setPrimaryHeader(CCSDS::PrimaryHeader{
+    0,                       // Packet Version Number 000
+    0,                       // telemetry packet
+    0,                       // no secondary header
+    0x123,                   // APID
+    CCSDS::UNSEGMENTED,
+    0,
+    0                        // calculated during serialization
+  });
+  if (!headerResult) return headerResult.error().code();
 
-### C++
-The following examples show how the high level C++ APIs can be used in a project
+  packetTemplate.setDataFieldSize(1024);
 
-Note: Assume a Big endian logic for data processing.
-1) This example shows how this library can be used to generate a ccsds packet or stream of packets using CCSDSPack
-
-```c++
-#include "CCSDSPack.h"
-
-int main(){
-
-  std::vector<std::uint8_t> inputBytes; // assume data is present
-  // make a packet and set header to be used as template  
-  CCSDS::Packet templatePacket;
-  if(const auto res = templatePacket.setPrimaryHeader(0xF7FF4FFFFFFF); !res.has_value()){
-    std::cerr << res.error().message() << std::endl;
-    return res.error().code();
-  }
-
-  // set template packet in manager
-  CCSDS::Manager manager(templatePacket);
-  manager.setDatFieldSize(1024); // sets max datafield size
-  
-  // load data
-  if (const auto res = manager.setApplicationData(inputBytes); !res.has_value()) {
-    std::cerr <<  res.error().message() << std::endl;
-    return res.error().code();
-  }
-  std::vector<CCSDS::Packet> packets = manager.getPackets();
-  // to manipulate as required.
-  
-  return 0;
-}
-```
-Where the 'inputBytes' are a set of bytes that are to be set as application into the packets. This is performed by
-first setting a template packet in the manager. Which then will be used as reference for all packets generated. and the
-application data is then set using the setApplicationData manager member method. This generates CCSDS packets in  the
-manager. It can be retrieved by using the getPackets method. and further manipulation can be performed if required.
-
-2) Assuming you already have a CCSDS packet stream and want to extract the data from it.
-
-```c++
-#include "CCSDSPack.h"
-
-int main(){
-
-  std::vector<CCSDS::Packet> packets; // assume data is present
-
-  // set template packet in manager
   CCSDS::Manager manager;
-  manager.setDatFieldSize(1024); // sets max datafield size
-  
-  // load data
-  if (const auto res = manager.load(packets); !res.has_value()) {
-    std::cerr <<  res.error().message() << std::endl;
-    return res.error().code();
-  }
-  // get the data buffer of the packets.
-  std::vector<std::uint8_t> data = manager.getApplicationDataBuffer();
-  return 0;
+  const auto templateResult = manager.setPacketTemplate(packetTemplate);
+  if (!templateResult) return templateResult.error().code();
+
+  const std::vector<std::uint8_t> inputBytes{0x10, 0x20, 0x30};
+  const auto dataResult = manager.setApplicationData(inputBytes);
+  if (!dataResult) return dataResult.error().code();
+
+  const auto wire = manager.getPacketsBuffer();
+  return wire.empty() ? 1 : 0;
 }
 ```
-Assuming we have a vector of CCSDS packets prepared ad hoc. These packets then can be loaded by the manager.
-If required the manager allows the packets to be validated for coherence, or if the template is set against it.
-In the example above the application data is retrieved from all packets into a single stream of data.
 
-For more examples, see [Examples](docs/EXAMPLES.md).
+## Command-line tools
+
+The build can provide:
+
+- `ccsds_encoder`;
+- `ccsds_decoder`;
+- `ccsds_validator`;
+- `CCSDSPack_tester`.
+
+The encoder, decoder, and validator support `crc16` and `none` packet-error-control profiles. See [CLI reference](docs/CLI.md) for exact options, concatenated decoding, trailing-byte handling, validation categories, and exit codes.
+
+## Packages and container
+
+Release packages are published under [GitHub Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases).
+
+Container images are published at:
+
+```bash
+docker pull ghcr.io/exospacelabs/ccsdspack:<version>
+```
+
+The image contains the library and command-line executables. Run the installed tester with:
+
+```bash
+docker run --rm ghcr.io/exospacelabs/ccsdspack:<version> /usr/bin/CCSDSPack_tester
+```
+
+## Legacy secondary headers
+
+The v1 API retains `PusA`, `PusB`, and `PusC` for compatibility with existing projects and configuration files. Their layouts are project-specific ancillary-data formats.
+
+- `PusA` and `PusB` are fixed-size legacy formats;
+- `PusC` contains a variable application-configured byte sequence described as a time-code field;
+- none of these classes is claimed to implement an official ECSS PUS revision;
+- `PusC` bytes are not automatically validated as a CCSDS time-code format.
+
+Standards-oriented ECSS PUS support remains v2.0.0 scope.
+
+## Compatibility with pre-v1.2 packets
+
+The v1 public source API remains available, but corrected wire semantics may differ from packets produced by earlier releases. Changes include Packet Data Length, CRC coverage, parsing boundaries, sequence behavior, Packet Identification enforcement, version validation, and Idle Packet validation.
+
+Stored or transmitted packets generated by older releases should be regenerated or migrated explicitly before adopting the v1.2 profile.
+
+## License
+
+CCSDSPack is licensed under the Apache License 2.0. See [LICENSE](LICENSE) and [Notice.md](Notice.md).

--- a/docs/CCSDS_133_0_B_2_PROFILE.md
+++ b/docs/CCSDS_133_0_B_2_PROFILE.md
@@ -1,0 +1,209 @@
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CCSDS 133.0-B-2 EC2 Space Packet PDU profile
+
+[Main README](../README.md)
+
+## Normative baseline
+
+CCSDSPack v1.2 targets the Space Packet Protocol packet data unit defined by:
+
+- **CCSDS 133.0-B-2, Issue 2, June 2020**;
+- including **Editorial Change 2, September 2024**.
+
+Editorial Change 2 changes document presentation only. It does not alter the Space Packet wire format or protocol semantics.
+
+## Conformity claim
+
+The supported claim is:
+
+> CCSDSPack v1.2 implements a CCSDS 133.0-B-2 EC2 Space Packet PDU profile.
+
+This claim covers construction, serialization, bounded parsing, validation, sequence-count handling, and stream management for CCSDS Space Packet PDUs.
+
+It does **not** claim implementation of the complete CCSDS Space Packet Protocol entity, including:
+
+- the abstract Packet Service interface;
+- the abstract Octet String Service interface;
+- all sending and receiving procedures;
+- all managed parameters;
+- a completed Protocol Implementation Conformance Statement (PICS);
+- transfer frames, Attached Synchronization Markers, CFDP, or other CCSDS protocol layers.
+
+`CCSDS::Manager` may prepend a configurable synchronization pattern around packet streams. That pattern is a CCSDSPack container convenience and is not part of a CCSDS Space Packet.
+
+## Primary header profile
+
+CCSDSPack uses the fixed six-octet primary header with:
+
+- Packet Version Number: 3 bits;
+- Packet Type: 1 bit;
+- Secondary Header Flag: 1 bit;
+- APID: 11 bits;
+- Sequence Flags: 2 bits;
+- Packet Sequence Count: 14 bits;
+- Packet Data Length: 16 bits.
+
+### Packet Version Number
+
+A serialized or parsed Space Packet must encode Packet Version Number `000`.
+
+`CCSDS::Header` remains a low-level three-bit field container for source compatibility and future protocol work. `CCSDS::Packet` is the Space Packet profile gate and refuses to serialize non-zero versions. Configuration files also require:
+
+```ini
+ccsds_version_number:int=0
+```
+
+### Packet Type
+
+Both telemetry (`0`) and telecommand (`1`) packet types are supported.
+
+### APID and Idle Packets
+
+The complete 11-bit APID range is supported. APID `0x7FF` is reserved for Idle Packets.
+
+A serializable or accepted Idle Packet must:
+
+- encode Secondary Header Flag `0`;
+- contain no secondary-header object;
+- carry at least one octet of mission-defined idle user data.
+
+CCSDSPack validates these structural rules but does not validate the mission-specific idle fill pattern.
+
+### Sequence control
+
+Sequence Flags use the CCSDS values:
+
+| Bits | Meaning |
+|---|---|
+| `00` | continuing segment |
+| `01` | first segment |
+| `10` | last segment |
+| `11` | unsegmented packet |
+
+The Manager uses one modulo-16384 Packet Sequence Count stream per bound Packet Identification value. Automatic mode advances once for every generated packet, including unsegmented packets.
+
+CCSDSPack uses **Packet Sequence Count semantics for both telemetry and telecommand packets**. The optional telecommand Packet Name interpretation is not implemented.
+
+Manual sequence mode is an expert override. Applications using manual counts are responsible for continuity.
+
+## Packet Data Length and size
+
+Packet Data Length is encoded as:
+
+```text
+number of octets following the six-octet primary header - 1
+```
+
+Therefore:
+
+```text
+total packet size = 6 + Packet Data Length + 1
+```
+
+The representable Packet Data Field range is 1 through 65,536 octets, giving a total packet-size range of 7 through 65,542 octets.
+
+Use:
+
+```cpp
+std::size_t CCSDS::Packet::getSerializedSize() const;
+```
+
+for the complete range. The legacy `getFullPacketLength()` returns `std::uint16_t` and saturates at `UINT16_MAX` rather than wrapping when the exact packet size is larger.
+
+## Secondary headers
+
+CCSDS 133.0-B-2 permits optional secondary-header information. CCSDSPack supports:
+
+- opaque `BufferHeader` bytes;
+- user-registered secondary-header classes;
+- legacy project-specific `PusA`, `PusB`, and `PusC` classes.
+
+The bundled `PusA`, `PusB`, and `PusC` names are retained for v1 compatibility. Their layouts are not claimed to implement an official ECSS Packet Utilisation Standard revision.
+
+The `PusC` byte sequence described as a time-code field is not automatically a conformant CCSDS time code. Mission software must select and validate any required time-code format separately.
+
+## CCSDSPack CRC16 mission profile
+
+CCSDS 133.0-B-2 defines a Space Packet as:
+
+```text
+Packet Primary Header + Packet Data Field
+```
+
+It does not define a third standardized packet error-control field.
+
+When `PacketErrorControlMode::CRC16` is selected, CCSDSPack reserves the **final two octets of the Packet Data Field** for a mission-profile CRC-16/CCITT-FALSE trailer. Those two octets:
+
+- are included in Packet Data Length;
+- are serialized most-significant byte first;
+- are excluded from their own CRC calculation;
+- are validated during parsing.
+
+The CRC input is:
+
+```text
+six-octet Packet Primary Header
++ optional secondary-header bytes
++ application-data bytes
+```
+
+`PacketErrorControlMode::None` reserves no trailer octets. CRC16 remains the default for existing v1 construction and configuration paths.
+
+## Parsing profile
+
+`deserializeBounded()`:
+
+- validates the six-octet primary header before copying the body;
+- rejects non-zero Packet Version Numbers;
+- derives the exact boundary from Packet Data Length;
+- rejects truncated packet bodies;
+- validates the configured CRC trailer when enabled;
+- returns the number of consumed octets;
+- leaves later concatenated packets or unrelated trailing bytes unconsumed;
+- commits parsed state only after validation succeeds.
+
+The receiving application must configure whether the stream uses the CRC16 profile. The mode is not inferred from packet bytes.
+
+## Manager profile
+
+One `CCSDS::Manager` represents one complete Packet Identification value and one sequence-count stream.
+
+The bound identifier contains:
+
+- Packet Version Number;
+- Packet Type;
+- Secondary Header Flag;
+- APID.
+
+Sequence Flags, Packet Sequence Count, and Packet Data Length are excluded because they vary within the stream.
+
+Applications managing multiple identifiers use multiple Manager instances or independent Packet objects. Within one managed data path, one APID should have one sequence-count authority.
+
+## Compatibility with releases before v1.2
+
+The public v1 source API remains available, but corrected wire behavior may be incompatible with packets generated by earlier versions. In particular, v1.2 corrects:
+
+- Packet Data Length to use `N - 1`;
+- inclusion of the optional CRC trailer in Packet Data Length;
+- CRC coverage from the first primary-header octet;
+- exact packet-boundary parsing;
+- sequence-count advancement and rollover;
+- full Packet Identification enforcement;
+- Packet Version Number and Idle Packet profile validation.
+
+Stored or transmitted pre-v1.2 packets should be regenerated or migrated with an explicit compatibility tool. They should not be assumed to parse under the corrected profile.
+
+## Conformance evidence
+
+The profile is exercised by:
+
+- independent Python-generated byte vectors committed under `test/test_resources`;
+- packet encode/decode and maximum-size tests;
+- malformed length, CRC, version, identifier, and sequence tests;
+- dedicated Idle Packet and PDU-profile tests;
+- the installed shared-library consumer under `test/package_tester/shared_lib`;
+- Linux and Windows CI builds and execution.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,134 +1,176 @@
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Configuration file
 
-[../](README.md) - CCSDSPack Documentation
+[Main README](../README.md) | [CCSDS 133.0-B-2 EC2 profile](CCSDS_133_0_B_2_PROFILE.md)
 
+CCSDSPack configuration files use one typed key-value entry per line:
 
-The configuration file can be used to load data into the application clearly. The library is required 
-to be installed, and CCSDSPack.h to included in your project to parse the configuration file.
-
-## Data
-The supported data types and syntax to be used are described below.
-
-Data types:
-- `bool` — `true` or `false`
-- `int` — decimal or hexadecimal integer
-- `float` — floating-point number
-- `string` — text value
-- `bytes` — array of integers (decimal or hex)
-
-NOTE: All lines that start with `#` will be ignored by the parser, therefore can be used as comments. 
-Integer values can be inserted in both decimal `255` and hexadecimal `0xFF` format.
-
-
-Syntax:
 ```ini
 <variable_name>:<data_type>=<value>
 ```
 
-Examples:
+Lines beginning with `#` are comments. Integers may use decimal or hexadecimal notation.
+
+## Supported data types
+
+- `bool`: `true` or `false`;
+- `int`: decimal or hexadecimal integer;
+- `float`: floating-point number;
+- `string`: text;
+- `bytes`: integer byte array.
+
+Example:
 
 ```ini
-# String 
-stringValue:string="Awesome string to test"
-
-# Integer
+name:string="packet profile"
 integerValue:int=42
-
-# Integer Hex
-integerValue:int=0x6b
-
-# boolean
-booleanValue:bool=true
-
-# float
-floatValue:float=0.85
-
-# arrays
-buffer:bytes=[ 1, 2, 3, 4, 5 ]
-bufferHex:bytes=[ 0xFF, 0xaa, 0xBB, 0xcc, 0xEE ]
-bufferHex2:bytes=[ 0x2, 0x40, 0x56, 0x87, 0xf0 ]
-
-# comment  this line is ignored by the parser
-# and this line as well 
+hexValue:int=0x6B
+enabled:bool=true
+ratio:float=0.85
+buffer:bytes=[0x01, 0x02, 0x03]
 ```
 
-## Usage
-The configuration file can be loaded into the application using the following code snippet:
-```c++
-Config cfg;
-std::string configFile = "/path/to/myConfigFile.cfg"
-{
-    if (auto res = cfg.load(configFile); !res.has_value()) {
-      std::cerr << "[ Error " << res.error().code() << " ]: "<<  res.error().message() << std::endl ;
-      return res.error().code();
-    }
-}
-```
-Where the load member function loads and parses the configuration file. In case of an error, it is 
-returned using the Result error management class.
+## Loading configuration
 
-After successfully loading the configuration file, the data can be accessed using:
-```c++
-if (cfg.isKey("data_field_size")) {
-    std::uint16_t dataFieldSize;
-    
-    // get data of type Result<T>
-    const auto res = cfg.get<int>("data_field_size");
-    
-    // check for error
-    if (!res.has_value()) {
-        std::cerr <<  res.error().message() << std::endl;
-        return res.error().code();
-    }else{
-        // assign retrieved value
-        dataFieldSize = res.value();
-    }
-    
-    // alternatively using the macro which performs the check for the user
-    ASSIGN_OR_PRINT(dataFieldSize, cfg.get<int>("data_field_size"));
+```cpp
+#include <CCSDSPack.h>
+#include <iostream>
+
+int main() {
+  Config cfg;
+  const auto result = cfg.load("/path/to/config.cfg");
+  if (!result) {
+    std::cerr << result.error().message() << '\n';
+    return result.error().code();
+  }
+  return 0;
 }
 ```
 
-## Template
-The template can be used to define a packet which defines parameters included automatically during
-the generation of new packets. This allows dynamic update of the packet without changing the source code.
+Read a value through `Result<T>`:
 
-General Settings fields:
+```cpp
+const auto sizeResult = cfg.get<int>("data_field_size");
+if (!sizeResult) return sizeResult.error().code();
+const auto dataFieldSize = sizeResult.value();
+```
 
+The existing result-assignment macros may also be used where appropriate.
 
-| Parameter                    | Data Type | Required                         |
-|------------------------------|-----------|----------------------------------|
-| `data_field_size`            | int       | Yes                              |
-| `sync_pattern_enable`        | bool      | Yes                              |
-| `sync_pattern`               | int       | No                               |
-| `validation_enable`          | bool      | Yes for the decoder              |
-| `ccsds_packet_error_control` | string    | No, defaults to `CRC16`          |
+## Packet template configuration
 
-`ccsds_packet_error_control` accepts `crc16`/`CRC16` or `none`/`None`. The encoder, decoder, and validator also expose an additive `--packet-error-control` CLI override. See [CLI.md](CLI.md).
+A normal v1.2 packet profile can begin with:
 
-Packet Main header fields:
+```ini
+ccsds_version_number:int=0
+ccsds_type:bool=false
+ccsds_data_field_header_flag:bool=false
+ccsds_APID:int=0x123
+ccsds_segmented:bool=false
 
-| Parameter                      | Data Type | Required                            |
-|--------------------------------|-----------|-------------------------------------|
-| `ccsds_APID`                   | int       | Yes                                 |
-| `ccsds_version_number`         | int       | Yes                                 |
-| `ccsds_type`                   | bool      | Yes                                 |
-| `ccsds_data_field_header_flag` | bool      | Yes                                 |
-| `ccsds_segmented`              | bool      | Yes                                 |
-| `define_secondary_header`      | bool      | Yes                                 |
-| `secondary_header_type`        | string    | if define_secondary_header True     |
-| `pus_version`                  | int       | if define_secondary_header True *   |
-| `pus_service_type`             | int       | if define_secondary_header True *   |
-| `pus_service_sub_type`         | int       | if define_secondary_header True *   |
-| `pus_source_id`                | int       | if define_secondary_header True *   |
-| `pus_event_id`                 | int       | if define_secondary_header True **  |
-| `pus_time_code`                | int       | if define_secondary_header True *** |
+data_field_size:int=1024
+ccsds_packet_error_control:string=crc16
 
-*Note: The highlighted parameters are strictly used with secondary headers of type PUS.
+define_secondary_header:bool=false
+```
 
-**Note: The highlighted parameter is specific to secondary header of type PUS-B.
+### General settings
 
-***Note: The highlighted parameter is strictly specific to secondary headers of type PUS-C.
+| Parameter | Type | Required | Meaning |
+|---|---|---:|---|
+| `data_field_size` | int | yes | Manager application-data chunk capacity before the optional CRC trailer |
+| `sync_pattern_enable` | bool | stream tools | Enables the CCSDSPack stream prefix; it is not part of a CCSDS packet |
+| `sync_pattern` | int | when enabled | Four-octet CCSDSPack synchronization pattern |
+| `validation_enable` | bool | decoder profile | Enables Manager validation |
+| `ccsds_packet_error_control` | string | no | `crc16` or `none`; defaults to `crc16` |
 
-See templatePacket.cfg for example usage of these parameters and the source files for tester 
-for example code usages.
+The encoder, decoder, and validator also provide the additive `--packet-error-control` override. See [CLI.md](CLI.md).
+
+### Primary-header settings
+
+| Parameter | Type | Required | Constraint |
+|---|---|---:|---|
+| `ccsds_version_number` | int | yes | must be `0` for CCSDS 133.0-B-2 Space Packets |
+| `ccsds_type` | bool | yes | `false` telemetry, `true` telecommand |
+| `ccsds_data_field_header_flag` | bool | yes | indicates optional secondary-header presence |
+| `ccsds_APID` | int | yes | `0..2047`; `2047` is the Idle Packet APID |
+| `ccsds_segmented` | bool | yes | selects initial segmented or unsegmented template state |
+
+`ccsds_version_number` values from 1 through 7 are rejected by `Packet::loadFromConfig()` even though the low-level Header class retains a three-bit field representation.
+
+CCSDSPack uses Packet Sequence Count semantics for telemetry and telecommand packets. The optional telecommand Packet Name interpretation is not configured or implemented.
+
+## Idle Packet configuration
+
+APID `0x7FF` is reserved for Idle Packets. A valid Idle Packet configuration must:
+
+- set `ccsds_data_field_header_flag` to `false`;
+- set `define_secondary_header` to `false`;
+- include non-empty mission-defined idle bytes in `application_data`.
+
+Example:
+
+```ini
+ccsds_version_number:int=0
+ccsds_type:bool=false
+ccsds_data_field_header_flag:bool=false
+ccsds_APID:int=0x7FF
+ccsds_segmented:bool=false
+
+data_field_size:int=16
+ccsds_packet_error_control:string=crc16
+
+define_secondary_header:bool=false
+application_data:bytes=[0x00]
+```
+
+CCSDSPack validates the structure but does not validate the mission-specific idle fill pattern.
+
+## Packet error control profile
+
+Accepted values are:
+
+```ini
+ccsds_packet_error_control:string=crc16
+```
+
+and:
+
+```ini
+ccsds_packet_error_control:string=none
+```
+
+In `crc16` mode, CCSDSPack reserves the final two octets of the CCSDS Packet Data Field for a mission-profile CRC-16/CCITT-FALSE trailer. The trailer is included in Packet Data Length. CCSDS 133.0-B-2 does not define it as a separate packet structural field.
+
+The receiving packet, decoder, or validator must be configured with the expected mode before parsing. The mode is not inferred from bytes.
+
+## Secondary-header settings
+
+| Parameter | Type | Required |
+|---|---|---:|
+| `define_secondary_header` | bool | yes |
+| `secondary_header_type` | string | when enabled |
+| `pus_version` | int | legacy PusA/PusB/PusC profiles |
+| `pus_service_type` | int | legacy PusA/PusB/PusC profiles |
+| `pus_service_sub_type` | int | legacy PusA/PusB/PusC profiles |
+| `pus_source_id` | int | legacy PusA/PusB/PusC profiles |
+| `pus_event_id` | int | legacy PusB only |
+| `pus_time_code` | bytes | legacy PusC only |
+
+The built-in `PusA`, `PusB`, and `PusC` layouts are project-specific legacy formats. Their names do not constitute an ECSS PUS compliance claim. `pus_time_code` bytes are not automatically validated as a CCSDS time-code format.
+
+## Packet Data Length
+
+`data_field_size` is a capacity/chunking setting. It is not copied into the primary-header Packet Data Length field.
+
+Packet Data Length is derived during finalization as:
+
+```text
+serialized Packet Data Field octets - 1
+```
+
+It includes secondary-header, application-data, and optional CRC-trailer octets actually serialized for that packet.

--- a/docs/V1_2_CURRENT_BEHAVIOUR.md
+++ b/docs/V1_2_CURRENT_BEHAVIOUR.md
@@ -1,66 +1,181 @@
-# CCSDSPack v1.2 current behaviour
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
 
-[Main README](../README.md)
+# CCSDSPack v1.2 current behavior
 
-> [!NOTE]
-> This document describes the behaviour currently implemented on the `develop` branch for the
-> upcoming v1.2.0 release. It is a pre-release implementation record, not a claim that every
-> v1.2.0 compliance work item is already complete.
+[Main README](../README.md) | [CCSDS 133.0-B-2 EC2 profile](CCSDS_133_0_B_2_PROFILE.md)
 
-## Protocol scope
+## Release scope
 
-CCSDSPack v1.2 targets the CCSDS 133.0-B-2 Space Packet Protocol packet data unit within the
-library's documented profile.
+CCSDSPack v1.2 implements a Space Packet PDU profile based on **CCSDS 133.0-B-2, Issue 2, including Editorial Change 2 (September 2024)**.
 
-The following are not implemented by the Space Packet core:
+The implemented scope includes:
 
-- CCSDS transfer frames;
-- attached synchronization markers as a CCSDS packet field;
-- CFDP;
-- ECSS Packet Utilisation Standard secondary headers.
-
-`CCSDS::Manager` can prepend a configurable synchronization pattern when reading or writing a
-packet stream. That pattern is a CCSDSPack container/framing convenience and is not part of the
-serialized CCSDS Space Packet.
-
-## Packet serialization
-
-A serialized packet is composed as follows:
-
-```text
-6-byte primary header
-+ optional secondary header
-+ application data
-+ optional packet error-control field
-```
-
-The 16-bit Packet Data Length field is encoded as:
-
-```text
-number of octets following the primary header - 1
-```
-
-The encoded length therefore includes:
-
-- the secondary header, when present;
+- six-octet Space Packet primary headers;
+- Packet Data Field construction and parsing;
+- optional secondary headers;
 - application data;
-- the packet error-control field, when enabled.
+- exact Packet Data Length handling;
+- bounded transactional parsing;
+- optional CCSDSPack CRC16 mission-profile trailers;
+- Packet Sequence Count handling and segmentation utilities;
+- Manager Packet Identification binding;
+- negative, regression, golden-vector, CLI, and external-consumer tests.
 
-A packet data field of 65,536 octets is represented by `0xFFFF`. A larger packet data field cannot
-be represented and the existing v1 `Packet::serialize()` API returns an empty buffer. Serialization
-also returns an empty buffer when the selected packet error-control mode is `None` and the packet
-data field contains no octets.
+The conformity claim is limited to the **Space Packet PDU profile**. The library does not implement the complete abstract Packet Service, Octet String Service, all protocol procedures, managed parameters, or a PICS.
 
-## Packet error control
+The following are outside this packet-core scope:
 
-The public `PacketErrorControlMode` supports:
+- transfer frames;
+- Attached Synchronization Markers as a CCSDS packet field;
+- CFDP;
+- official ECSS Packet Utilisation Standard secondary headers.
 
-- `PacketErrorControlMode::None`;
-- `PacketErrorControlMode::CRC16`.
+`CCSDS::Manager` can prepend a configurable synchronization pattern around packet streams. That pattern is a CCSDSPack container/framing convenience and is not part of a serialized CCSDS Space Packet.
 
-`CRC16` remains the default for existing v1 constructors, configuration paths, and callers.
+## Primary header
 
-Configuration files may select the mode with:
+The primary header is always six octets and contains:
+
+```text
+Packet Version Number:       3 bits
+Packet Type:                 1 bit
+Secondary Header Flag:       1 bit
+APID:                       11 bits
+Sequence Flags:              2 bits
+Packet Sequence Count:      14 bits
+Packet Data Length:         16 bits
+```
+
+All fields are serialized in network byte order.
+
+### Packet Version Number
+
+`CCSDS::Header` retains the complete three-bit representation as a low-level field container. `CCSDS::Packet` is the Space Packet profile gate:
+
+- parsing rejects any Packet Version Number other than `000`;
+- serialization rejects any Packet Version Number other than `000`;
+- configuration requires `ccsds_version_number:int=0`.
+
+### Packet Type
+
+Packet Type `0` and `1` are available for telemetry and telecommand packets respectively.
+
+### APID and Idle Packets
+
+The complete 11-bit APID range is supported:
+
+- `0..2046`: normal APIDs;
+- `2047` (`0x7FF`): reserved Idle Packet APID.
+
+An Idle Packet is accepted or serialized only when:
+
+- Secondary Header Flag is zero;
+- no secondary-header object is installed;
+- at least one octet of mission-defined idle user data is present.
+
+CCSDSPack does not validate the mission-specific idle fill pattern.
+
+### Sequence control
+
+Sequence Flags use the CCSDS values:
+
+```text
+00 continuation
+01 first
+10 last
+11 unsegmented
+```
+
+Manager automatic mode:
+
+- owns one Packet Sequence Count stream;
+- assigns one count to every generated packet;
+- advances once for every packet, including unsegmented packets;
+- wraps modulo 16384;
+- assigns first, continuation, last, or unsegmented flags according to generated packet count.
+
+CCSDSPack uses Packet Sequence Count semantics for telemetry and telecommand packets. The optional telecommand Packet Name interpretation is not implemented.
+
+Manual sequence mode reuses the caller-selected count and leaves continuity responsibility to the application.
+
+## Packet Identification and Manager ownership
+
+One `CCSDS::Manager` represents one complete Packet Identification value and one sequence-count stream.
+
+The bound identifier contains:
+
+```text
+Packet Version Number
++ Packet Type
++ Secondary Header Flag
++ APID
+```
+
+Sequence Flags, Packet Sequence Count, and Packet Data Length are not part of the binding because they vary within the stream.
+
+A Manager:
+
+- binds immediately from a template;
+- otherwise binds from the first accepted packet;
+- rejects packets with a different identifier;
+- loads packet vectors and concatenated buffers transactionally;
+- removes the binding on `clear()`.
+
+Applications handling multiple identifiers use multiple Manager instances or independent Packet objects. Within one managed data path, one APID should have one sequence-count authority.
+
+## Packet Data Field and Packet Data Length
+
+A serialized packet contains:
+
+```text
+6-octet Packet Primary Header
++ Packet Data Field
+```
+
+The Packet Data Field contains:
+
+```text
+optional secondary-header bytes
++ application-data bytes
++ optional CCSDSPack CRC16 trailer
+```
+
+Packet Data Length is encoded as:
+
+```text
+number of Packet Data Field octets - 1
+```
+
+The encoded value therefore includes all optional CRC trailer octets.
+
+The representable Packet Data Field range is 1 through 65,536 octets. The total serialized packet range is 7 through 65,542 octets.
+
+`Packet::getSerializedSize()` returns the exact current size as `std::size_t`. The legacy `getFullPacketLength()` API returns `std::uint16_t` and saturates at `UINT16_MAX` instead of wrapping for packets larger than 65,535 octets.
+
+Serialization returns an empty vector when:
+
+- the header is invalid;
+- Packet Version Number is not zero;
+- Idle Packet structural rules are violated;
+- the Packet Data Field would be empty;
+- the Packet Data Field would exceed 65,536 octets;
+- automatic finalization cannot complete.
+
+## CCSDSPack CRC16 mission profile
+
+CCSDS 133.0-B-2 does not define a third standardized Packet Error Control field. CCSDSPack instead reserves the final two Packet Data Field octets when `PacketErrorControlMode::CRC16` is selected.
+
+The supported modes are:
+
+- `PacketErrorControlMode::CRC16`;
+- `PacketErrorControlMode::None`.
+
+CRC16 remains the default for existing v1 constructors and configuration paths.
+
+Configuration files may select:
 
 ```ini
 ccsds_packet_error_control:string=crc16
@@ -72,119 +187,128 @@ or:
 ccsds_packet_error_control:string=none
 ```
 
-The accepted values are `crc16`, `CRC16`, `none`, and `None`.
-
-When CRC16 is enabled, the calculation covers:
+In CRC16 mode, the calculation covers:
 
 ```text
-primary header
-+ secondary header, when present
-+ application data
+six-octet primary header
++ optional secondary-header bytes
++ application-data bytes
 ```
 
-The CRC field itself is excluded. The two CRC bytes are serialized most-significant byte first.
-The polynomial, initial value, and final XOR value remain configurable through the C++ API.
+The two CRC octets are excluded from their own calculation and are serialized most-significant byte first. Polynomial, initial value, and final XOR remain configurable through the C++ API.
+
+The receiving application must configure the expected mode before deserialization. CRC presence is not inferred from packet bytes.
 
 ## Parsing and validation
 
-`Packet::deserialize()` uses the packet error-control mode configured by the caller. It does not
-infer CRC presence from trailing bytes. In CRC16 mode, the final two supplied bytes are extracted as
-the received CRC field. In `None` mode, no bytes are removed as packet error control.
+`Packet::deserializeBounded()`:
 
-The low-level `Packet::deserialize()` overloads currently consume the complete supplied buffer. They
-do not yet constrain parsing to the Packet Data Length declared by the primary header. Exact bounded
-low-level parsing is tracked by issue #48.
+- requires at least six primary-header octets;
+- rejects non-zero Packet Version Numbers;
+- derives the exact boundary as `6 + Packet Data Length + 1`;
+- rejects truncated packet bodies;
+- validates the selected CRC16 trailer when enabled;
+- validates Idle Packet structural rules;
+- returns the consumed-byte count;
+- leaves concatenated packets or unrelated trailing bytes unconsumed;
+- stages state and commits only after every check succeeds.
 
-CRC comparison is currently performed by `CCSDS::Validator`. Automatic CRC rejection inside the
-low-level packet parsing path is tracked by issue #51.
+The legacy vector-based `deserialize()` overloads use the same bounded parser and preserve their existing `ResultBool` signatures.
 
-`CCSDS::Manager::load()` uses the declared Packet Data Length to split concatenated packet streams:
+Typed secondary-header parsing requires either:
 
-```text
-total packet size = 6 + Packet Data Length + 1
+- a registered fixed-size secondary-header type;
+- an explicit byte count for opaque or project-specific variable-size headers.
+
+`CCSDS::Manager::load()` uses Packet Data Length to split concatenated streams and rejects truncated primary headers, packet bodies, and synchronization patterns.
+
+The standalone validator reports length, CRC, version, APID, Packet Type, Secondary Header Flag, Sequence Flags, and sequence-count continuity separately.
+
+## Non-mutating inspection
+
+Packet, Header, and DataField getters do not invoke finalization.
+
+Inspection does not recalculate or alter:
+
+- Packet Data Length;
+- CRC16;
+- Packet Sequence Count;
+- secondary-header contents;
+- received packet bytes.
+
+`update()` and `serialize()` are the explicit finalization paths. Manager byte getters serialize packet copies rather than mutating stored packets.
+
+## Secondary headers
+
+The v1 API supports:
+
+- `BufferHeader` for opaque bytes;
+- custom registered classes derived from `SecondaryHeaderAbstract`;
+- legacy project-specific `PusA`, `PusB`, and `PusC` classes.
+
+The bundled Pus-named classes are retained for source and configuration compatibility. They are not claimed to implement an official ECSS PUS revision.
+
+The variable `PusC` byte sequence described as a time-code field is not automatically validated as a CCSDS or ECSS time-code format.
+
+Standards-oriented ECSS PUS support remains v2.0.0 scope.
+
+## Configuration profile
+
+Required packet keys include:
+
+```ini
+ccsds_version_number:int=0
+ccsds_type:bool=false
+ccsds_data_field_header_flag:bool=false
+ccsds_APID:int=291
+ccsds_segmented:bool=false
 ```
 
-It rejects truncated primary headers, truncated packet bodies, and incomplete synchronization
-patterns before copying packet bytes.
+`ccsds_version_number` accepts only zero. APID accepts values from 0 through 2047. Idle Packet configurations require no secondary header and non-empty `application_data`.
 
-## Manager ownership model
+Optional packet error control:
 
-`CCSDS::Manager` represents one packet stream defined by one `Packet` template and one primary-header
-identity. In particular, one Manager instance is intended to manage one APID and one associated
-sequence-count stream.
+```ini
+ccsds_packet_error_control:string=crc16
+```
 
-Packets generated through `Manager::setApplicationData()` inherit the APID and other primary-header
-identity fields from the configured template. A per-APID counter map inside one Manager is therefore
-not part of the library model.
+or:
 
-Applications handling multiple APIDs should use either:
+```ini
+ccsds_packet_error_control:string=none
+```
 
-- one `CCSDS::Manager` instance per APID; or
-- independent `CCSDS::Packet` objects when Manager-level segmentation and stream handling are not
-  required.
+The `data_field_size` value controls the Manager application-data chunk capacity. It is not copied directly into Packet Data Length, which is always derived from the finalized serialized Packet Data Field.
 
-The current implementation does not yet reject every externally constructed packet with an APID
-that differs from the Manager template. Enforcing the single-APID invariant for `addPacket()` and
-`load()` is tracked by issue #53.
+## Compatibility with releases before v1.2
 
-The `data_field_size` template/configuration value is used by Manager as the maximum application-data
-chunk placed in each generated packet. It is not copied directly into the encoded Packet Data Length;
-the encoded value is derived from the actual serialized packet data field and selected error-control
-mode.
+The public v1 method names and construction paths remain available. Corrected packet bytes and stricter parsing are intentionally incompatible with some packets generated by earlier releases.
 
-## Sequence-count behaviour
+Relevant changes include:
 
-The final v1.2 sequence-count policy is not complete yet and remains tracked by issue #52.
+- Packet Data Length stores `N - 1`;
+- optional CRC trailer octets are included in Packet Data Length;
+- CRC coverage begins at the first primary-header octet;
+- low-level parsing honors the declared packet boundary;
+- CRC mismatches fail during parsing;
+- non-zero Packet Version Numbers are rejected by Packet paths;
+- Idle Packet structure is validated;
+- sequence counts advance and roll over consistently;
+- Manager enforces the complete Packet Identification value.
 
-Current behaviour includes:
-
-- Manager maintains one sequence counter for its single managed packet stream;
-- generated segmented packets receive first, continuation, and last sequence flags;
-- clearing Manager packets resets the Manager counter;
-- packet header serialization masks the sequence count to the CCSDS 14-bit field.
-
-The current packet update path still forces unsegmented packets to sequence count zero. Preserving
-explicit non-zero unsegmented counts, defining modulo-16384 rollover, and making automatic update
-policy explicit remain v1.2 work.
-
-## APID behaviour
-
-The primary-header representation contains the CCSDS 11-bit APID field. Direct header assignment
-currently masks values to 11 bits.
-
-The configuration loading path does not yet provide complete 11-bit APID handling, and silent field
-masking is still present in low-level setters. Full APID range support and explicit validation are
-tracked by issues #54 and #55.
-
-## Legacy secondary headers
-
-The v1 `PusA`, `PusB`, and `PusC` classes remain available for source and configuration compatibility.
-Their layouts are project-specific legacy secondary headers and are not claimed to implement an ECSS
-PUS revision.
-
-Standards-oriented ECSS PUS support remains v2.0.0 scope. The corrected Space Packet length and
-packet error-control semantics described in this document are v1.2.0 work, not deferred v2 work.
-
-## Compatibility with releases before v1.2.0
-
-The v1 public method names and signatures remain available, but corrected packet bytes are
-intentionally wire-incompatible with packets emitted by earlier versions where:
-
-- Packet Data Length stored the raw data-field size instead of `N - 1`;
-- CRC bytes were excluded from Packet Data Length;
-- CRC16 was calculated over the data field only rather than from the first primary-header byte.
-
-Users exchanging stored or transmitted packets with pre-v1.2.0 software must account for that wire
-format correction.
+Stored or transmitted pre-v1.2 packets should be regenerated or migrated explicitly. They should not be assumed to parse under the corrected profile.
 
 ## Conformance and regression evidence
 
-The current behaviour is covered by:
+The v1.2 behavior is covered by:
 
-- `test/src/testGroupEdgeCases.cpp` for independent Packet Data Length and CRC vectors, CRC-disabled
-  packets, configurable CRC parameters, maximum length, and overflow rejection;
-- `test/src/testGroupValidator.cpp` for validator length and CRC behaviour;
-- `test/src/testGroupManagement.cpp` for segmentation, packet-stream boundaries, truncation, sync
-  patterns, and file round trips;
-- pull request #96 for optional packet error control;
-- pull request #97 for corrected Packet Data Length and CRC coverage.
+- independent Python-generated vectors under `test/reference` and `test/test_resources`;
+- exact encode and logical decode assertions;
+- malformed length, CRC, version, identifier, sequence, and mutation tests;
+- dedicated CCSDS PDU-profile and Idle Packet tests;
+- maximum Packet Data Length and exact serialized-size tests;
+- Manager segmentation, rollover, concatenation, synchronization-pattern, and transactional-load tests;
+- the installed external consumer under `test/package_tester/shared_lib`;
+- encoder, decoder, and validator integration tests;
+- Linux and Windows CI workflows;
+- Doxygen generation checks for public API contracts.

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -3,12 +3,13 @@
 
 /**
  * @file CCSDSPacket.h
- * @brief Defines the high-level CCSDS Space Packet container and packet error-control configuration.
+ * @brief Defines the CCSDS 133.0-B-2 EC2 Space Packet PDU container and mission-profile CRC trailer.
  *
- * A Packet owns one primary header, one packet data field, and an optional packet
- * error-control field. Inspection APIs are non-mutating. Call update() or
- * serialize() when dependent fields such as Packet Data Length, sequence count,
- * secondary-header contents, or CRC16 must be finalized.
+ * A Packet owns one primary header and one Packet Data Field. CCSDSPack may reserve
+ * the final two Packet Data Field octets for a mission-profile CRC16 trailer. The
+ * trailer is not a third CCSDS Space Packet structural field. Inspection APIs are
+ * non-mutating. Call update() or serialize() when dependent fields such as Packet
+ * Data Length, sequence count, secondary-header contents, or CRC16 must be finalized.
  */
 #ifndef CCSDS_PACKET_H
 #define CCSDS_PACKET_H
@@ -25,11 +26,16 @@
 namespace CCSDS {
   /**
    * @struct CRC16Config
-   * @brief Parameters used by the packet CRC-16 calculation and validation paths.
+   * @brief Parameters for the optional CCSDSPack mission-profile CRC16 trailer.
    *
    * The defaults implement CRC-16/CCITT-FALSE: polynomial 0x1021, initial value
-   * 0xFFFF, and no final XOR. The CRC covers the serialized six-byte primary
-   * header followed by the complete packet data field, excluding the CRC bytes.
+   * 0xFFFF, and no final XOR. When enabled, CCSDSPack reserves the final two
+   * octets of the CCSDS Packet Data Field for the trailer. The CRC covers the
+   * serialized six-byte primary header followed by all preceding Packet Data
+   * Field octets, excluding the two CRC octets themselves.
+   *
+   * @note CCSDS 133.0-B-2 does not define this CRC trailer. It is a documented
+   * CCSDSPack mission-profile convention carried inside the Packet Data Field.
    */
   struct CRC16Config {
     std::uint16_t polynomial = 0x1021;   ///< CRC generator polynomial.
@@ -39,32 +45,42 @@ namespace CCSDS {
 
   /**
    * @enum PacketErrorControlMode
-   * @brief Selects whether a packet carries a two-byte CRC16 error-control field.
+   * @brief Selects whether the Packet Data Field ends with the CCSDSPack CRC16 trailer.
    *
    * Parsing never infers the mode from trailing bytes. Configure the receiving
    * Packet before deserialization when the stream does not use the default CRC16
-   * mode.
+   * profile. The trailer octets are included in the CCSDS Packet Data Length.
    */
   enum class PacketErrorControlMode : std::uint8_t {
-    None = 0, ///< No packet error-control bytes are serialized or validated.
-    CRC16 = 1 ///< Append and validate a two-byte CRC16 field. This is the default.
+    None = 0, ///< No mission-profile CRC trailer is serialized or validated.
+    CRC16 = 1 ///< Reserve and validate a two-byte CRC16 trailer. This is the v1 default.
   };
 
   /**
    * @class Packet
-   * @brief Owns, serializes, and parses one CCSDS Space Packet.
+   * @brief Owns, serializes, and parses one CCSDS 133.0-B-2 EC2 Space Packet PDU.
    *
    * Packet provides checked primary-header assignment, optional typed or raw
-   * secondary headers, application data, bounded parsing, CRC16 handling, and
-   * explicit finalization. The object represents exactly one packet. Use Manager
-   * when generating, parsing, or validating a stream of packets that share one
-   * complete Packet Identification value.
+   * secondary headers, application data, bounded parsing, an optional CCSDSPack
+   * CRC16 trailer, and explicit finalization. It implements the Space Packet PDU
+   * profile, not the complete abstract Packet Service, Octet String Service, or
+   * protocol implementation conformance statement defined by CCSDS 133.0-B-2.
+   * The object represents exactly one packet. Use Manager when generating,
+   * parsing, or validating a stream of packets that share one complete Packet
+   * Identification value.
    *
    * @par Finalization
    * Setters mark the packet dirty. Getters only inspect the currently stored
    * state and never call update(). update() recalculates dependent fields without
    * producing bytes. serialize() calls update() and returns the finalized wire
-   * representation.
+   * representation. Packet finalization accepts only encoded Packet Version
+   * Number 000, as required by CCSDS 133.0-B-2.
+   *
+   * @par Idle packets
+   * APID 0x7FF is reserved for Idle Packets. A serializable Idle Packet must use
+   * Secondary Header Flag zero, contain no secondary-header object, and carry at
+   * least one octet of mission-defined idle user data. CCSDSPack does not validate
+   * the mission-specific idle fill pattern.
    *
    * @par Parsing boundaries
    * deserializeBounded() reads exactly the length declared by the primary header
@@ -84,14 +100,15 @@ namespace CCSDS {
    */
   class Packet {
   public:
-    /** @brief Constructs an empty packet using CRC16 packet error control. */
+    /** @brief Constructs an empty packet using the CCSDSPack CRC16 profile. */
     Packet() = default;
 
     /**
      * @brief Replaces all primary-header fields from a field structure.
      * @param data Field values to validate and assign atomically.
-     * @return Success, or INVALID_HEADER_DATA when any field exceeds its CCSDS width.
-     * @note The supplied Packet Data Length may later be replaced by update().
+     * @return Success, or INVALID_HEADER_DATA when any field exceeds its bit width.
+     * @note The supplied Packet Data Length may later be replaced by update(). A
+     * non-zero Packet Version Number remains inspectable but prevents Packet serialization.
      */
     ResultBool setPrimaryHeader(PrimaryHeader data);
 
@@ -99,6 +116,7 @@ namespace CCSDS {
      * @brief Replaces the primary header from the low 48 bits of a packed value.
      * @param data Packed CCSDS primary-header value.
      * @return Success, or an error when the encoded fields are invalid.
+     * @note Packet serialization accepts only encoded Packet Version Number zero.
      */
     [[nodiscard]] ResultBool setPrimaryHeader(std::uint64_t data);
 
@@ -106,20 +124,21 @@ namespace CCSDS {
      * @brief Replaces the primary header from exactly six serialized bytes.
      * @param data Big-endian CCSDS primary-header bytes.
      * @return Success, or INVALID_HEADER_DATA for an invalid byte count or fields.
+     * @note Packet serialization accepts only encoded Packet Version Number zero.
      */
     [[nodiscard]] ResultBool setPrimaryHeader(const std::vector<std::uint8_t> &data);
 
     /**
      * @brief Copies an already constructed Header into this packet.
      * @param header Header instance to copy.
-     * @note An invalid copied header prevents serialization until corrected.
+     * @note An invalid or non-zero-version copied header prevents Packet serialization.
      */
     void setPrimaryHeader(const Header &header);
 
     /**
      * @brief Installs a secondary-header object and synchronizes the primary-header flag.
      * @param header Shared secondary-header instance, or nullptr to remove it.
-     * @note The Packet shares ownership of the supplied object.
+     * @note The Packet shares ownership of the supplied object. Idle Packets may not serialize with one.
      */
     void setDataFieldHeader(const std::shared_ptr<SecondaryHeaderAbstract> &header);
 
@@ -196,15 +215,17 @@ namespace CCSDS {
     void setSequenceFlags(ESequenceFlag flags);
 
     /**
-     * @brief Sets the 14-bit packet sequence count.
+     * @brief Sets the 14-bit Packet Sequence Count used by the CCSDSPack profile.
      * @param count Value in the inclusive range 0..16383.
      * @return Success, or INVALID_HEADER_DATA for an out-of-range count.
+     * @note CCSDSPack uses Packet Sequence Count semantics for both telemetry and
+     * telecommand packets; the optional telecommand Packet Name interpretation is not implemented.
      */
     [[nodiscard]] ResultBool setSequenceCount(std::uint16_t count);
 
     /**
      * @brief Sets the maximum combined secondary-header and application-data capacity.
-     * @param size Maximum packet data-field content bytes before optional PEC bytes.
+     * @param size Maximum Packet Data Field content bytes before the optional CRC trailer.
      * @note Existing content is not truncated when the capacity is reduced.
      */
     void setDataFieldSize(std::uint16_t size);
@@ -217,26 +238,27 @@ namespace CCSDS {
     void setUpdatePacketEnable(bool enable);
 
     /**
-     * @brief Selects packet error-control behavior for serialization and parsing.
+     * @brief Selects the CCSDSPack mission-profile CRC trailer behavior.
      * @param mode None or CRC16.
-     * @note Configure this before deserializing a CRC-free packet.
+     * @note Configure this before deserializing a CRC-free packet. CRC trailer
+     * octets are part of the CCSDS Packet Data Field and Packet Data Length.
      */
     void setPacketErrorControlMode(PacketErrorControlMode mode);
 
-    /** @brief Returns the configured packet error-control mode. */
+    /** @brief Returns the configured mission-profile CRC trailer mode. */
     [[nodiscard]] PacketErrorControlMode getPacketErrorControlMode() const {
       return (m_sequenceCounter & PACKET_ERROR_CONTROL_DISABLED_MASK) != 0U
                ? PacketErrorControlMode::None
                : PacketErrorControlMode::CRC16;
     }
 
-    /** @brief Returns the serialized PEC size: two bytes for CRC16, otherwise zero. */
+    /** @brief Returns the reserved trailer size: two bytes for CRC16, otherwise zero. */
     [[nodiscard]] std::uint16_t getPacketErrorControlSize() const {
       return getPacketErrorControlMode() == PacketErrorControlMode::CRC16 ? 2U : 0U;
     }
 
     /**
-     * @brief Parses one packet using the currently configured PEC mode.
+     * @brief Parses one packet using the currently configured CRC profile.
      * @param data Buffer beginning with a CCSDS primary header.
      * @return Success, or a deterministic header, length, data, or checksum error.
      * @note Trailing bytes are ignored. Use deserializeBounded() to learn the boundary.
@@ -257,16 +279,16 @@ namespace CCSDS {
     /**
      * @brief Parses one packet using an explicit opaque secondary-header byte count.
      * @param data Buffer beginning with a CCSDS packet.
-     * @param headerDataSizeBytes Number of packet-data-field bytes assigned to BufferHeader.
+     * @param headerDataSizeBytes Number of Packet Data Field bytes assigned to BufferHeader.
      * @return Success, or a parsing error when the declared boundary is invalid.
      */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data,
                                          std::uint16_t headerDataSizeBytes);
 
     /**
-     * @brief Parses an already separated primary header and packet data field.
+     * @brief Parses an already separated primary header and Packet Data Field.
      * @param headerData Exactly six primary-header bytes.
-     * @param data Packet data-field bytes including the configured PEC bytes.
+     * @param data Packet Data Field bytes including the configured CRC trailer.
      * @return Success, or a header, length, or checksum error.
      */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &headerData,
@@ -305,16 +327,28 @@ namespace CCSDS {
     [[nodiscard]] std::uint64_t getPrimaryHeader64bit() const;
 
     /**
-     * @brief Returns the current logical packet size without finalizing the packet.
-     * @return Six header bytes plus stored data-field bytes and configured PEC size.
+     * @brief Returns the current packet size through the legacy 16-bit API.
+     * @return Exact size through 65535 bytes, otherwise UINT16_MAX instead of wrapping.
+     * @note Use getSerializedSize() for the complete CCSDS range up to 65542 bytes.
      */
     std::uint16_t getFullPacketLength();
     /** @brief Const overload of getFullPacketLength(). */
     [[nodiscard]] std::uint16_t getFullPacketLength() const;
 
     /**
-     * @brief Finalizes and serializes the packet.
-     * @return Complete wire bytes, or an empty vector when the header, size, or update state is invalid.
+     * @brief Returns the exact current serialized size without finalizing the packet.
+     * @return Six primary-header bytes plus stored data-field content and configured CRC trailer size.
+     * @note The maximum CCSDS Space Packet size is 65542 bytes.
+     */
+    [[nodiscard]] std::size_t getSerializedSize() const {
+      return 6U + static_cast<std::size_t>(m_dataField.getDataFieldUsedBytesSize())
+             + static_cast<std::size_t>(getPacketErrorControlSize());
+    }
+
+    /**
+     * @brief Finalizes and serializes the packet under the v1.2 PDU profile.
+     * @return Complete wire bytes, or an empty vector when the header, version,
+     * Idle Packet structure, size, or update state is invalid.
      */
     std::vector<std::uint8_t> serialize();
 
@@ -333,32 +367,36 @@ namespace CCSDS {
     /** @brief Const overload of getApplicationDataBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getApplicationDataBytes() const;
 
-    /** @brief Returns secondary-header bytes followed by application data, excluding PEC bytes. */
+    /**
+     * @brief Returns the internal secondary-header plus application-data bytes.
+     * @note The optional CRC trailer is omitted here even though it occupies the
+     * final octets of the wire-level CCSDS Packet Data Field.
+     */
     std::vector<std::uint8_t> getFullDataFieldBytes();
     /** @brief Const overload of getFullDataFieldBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getFullDataFieldBytes() const;
 
-    /** @brief Returns the currently stored CRC as two big-endian bytes, or an empty vector in None mode. */
+    /** @brief Returns the stored CRC trailer as two big-endian bytes, or empty in None mode. */
     std::vector<std::uint8_t> getCRCVectorBytes();
     /** @brief Const overload of getCRCVectorBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getCRCVectorBytes() const;
 
-    /** @brief Returns the currently stored CRC value, or zero when PEC is disabled or the header is invalid. */
+    /** @brief Returns the stored CRC trailer value, or zero when disabled or the header is invalid. */
     std::uint16_t getCRC();
     /** @brief Const overload of getCRC(). */
     [[nodiscard]] std::uint16_t getCRC() const;
 
-    /** @brief Returns remaining configured packet data-field capacity. */
+    /** @brief Returns remaining configured internal data-field capacity before the CRC trailer. */
     [[nodiscard]] std::uint16_t getDataFieldMaximumSize() const;
 
-    /** @brief Returns whether a secondary header is currently installed. */
+    /** @brief Returns whether the primary header currently asserts a secondary header. */
     bool getDataFieldHeaderFlag();
     /** @brief Const overload of getDataFieldHeaderFlag(). */
     [[nodiscard]] bool getDataFieldHeaderFlag() const;
 
     /**
      * @brief Returns mutable access to the owned DataField.
-     * @warning Direct mutation can bypass Packet setter bookkeeping; prefer Packet setters.
+     * @warning Direct mutation can bypass Packet setter bookkeeping and profile checks; prefer Packet setters.
      */
     DataField &getDataField();
     /** @brief Returns read-only access to the owned DataField. */
@@ -397,9 +435,10 @@ namespace CCSDS {
     /**
      * @brief Finalizes dependent packet state without returning serialized bytes.
      *
-     * When updates are enabled, this refreshes the secondary header, encodes
-     * Packet Data Length as packet-data-field octets minus one, writes the cached
-     * sequence count, and recalculates CRC16 over the finalized header and data.
+     * When updates are enabled and the packet satisfies the v1.2 profile, this
+     * refreshes the secondary header, encodes Packet Data Length as Packet Data
+     * Field octets minus one, writes the cached sequence count, and recalculates
+     * the optional CRC16 trailer over the finalized header and preceding data.
      */
     void update();
 
@@ -407,6 +446,7 @@ namespace CCSDS {
      * @brief Loads packet construction settings from a configuration file.
      * @param configPath Path to a CCSDSPack key:type=value configuration file.
      * @return Success, or CONFIG_FILE_ERROR/field-specific validation errors.
+     * @note ccsds_version_number must be zero for this Space Packet profile.
      */
     ResultBool loadFromConfigFile(const std::string &configPath);
 #ifndef CCSDS_MCU
@@ -414,6 +454,7 @@ namespace CCSDS {
      * @brief Loads packet construction settings from an already parsed Config.
      * @param cfg Configuration object containing the required CCSDS header keys.
      * @return Success, or a configuration/field validation error.
+     * @note ccsds_version_number must be zero for this Space Packet profile.
      */
     ResultBool loadFromConfig(const Config &cfg);
 #endif

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -100,6 +100,17 @@ namespace {
       parsed.dataField = packetData;
     }
 
+    if (parsed.header.getAPID() == CCSDS::IDLE_APID) {
+      if (parsed.header.getDataFieldHeaderFlag() != 0U) {
+        return CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
+                            "Cannot deserialize Idle Packet: secondary-header flag must be zero."};
+      }
+      if (parsed.dataField.empty()) {
+        return CCSDS::Error{CCSDS::ErrorCode::INVALID_DATA,
+                            "Cannot deserialize Idle Packet: mission-defined idle user data is required."};
+      }
+    }
+
     return parsed;
   }
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -19,6 +19,16 @@ namespace {
     std::uint16_t receivedCRC{};
   };
 
+  bool packetProfileAllowsSerialization(const CCSDS::Header &header,
+                                        const CCSDS::DataField &dataField) {
+    if (header.getVersionNumber() != 0U) return false;
+    if (header.getAPID() != CCSDS::IDLE_APID) return true;
+
+    return header.getDataFieldHeaderFlag() == 0U
+           && !dataField.getDataFieldHeaderFlag()
+           && dataField.getApplicationDataBytesSize() > 0U;
+  }
+
   CCSDS::Result<std::size_t> declaredPacketSize(const std::vector<std::uint8_t> &data) {
     if (data.size() < 6U) {
       return CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
@@ -97,6 +107,7 @@ namespace {
 void CCSDS::Packet::update() {
   if (m_updateStatus || !m_enableUpdatePacket) return;
   if (m_primaryHeader.getHeaderStatus() == INVALID) return;
+  if (!packetProfileAllowsSerialization(m_primaryHeader, m_dataField)) return;
 
   const auto dataField = m_dataField.serialize();
   const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
@@ -154,8 +165,8 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
   ASSIGN_CP(APID, cfg.get<int>("ccsds_APID"));
   ASSIGN_CP(segmented, cfg.get<bool>("ccsds_segmented"));
 
-  RET_IF_ERR_MSG(versionNumber < 0 || versionNumber > 7, ErrorCode::CONFIG_FILE_ERROR,
-                 "Config: ccsds_version_number must be between 0 and 7");
+  RET_IF_ERR_MSG(versionNumber != 0, ErrorCode::CONFIG_FILE_ERROR,
+                 "Config: ccsds_version_number must be 0 for CCSDS 133.0-B-2 Space Packets");
   RET_IF_ERR_MSG(APID < 0 || APID > static_cast<int>(IDLE_APID), ErrorCode::CONFIG_FILE_ERROR,
                  "Config: ccsds_APID must be between 0 and 2047");
 
@@ -210,6 +221,11 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
     ASSIGN_CP(applicationData, cfg.get<std::vector<std::uint8_t>>("application_data"));
     FORWARD_RESULT(m_dataField.setApplicationData(applicationData));
   }
+
+  RET_IF_ERR_MSG(m_primaryHeader.getAPID() == IDLE_APID
+                 && !packetProfileAllowsSerialization(m_primaryHeader, m_dataField),
+                 ErrorCode::CONFIG_FILE_ERROR,
+                 "Config: Idle Packets require no secondary header and non-empty idle user data");
 
   return true;
 }
@@ -298,6 +314,7 @@ std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() const {
 
 std::vector<std::uint8_t> CCSDS::Packet::serialize() {
   if (m_primaryHeader.getHeaderStatus() == INVALID) return {};
+  if (!packetProfileAllowsSerialization(m_primaryHeader, m_dataField)) return {};
 
   const auto currentDataField = getFullDataFieldBytes();
   const auto currentPacketDataFieldSize = currentDataField.size() + getPacketErrorControlSize();
@@ -308,6 +325,7 @@ std::vector<std::uint8_t> CCSDS::Packet::serialize() {
   }
 
   update();
+  if (!m_updateStatus && m_enableUpdatePacket) return {};
   const auto header = static_cast<const Header &>(m_primaryHeader).serialize();
   if (header.size() != 6U) return {};
   const auto dataField = getFullDataFieldBytes();
@@ -471,8 +489,8 @@ std::uint16_t CCSDS::Packet::getFullPacketLength() {
 }
 
 std::uint16_t CCSDS::Packet::getFullPacketLength() const {
-  return static_cast<std::uint16_t>(6U + m_dataField.getDataFieldUsedBytesSize()
-                                    + getPacketErrorControlSize());
+  return static_cast<std::uint16_t>(
+    std::min<std::size_t>(getSerializedSize(), std::numeric_limits<std::uint16_t>::max()));
 }
 
 CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const std::uint64_t data) {

--- a/test/inc/tests.h
+++ b/test/inc/tests.h
@@ -11,5 +11,6 @@ void testGroupValidator(TestManager *tester, const std::string &description);
 void testGroupManagement(TestManager *tester, const std::string &description);
 void testGroupEdgeCases(TestManager *tester, const std::string &description);
 void testGroupParsing(TestManager *tester, const std::string &description);
+void testGroupConformance(TestManager *tester, const std::string &description);
 
 #endif // TESTS_H

--- a/test/package_tester/shared_lib/src/main.cpp
+++ b/test/package_tester/shared_lib/src/main.cpp
@@ -150,12 +150,13 @@ int main() {
     return fail("decoded fields", "decoded packet does not match the v1.2 logical fields");
   }
 
-  // Exercise legacy observation APIs from an external translation unit.
+  // Exercise legacy and additive observation APIs from an external translation unit.
   if (decoded.getPrimaryHeader64bit() == 0U
       || decoded.getFullPacketLength() != expectedPacket.size()
+      || decoded.getSerializedSize() != expectedPacket.size()
       || !decoded.getDataFieldHeaderFlag()
       || decoded.getCRCVectorBytes() != std::vector<std::uint8_t>({0xB7, 0x45})) {
-    return fail("legacy packet API", "legacy getters returned unexpected values");
+    return fail("packet API", "legacy or additive getters returned unexpected values");
   }
   (void)decoded.getDataField();
   (void)decoded.getPrimaryHeader();
@@ -201,6 +202,49 @@ int main() {
          != std::vector<std::uint8_t>({0xAA, 0x55})
       || decodedCrcDisabled.getCRC() != 0U) {
     return fail("CRC-disabled decode", "CRC-free packet did not round-trip");
+  }
+
+  CCSDS::Packet invalidVersion;
+  if (const auto result = invalidVersion.setPrimaryHeader(CCSDS::PrimaryHeader{
+        1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0
+      }); !result) {
+    return failResult("non-zero PVN setup", result.error());
+  }
+  if (const auto result = invalidVersion.setApplicationData({0x01}); !result) {
+    return failResult("non-zero PVN data", result.error());
+  }
+  if (!invalidVersion.serialize().empty()) {
+    return fail("Packet Version Number", "non-zero PVN was serialized as a Space Packet");
+  }
+
+  CCSDS::Packet invalidIdle;
+  if (const auto result = invalidIdle.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+      }); !result) {
+    return failResult("Idle Packet setup", result.error());
+  }
+  if (const auto result = invalidIdle.setDataFieldHeader({0x01}); !result) {
+    return failResult("Idle Packet secondary header", result.error());
+  }
+  if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {
+    return failResult("Idle Packet data", result.error());
+  }
+  if (!invalidIdle.serialize().empty()) {
+    return fail("Idle Packet", "Idle Packet with a secondary header was serialized");
+  }
+
+  CCSDS::Packet validIdle;
+  if (const auto result = validIdle.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+      }); !result) {
+    return failResult("valid Idle Packet setup", result.error());
+  }
+  if (const auto result = validIdle.setApplicationData({0x00}); !result) {
+    return failResult("valid Idle Packet data", result.error());
+  }
+  const auto validIdleBytes = validIdle.serialize();
+  if (validIdleBytes.empty() || validIdle.getSerializedSize() != validIdleBytes.size()) {
+    return fail("valid Idle Packet", "conformant Idle Packet did not serialize");
   }
 
   std::cout << "CCSDSPack installed shared-library consumer passed.\n";

--- a/test/src/testGroupConformance.cpp
+++ b/test/src/testGroupConformance.cpp
@@ -4,6 +4,7 @@
 #include <CCSDSPack.h>
 #include <cstdio>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 #include "tests.h"
@@ -75,6 +76,28 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
       0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
     }));
     return packet.serialize().empty();
+  });
+
+  tester->unitTest("Received Idle Packet rejects secondary-header flag", []() {
+    const std::vector<std::uint8_t> bytes{
+      0x0F, 0xFF, 0xC0, 0x00, 0x00, 0x00, 0x00
+    };
+    CCSDS::Packet packet;
+    packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    return !packet.deserialize(bytes);
+  });
+
+  tester->unitTest("Received Idle Packet requires idle user data", []() {
+    const std::vector<std::uint8_t> header{
+      0x07, 0xFF, 0xC0, 0x00, 0x00, 0x01
+    };
+    const auto checksum = CCSDS::crc16(header);
+    std::vector<std::uint8_t> bytes = header;
+    bytes.push_back(static_cast<std::uint8_t>(checksum >> 8U));
+    bytes.push_back(static_cast<std::uint8_t>(checksum & 0xFFU));
+
+    CCSDS::Packet packet;
+    return !packet.deserialize(bytes);
   });
 
   tester->unitTest("Valid Idle Packet serializes without a secondary header", []() {

--- a/test/src/testGroupConformance.cpp
+++ b/test/src/testGroupConformance.cpp
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPack.h>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+#include "tests.h"
+
+namespace {
+  bool writeConfig(const std::string &path, const int version) {
+    std::ofstream file(path, std::ios::trunc);
+    if (!file) return false;
+
+    file << "ccsds_version_number:int=" << version << '\n'
+         << "ccsds_type:bool=false\n"
+         << "ccsds_data_field_header_flag:bool=false\n"
+         << "ccsds_APID:int=1\n"
+         << "ccsds_segmented:bool=false\n"
+         << "data_field_size:int=8\n";
+    return static_cast<bool>(file);
+  }
+}
+
+void testGroupConformance(TestManager *tester, const std::string &description) {
+  std::cout << "  testGroupConformance: " << description << std::endl;
+
+  tester->unitTest("Packet serialization rejects non-zero Packet Version Number", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    TEST_VOID(packet.setApplicationData({0x01}));
+    return packet.serialize().empty();
+  });
+
+  tester->unitTest("Configuration accepts only Packet Version Number zero", []() {
+    const std::string validPath = "ccsdspack_pvn_zero.cfg";
+    const std::string invalidPath = "ccsdspack_pvn_one.cfg";
+    if (!writeConfig(validPath, 0) || !writeConfig(invalidPath, 1)) return false;
+
+    CCSDS::Packet valid;
+    CCSDS::Packet invalid;
+    const auto validResult = valid.loadFromConfigFile(validPath);
+    const auto invalidResult = invalid.loadFromConfigFile(invalidPath);
+    std::remove(validPath.c_str());
+    std::remove(invalidPath.c_str());
+
+    return validResult && !invalidResult;
+  });
+
+  tester->unitTest("Idle Packet rejects a secondary header", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    TEST_VOID(packet.setDataFieldHeader({0x10}));
+    TEST_VOID(packet.setApplicationData({0x00}));
+    return packet.serialize().empty();
+  });
+
+  tester->unitTest("Idle Packet rejects an asserted secondary-header flag", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 1, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    TEST_VOID(packet.setApplicationData({0x00}));
+    return packet.serialize().empty();
+  });
+
+  tester->unitTest("Idle Packet requires mission-defined idle user data", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    return packet.serialize().empty();
+  });
+
+  tester->unitTest("Valid Idle Packet serializes without a secondary header", []() {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+    }));
+    TEST_VOID(packet.setApplicationData({0x00}));
+    const auto bytes = packet.serialize();
+    return bytes.size() == 9U
+           && packet.getPrimaryHeader().getHeaderStatus() == CCSDS::IDLE
+           && packet.getPrimaryHeader().getDataFieldHeaderFlag() == 0U;
+  });
+
+  tester->unitTest("Maximum serialized size is reported without uint16 overflow", []() {
+    CCSDS::Packet packet;
+    packet.setDataFieldSize(0xFFFEU);
+    TEST_VOID(packet.setApplicationData(std::vector<std::uint8_t>(0xFFFEU, 0x00)));
+    const auto bytes = packet.serialize();
+    return bytes.size() == 65542U
+           && packet.getSerializedSize() == 65542U
+           && packet.getFullPacketLength() == 0xFFFFU;
+  });
+
+  tester->unitTest("Telecommand packets use modulo-16384 sequence counts", []() {
+    CCSDS::Packet packetTemplate;
+    TEST_VOID(packetTemplate.setPrimaryHeader(CCSDS::PrimaryHeader{
+      0, 1, 0, 0x123, CCSDS::UNSEGMENTED, 0x3FFF, 0
+    }));
+    packetTemplate.setDataFieldSize(1U);
+
+    CCSDS::Manager manager;
+    TEST_VOID(manager.setPacketTemplate(packetTemplate));
+    TEST_VOID(manager.setSequenceCount(0x3FFFU));
+    TEST_VOID(manager.setApplicationData({0xAA, 0xBB}));
+
+    const auto packets = manager.getPackets();
+    return packets.size() == 2U
+           && packets[0].getPrimaryHeader().getType() == 1U
+           && packets[0].getPrimaryHeader().getSequenceCount() == 0x3FFFU
+           && packets[1].getPrimaryHeader().getSequenceCount() == 0U;
+  });
+}

--- a/test/src/testGroupEdgeCases.cpp
+++ b/test/src/testGroupEdgeCases.cpp
@@ -26,6 +26,9 @@ namespace {
          << "ccsds_data_field_header_flag:bool=false\n"
          << "ccsds_APID:int=" << apid << "\n"
          << "ccsds_segmented:bool=false\n";
+    if (apid == static_cast<int>(CCSDS::IDLE_APID)) {
+      file << "application_data:bytes=[0x00]\n";
+    }
     return static_cast<bool>(file);
   }
 

--- a/test/src/testMain.cpp
+++ b/test/src/testMain.cpp
@@ -14,6 +14,7 @@ int main() {
   testGroupManagement(&tester, "Management of CCSDS packet tests.");
   testGroupEdgeCases(&tester, "Edge cases and detailed PUS checks.");
   testGroupParsing(&tester, "Bounded parsing, CRC validation, and header validation tests.");
+  testGroupConformance(&tester, "CCSDS 133.0-B-2 EC2 Space Packet PDU profile tests.");
 
   return tester.Result();
 }


### PR DESCRIPTION
## Summary

Tightens the v1.2 packet implementation and documentation against CCSDS 133.0-B-2, Issue 2, including Editorial Change 2 (September 2024).

The release claim is deliberately scoped to a **Space Packet PDU profile**, not the complete abstract Packet Service, Octet String Service, protocol procedures, managed parameters, or PICS.

## Packet Version Number

- keeps `Header` as a low-level three-bit field container for source compatibility;
- makes `Packet` the Space Packet profile gate;
- rejects non-zero Packet Version Numbers during serialization;
- continues rejecting them during parsing;
- restricts `ccsds_version_number` configuration to zero.

## Idle Packet rules

APID `0x7FF` packets now require:

- Secondary Header Flag zero;
- no installed secondary-header object on generation;
- at least one octet of mission-defined idle user data.

Generation, configuration loading, and low-level parsing reject covered invalid Idle Packet structures. The mission-specific idle fill pattern remains outside library validation.

## Packet size API

Adds the additive API:

```cpp
std::size_t Packet::getSerializedSize() const;
```

It reports the complete CCSDS range through 65,542 octets. The legacy `getFullPacketLength()` remains source-compatible and now saturates at `UINT16_MAX` instead of wrapping.

## CRC16 profile clarification

Documentation and public API comments now state that the optional CRC16 bytes are a **CCSDSPack mission-profile trailer inside the CCSDS Packet Data Field**. They are included in Packet Data Length. CCSDS 133.0-B-2 does not define a third standardized packet error-control structural field.

## Conformity scope

Adds `docs/CCSDS_133_0_B_2_PROFILE.md` and synchronizes the README, configuration guide, and v1.2 behavior document.

The supported claim is:

> CCSDSPack v1.2 implements a CCSDS 133.0-B-2 EC2 Space Packet PDU profile.

The documentation also records:

- Packet Sequence Count semantics for telemetry and telecommand packets;
- telecommand Packet Name semantics are not implemented;
- one sequence-count authority per managed APID/data path;
- legacy `PusA`, `PusB`, and `PusC` remain project-specific, not ECSS PUS implementations;
- pre-v1.2 wire migration requirements.

## Tests

Adds a dedicated PDU conformance group covering:

- non-zero PVN serialization rejection;
- configuration PVN rejection;
- Idle Packet secondary-header rejection;
- Idle Packet user-data requirement;
- invalid received Idle Packet structures;
- valid Idle Packet serialization;
- exact maximum serialized-size reporting;
- telecommand modulo-16384 Packet Sequence Count behavior.

The installed shared-library consumer also compiles and exercises the additive size API, PVN enforcement, and Idle Packet rules.

The first test run exposed one obsolete fixture that treated APID `0x7FF` as a normal empty packet configuration. The fixture now retains APID 2047 coverage while supplying one mission-defined idle byte, matching the profile rather than weakening it.

## CI

Final tested head: `459036dfee95265bf88917eac6ccbe0cc257d102`.

Linux:

- Ubuntu 22.04 native build and 93 tests pass;
- Ubuntu 22.04 CLI integration and installed-package consumer pass;
- Ubuntu 22.04 native DEB, Cortex-M MCU TGZ, and aarch64 DEB/package generation pass;
- Ubuntu 24.04 native tests, CLI integration, installation, and external consumer pass;
- `ubuntu-latest` native tests, CLI integration, installation, and external consumer pass.

Windows:

- MinGW configuration and build pass;
- all 93 native tests pass;
- CLI integration passes;
- installation and external consumer configure/build/run pass;
- installed DLL loading passes.

Doxygen generation also passes. UML remains non-blocking because its branch-coupled generation behavior is outside the Linux/Windows functional gates requested for this PR.

Closes #94
