### PR TITLE
release(CCSDSPack): #95 prepare v1.2.0 hardware validation candidate

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -137,6 +137,7 @@ jobs:
         if: matrix.os == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          body_path: docs/releases/v1.2.0.md
           files: packages/ccsdspack*
 
       - name: Log in to GHCR

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
             rm -rf bin/* build/*
             ./package.sh -p DEB
 
-            # 2) Bare-metal Cortex-M7 TGZ
+            # 2) Bare-metal Cortex-M7 TGZ plus compile-only consumer probe
             rm -rf bin/* build/*
             ./package.sh -t cmake/toolchains/arm-none-eabi.cmake -p MCU -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
 
@@ -123,13 +123,17 @@ jobs:
           path: packaging.log
           if-no-files-found: error
 
-      #- name: Upload package artifact
-      #  if: matrix.os == 'ubuntu-22.04'
-      #  uses: actions/upload-artifact@v4
-      #  with:
-      #    name: ccsdspack-deb-${{ github.sha }}
-      #    path: packages/*.deb
-      #    if-no-files-found: error
+      - name: Upload hardware validation packages
+        if: matrix.os == 'ubuntu-22.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccsdspack-v1.2.0-hardware-${{ github.sha }}
+          path: |
+            packages/*.deb
+            packages/*.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+
       # --------------------------
       # Release publishing (only on tags, only from ubuntu-22.04)
       # --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Changelog
+
+All notable changes to CCSDSPack are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses semantic versioning for its public package versions.
+
+## [1.2.0] - 2026-07-16
+
+### Added
+
+- A documented **CCSDS 133.0-B-2 Issue 2, including Editorial Change 2, Space Packet PDU profile**.
+- `PacketErrorControlMode::None` alongside the existing CRC16 default.
+- `Packet::deserializeBounded()` overloads that parse one declared packet and report the consumed byte count.
+- `Packet::getSerializedSize()` using `std::size_t`, covering the complete 65,542-octet Space Packet size range.
+- Independent Python-generated CCSDS golden vectors committed as fixed test resources.
+- Negative, parser-regression, rollover, Idle Packet, PVN, and maximum-size conformance tests.
+- An installed-package external consumer that resolves CCSDSPack only through `find_package()` and validates version 1.2.0 on Linux and Windows.
+- Encoder, decoder, and validator support for explicit `crc16` and `none` profiles.
+- Decoder support for concatenated packets and preservation of unrelated trailing bytes.
+- Detailed Doxygen contracts and representative usage documentation for every installed public header.
+
+### Changed
+
+- Packet Data Length now follows CCSDS semantics exactly: the number of Packet Data Field octets minus one.
+- The optional CCSDSPack CRC16 value is documented and encoded as a mission-profile trailer inside the Packet Data Field, not as a third CCSDS structural field.
+- CRC16 parsing validates the received trailer before committing decoded state.
+- Packet parsing is bounded by the encoded Packet Data Length and no longer consumes unrelated trailing input.
+- `Manager` sequence counts advance once per generated packet, use the full 14-bit range, and roll over modulo 16384.
+- `Manager` binds one complete Packet Identification value: version, packet type, Secondary Header Flag, and APID.
+- Public inspection getters no longer perform hidden packet mutation or finalization.
+- The complete 11-bit APID range is supported; APID `0x7FF` is treated as Idle.
+- Packet generation and configuration enforce Packet Version Number `000`.
+- Idle Packets require Secondary Header Flag zero, no installed secondary header, and at least one mission-defined idle-data octet.
+- The legacy 16-bit `getFullPacketLength()` remains source-compatible and saturates at `UINT16_MAX`; use `getSerializedSize()` for the exact complete range.
+- Telemetry and telecommand packets both use Packet Sequence Count semantics. Telecommand Packet Name semantics are not implemented.
+
+### Fixed
+
+- Incorrect Packet Data Length generation and maximum-length handling.
+- CRC coverage, extraction, and parse-time validation defects.
+- Packet-boundary handling for concatenated and truncated input.
+- Sequence-count coupling to sequence flags and inconsistent rollover behavior.
+- Acceptance of mixed packet identifiers within one Manager stream.
+- Partial state mutation after failed vector or buffer loads.
+- Non-zero Packet Version Number generation and invalid Idle Packet structures.
+- CLI diagnostics for distinct length, CRC, version, APID, and sequence failures.
+
+### Compatibility
+
+CCSDSPack 1.2.0 is intended to remain **source-compatible** with existing v1 public API usage. Additive APIs and overloads are used where the previous signature could not represent the corrected behavior.
+
+The corrected wire format is not guaranteed to be compatible with packets produced by earlier releases. Stored or transmitted pre-1.2 packets may differ in Packet Data Length, CRC coverage, sequence behavior, packet boundaries, Packet Identification enforcement, PVN validation, or Idle Packet validation. Regenerate or explicitly migrate those packets before adopting the v1.2 profile.
+
+CRC16 remains the default for existing v1 construction and configuration paths.
+
+### Conformity scope
+
+The release claim is limited to a **CCSDS 133.0-B-2 EC2 Space Packet PDU profile**. CCSDSPack does not implement the complete abstract Packet Service, Octet String Service, all protocol procedures, managed-parameter interfaces, or a completed Protocol Implementation Conformance Statement.
+
+The bundled `PusA`, `PusB`, and `PusC` types remain legacy project-specific secondary-header formats. They are not official ECSS Packet Utilisation Standard implementations.
+
+### Validation
+
+The final release candidate is gated by:
+
+- Ubuntu 22.04, Ubuntu 24.04, and `ubuntu-latest` native builds and tests;
+- Windows `windows-latest` MinGW build and tests;
+- CLI integration on Linux and Windows;
+- installation and exact-version external-consumer checks on Linux and Windows;
+- Ubuntu 22.04 native, Cortex-M, aarch64, and package generation;
+- independent byte vectors and 93 native regression/conformance tests.
+
+## Earlier releases
+
+Changes for releases before 1.2.0 remain available in the repository commit history and GitHub Releases.
+
+[1.2.0]: https://github.com/ExoSpaceLabs/CCSDSPack/compare/v1.1.1...v1.2.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(LIB_NAME "CCSDSPack")
 
 # Versioning
 set(MAJOR "1")
-set(MINOR "1")
-set(PATCH "1")
+set(MINOR "2")
+set(PATCH "0")
 
 set(VER "-v${MAJOR}.${MINOR}.${PATCH}")
 set(LIB_VERSIONED "${LIB_NAME}${VER}")

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,5 @@
+# Release notes
+
+Versioned files in this directory are the authoritative GitHub release descriptions used by the tag publishing workflow.
+
+A release-note file must describe the exact tagged version, compatibility and migration requirements, conformity scope, validation evidence, and expected artifacts. The file is reviewed and tested as part of the release-candidate pull request before a tag is created.

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,108 @@
+# CCSDSPack v1.2.0
+
+CCSDSPack v1.2.0 completes the v1 packet-core correction and documentation work for a **CCSDS 133.0-B-2 Issue 2, including Editorial Change 2, Space Packet PDU profile**.
+
+This is a source-compatible minor release with additive APIs. The corrected packet semantics can change wire bytes or reject packets accepted by earlier releases, so existing stored or transmitted packets should be regenerated or migrated deliberately.
+
+## Highlights
+
+- Correct CCSDS Packet Data Length encoding and exact packet-boundary parsing.
+- Parse-time CRC16 validation with transactional failure behavior.
+- Optional `PacketErrorControlMode::None`; CRC16 remains the existing v1 default.
+- CRC16 clarified as a CCSDSPack mission-profile trailer in the final two Packet Data Field octets.
+- Full 14-bit Packet Sequence Count behavior with modulo-16384 rollover.
+- One complete Packet Identification binding per `Manager` stream.
+- Complete 11-bit APID support, including structural validation for Idle Packets.
+- Packet Version Number `000` enforcement for Space Packet generation and configuration.
+- Additive `Packet::getSerializedSize()` support for the complete 65,542-octet maximum packet size.
+- Bounded parsing and consumed-byte reporting for concatenated packet streams.
+- Updated encoder, decoder, and validator behavior with Linux and Windows CLI integration tests.
+- Independent golden vectors, negative tests, installed-package consumer tests, and detailed public API documentation.
+
+## Conformity scope
+
+CCSDSPack v1.2.0 implements a **CCSDS 133.0-B-2 EC2 Space Packet PDU profile** for packet construction, serialization, bounded parsing, validation, segmentation utilities, and packet-stream management.
+
+The release does not claim implementation of the complete abstract Packet Service, Octet String Service, all protocol procedures, managed-parameter interfaces, or a completed Protocol Implementation Conformance Statement.
+
+The bundled `PusA`, `PusB`, and `PusC` classes are legacy project-specific secondary-header formats. They are not official ECSS Packet Utilisation Standard implementations. Standards-oriented ECSS PUS support remains v2 scope.
+
+## Wire compatibility warning
+
+Packets produced before v1.2.0 may differ in one or more of these areas:
+
+- Packet Data Length;
+- CRC coverage and placement;
+- parse boundaries and treatment of trailing bytes;
+- sequence-count advancement and rollover;
+- Packet Identification enforcement;
+- Packet Version Number validation;
+- Idle Packet validation.
+
+Do not assume archived pre-v1.2 packet bytes are interchangeable with the v1.2 profile. Regenerate them from source data or migrate them with an explicitly selected legacy interpretation.
+
+## New and additive APIs
+
+### Exact serialized size
+
+```cpp
+std::size_t size = packet.getSerializedSize();
+```
+
+This API represents the full CCSDS range through 65,542 octets. The legacy `getFullPacketLength()` remains available and saturates at `UINT16_MAX` rather than wrapping.
+
+### Bounded parsing
+
+```cpp
+CCSDS::Packet packet;
+auto consumed = packet.deserializeBounded(stream);
+if (!consumed) {
+  return consumed.error().code();
+}
+
+stream.erase(stream.begin(), stream.begin() + consumed.value());
+```
+
+The parser consumes exactly the packet length encoded in the primary header and leaves later bytes untouched.
+
+### Packet error-control profile
+
+```cpp
+packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::CRC16);
+packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+```
+
+The receiver must configure the same profile before parsing. CRC16 remains the default for existing v1 paths.
+
+## Primary-header profile
+
+- Packet Version Number is encoded as `000`.
+- APIDs use the complete 11-bit range.
+- APID `0x7FF` identifies an Idle Packet.
+- Idle Packets require Secondary Header Flag zero, no installed secondary header, and at least one mission-defined idle-data octet.
+- Telemetry and telecommand packets use Packet Sequence Count semantics.
+- Telecommand Packet Name semantics are not implemented.
+
+## Validation evidence
+
+The release candidate is validated by:
+
+- 93 native regression and conformance tests;
+- independent Python-generated CCSDS byte vectors committed as fixed resources;
+- Linux builds on Ubuntu 22.04, Ubuntu 24.04, and `ubuntu-latest`;
+- Windows MinGW build on `windows-latest`;
+- encoder, decoder, and validator integration tests on Linux and Windows;
+- installation and exact-version external-consumer tests on Linux and Windows;
+- Ubuntu 22.04 native, Cortex-M, aarch64, and package generation.
+
+## Release artifacts
+
+The `v1.2.0` tag workflow is expected to publish:
+
+- native Linux package artifacts;
+- Cortex-M static-library package;
+- aarch64 Linux package;
+- `ghcr.io/exospacelabs/ccsdspack:v1.2.0`;
+- `ghcr.io/exospacelabs/ccsdspack:latest`.
+
+See `CHANGELOG.md` for the complete categorized change list and `docs/CCSDS_133_0_B_2_PROFILE.md` for the precise protocol profile.

--- a/package.sh
+++ b/package.sh
@@ -19,7 +19,7 @@ Options:
   -h, --help               Show this help message
 
 Examples:
-  To build deb package using system architecture (e.g. x85_64):
+  To build deb package using system architecture (e.g. x86_64):
   ./package.sh -p DEB
 
   Cross-Compile deb package for aarch64 (e.g. Raspberry Pi):
@@ -104,6 +104,26 @@ fi
 
 # Build
 cmake --build . --config Release -- -j
+
+# Compile the same HAL-independent consumer core used by the STM32 hardware test.
+# This does not replace execution on the board; it catches stale public API calls,
+# missing CCSDS_MCU guards, and Cortex-M7 compile-flag mismatches in CI.
+if [[ "${package_type^^}" == "MCU" ]]; then
+  effective_mcu_flags="${mcu_flags:--fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard}"
+  read -r -a mcu_flag_array <<< "${effective_mcu_flags}"
+
+  arm-none-eabi-g++ \
+    -std=gnu++17 \
+    -DCCSDS_MCU \
+    -Os \
+    -ffunction-sections \
+    -fdata-sections \
+    "${mcu_flag_array[@]}" \
+    -I../inc \
+    -I../test/package_tester/stm32h7xx/CM7/Inc \
+    -c ../test/package_tester/stm32h7xx/CM7/Src/ccsdspack_mcu_compile_probe.cpp \
+    -o ccsdspack_mcu_compile_probe.o
+fi
 
 # Package
 if [[ "${package_type^^}" == "MCU" ]]; then

--- a/package.sh
+++ b/package.sh
@@ -105,9 +105,11 @@ fi
 # Build
 cmake --build . --config Release -- -j
 
-# Compile the same HAL-independent consumer core used by the STM32 hardware test.
-# This does not replace execution on the board; it catches stale public API calls,
-# missing CCSDS_MCU guards, and Cortex-M7 compile-flag mismatches in CI.
+# Compile and relocatably link the same HAL-independent consumer core used by
+# the STM32 hardware test. This does not replace the final board link or run; it
+# catches stale public API calls, missing CCSDS_MCU configuration, compile-flag
+# mismatches, archive naming errors, missing library symbols, and consumer/library
+# ABI drift in CI.
 if [[ "${package_type^^}" == "MCU" ]]; then
   effective_mcu_flags="${mcu_flags:--fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard}"
   read -r -a mcu_flag_array <<< "${effective_mcu_flags}"
@@ -123,6 +125,19 @@ if [[ "${package_type^^}" == "MCU" ]]; then
     -I../test/package_tester/stm32h7xx/CM7/Inc \
     -c ../test/package_tester/stm32h7xx/CM7/Src/ccsdspack_mcu_compile_probe.cpp \
     -o ccsdspack_mcu_compile_probe.o
+
+  mcu_archive="$(find ../lib . -name libccsdspack.a -type f -print -quit)"
+  if [[ -z "${mcu_archive}" ]]; then
+    echo "MCU archive libccsdspack.a was not produced" >&2
+    exit 3
+  fi
+
+  arm-none-eabi-g++ \
+    -r \
+    "${mcu_flag_array[@]}" \
+    ccsdspack_mcu_compile_probe.o \
+    "${mcu_archive}" \
+    -o ccsdspack_mcu_link_probe.o
 fi
 
 # Package

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  ./test/package_tester/aarch64_validate.sh <ccsdspack-arm64.deb>
+  bash test/package_tester/aarch64_validate.sh <ccsdspack-arm64.deb>
 
 Run this script from a CCSDSPack source checkout on an aarch64/arm64 Linux
 system, such as a 64-bit Raspberry Pi OS installation. It installs the package,

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo -E ./test/package_tester/aarch64_validate.sh <ccsdspack-arm64.deb>
+
+Run this script from a CCSDSPack source checkout on an aarch64/arm64 Linux
+system, such as a 64-bit Raspberry Pi OS installation. It installs the package,
+runs the installed regression tester and CLI integration suite, then builds and
+runs an external CMake consumer against the installed package metadata.
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+case "$(uname -m)" in
+  aarch64|arm64)
+    ;;
+  *)
+    echo "ERROR: this validation must run natively on aarch64/arm64; got $(uname -m)" >&2
+    exit 3
+    ;;
+esac
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "ERROR: run with sudo -E so the DEB can be installed." >&2
+  exit 4
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+package_path="$(realpath "$1")"
+
+if [[ ! -f "${package_path}" ]]; then
+  echo "ERROR: package not found: ${package_path}" >&2
+  exit 5
+fi
+
+package_arch="$(dpkg-deb -f "${package_path}" Architecture)"
+if [[ "${package_arch}" != "arm64" ]]; then
+  echo "ERROR: package architecture is ${package_arch}, expected arm64" >&2
+  exit 6
+fi
+
+package_version="$(dpkg-deb -f "${package_path}" Version)"
+if [[ "${package_version}" != "1.2.0" ]]; then
+  echo "ERROR: package version is ${package_version}, expected 1.2.0" >&2
+  exit 7
+fi
+
+package_name="$(dpkg-deb -f "${package_path}" Package)"
+echo "Installing ${package_name} ${package_version} (${package_arch})"
+dpkg -i "${package_path}"
+
+mapfile -t installed_files < <(dpkg -L "${package_name}")
+
+find_installed() {
+  local pattern="$1"
+  local path
+  for path in "${installed_files[@]}"; do
+    if [[ "${path}" =~ ${pattern} ]]; then
+      printf '%s\n' "${path}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+tester="$(find_installed '/CCSDSPack_tester$')" || {
+  echo "ERROR: installed CCSDSPack_tester not found" >&2
+  exit 8
+}
+encoder="$(find_installed '/ccsds_encoder$')" || {
+  echo "ERROR: installed ccsds_encoder not found" >&2
+  exit 9
+}
+cmake_config="$(find_installed '/cmake/CCSDSPack/CCSDSPackConfig.cmake$')" || {
+  echo "ERROR: installed CCSDSPackConfig.cmake not found" >&2
+  exit 10
+}
+library_file="$(find_installed '/libccsdspack\.so(\.1(\.2\.0)?)?$')" || true"
+
+bin_dir="$(dirname "${tester}")"
+cmake_dir="$(dirname "${cmake_config}")"
+if [[ -n "${library_file}" ]]; then
+  export LD_LIBRARY_PATH="$(dirname "${library_file}"):${LD_LIBRARY_PATH:-}"
+fi
+
+for tool in cmake python3 ctest; do
+  command -v "${tool}" >/dev/null || {
+    echo "ERROR: required command not found: ${tool}" >&2
+    exit 11
+  }
+done
+
+if [[ ! -x "${tester}" || ! -x "${encoder}" ]]; then
+  echo "ERROR: installed executables are not runnable" >&2
+  exit 12
+fi
+
+echo "Running installed native regression tester"
+(
+  cd "${bin_dir}"
+  "${tester}"
+)
+
+echo "Running installed encoder/decoder/validator integration suite"
+python3 "${repo_root}/test/cli_integration.py" \
+  --bin-dir "${bin_dir}" \
+  --resources "${repo_root}/test/test_resources"
+
+echo "Building external consumer against installed CCSDSPack 1.2.0"
+consumer_build="${repo_root}/build/aarch64-package-validation"
+rm -rf "${consumer_build}"
+cmake \
+  -S "${repo_root}/test/package_tester/shared_lib" \
+  -B "${consumer_build}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCCSDSPack_DIR="${cmake_dir}"
+cmake --build "${consumer_build}" -- -j"$(nproc)"
+ctest --test-dir "${consumer_build}" --output-on-failure
+
+echo "CCSDSPACK_AARCH64_TEST:PASS"

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  sudo -E ./test/package_tester/aarch64_validate.sh <ccsdspack-arm64.deb>
+  ./test/package_tester/aarch64_validate.sh <ccsdspack-arm64.deb>
 
 Run this script from a CCSDSPack source checkout on an aarch64/arm64 Linux
 system, such as a 64-bit Raspberry Pi OS installation. It installs the package,
@@ -27,14 +27,16 @@ case "$(uname -m)" in
     ;;
 esac
 
-if [[ ${EUID} -ne 0 ]]; then
-  echo "ERROR: run with sudo -E so the DEB can be installed." >&2
-  exit 4
-fi
+for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath; do
+  command -v "${tool}" >/dev/null || {
+    echo "ERROR: required command not found: ${tool}" >&2
+    exit 4
+  }
+done
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
-package_path="$(realpath "$1")"
+package_path="$(realpath -m "$1")"
 
 if [[ ! -f "${package_path}" ]]; then
   echo "ERROR: package not found: ${package_path}" >&2
@@ -55,7 +57,7 @@ fi
 
 package_name="$(dpkg-deb -f "${package_path}" Package)"
 echo "Installing ${package_name} ${package_version} (${package_arch})"
-dpkg -i "${package_path}"
+sudo dpkg -i "${package_path}"
 
 mapfile -t installed_files < <(dpkg -L "${package_name}")
 
@@ -79,11 +81,19 @@ encoder="$(find_installed '/ccsds_encoder$')" || {
   echo "ERROR: installed ccsds_encoder not found" >&2
   exit 9
 }
-cmake_config="$(find_installed '/cmake/CCSDSPack/CCSDSPackConfig.cmake$')" || {
-  echo "ERROR: installed CCSDSPackConfig.cmake not found" >&2
+decoder="$(find_installed '/ccsds_decoder$')" || {
+  echo "ERROR: installed ccsds_decoder not found" >&2
   exit 10
 }
-library_file="$(find_installed '/libccsdspack\.so(\.1(\.2\.0)?)?$')" || true"
+validator="$(find_installed '/ccsds_validator$')" || {
+  echo "ERROR: installed ccsds_validator not found" >&2
+  exit 11
+}
+cmake_config="$(find_installed '/cmake/CCSDSPack/CCSDSPackConfig.cmake$')" || {
+  echo "ERROR: installed CCSDSPackConfig.cmake not found" >&2
+  exit 12
+}
+library_file="$(find_installed '/libccsdspack\.so(\.1(\.2\.0)?)?$' || true)"
 
 bin_dir="$(dirname "${tester}")"
 cmake_dir="$(dirname "${cmake_config}")"
@@ -91,17 +101,12 @@ if [[ -n "${library_file}" ]]; then
   export LD_LIBRARY_PATH="$(dirname "${library_file}"):${LD_LIBRARY_PATH:-}"
 fi
 
-for tool in cmake python3 ctest; do
-  command -v "${tool}" >/dev/null || {
-    echo "ERROR: required command not found: ${tool}" >&2
-    exit 11
-  }
+for executable in "${tester}" "${encoder}" "${decoder}" "${validator}"; do
+  if [[ ! -x "${executable}" ]]; then
+    echo "ERROR: installed executable is not runnable: ${executable}" >&2
+    exit 13
+  fi
 done
-
-if [[ ! -x "${tester}" || ! -x "${encoder}" ]]; then
-  echo "ERROR: installed executables are not runnable" >&2
-  exit 12
-fi
 
 echo "Running installed native regression tester"
 (

--- a/test/package_tester/shared_lib/CMakeLists.txt
+++ b/test/package_tester/shared_lib/CMakeLists.txt
@@ -9,8 +9,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # This project must resolve CCSDSPack exclusively through its installed CMake
-# package. CI passes CMAKE_PREFIX_PATH to the installation under test.
-find_package(CCSDSPack CONFIG REQUIRED)
+# package. CI passes CMAKE_PREFIX_PATH to the installation under test. Requiring
+# the exact release version turns the external consumer into a package-metadata
+# gate on both Linux and Windows.
+find_package(CCSDSPack 1.2.0 EXACT CONFIG REQUIRED)
 
 add_executable(hello_ccsds src/main.cpp)
 target_link_libraries(hello_ccsds PRIVATE ccsdspack::CCSDSPack)

--- a/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+++ b/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
@@ -7,7 +7,7 @@
 // The prebuilt MCU archive is compiled with CCSDS_MCU. Consumers of the static
 // archive must see the same public-header interface in every translation unit.
 #ifndef CCSDS_MCU
-#define CCSDS_MCU 1
+#error "Define CCSDS_MCU when compiling the STM32 validation application"
 #endif
 
 #include "CCSDSPack.h"

--- a/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+++ b/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
@@ -1,0 +1,252 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CCSDSPACK_MCU_TEST_H
+#define CCSDSPACK_MCU_TEST_H
+
+// The prebuilt MCU archive is compiled with CCSDS_MCU. Consumers of the static
+// archive must see the same public-header interface in every translation unit.
+#ifndef CCSDS_MCU
+#define CCSDS_MCU 1
+#endif
+
+#include "CCSDSPack.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace CCSDSPackMcuTest {
+  enum ResultCode : int {
+    Pass = 0,
+    SetPrimaryHeaderFailed = 1,
+    RegisterSecondaryHeaderFailed = 2,
+    SetSecondaryHeaderFailed = 3,
+    SetManagerTemplateFailed = 4,
+    ManagerSequenceConfigurationFailed = 5,
+    SetApplicationDataFailed = 6,
+    WireVectorMismatch = 7,
+    ManagerSequenceAdvanceFailed = 8,
+    BoundedDecodeFailed = 9,
+    BoundedDecodeSizeMismatch = 10,
+    DecodedFieldsMismatch = 11,
+    ValidatorRejectedPacket = 12,
+    CrcFreeHeaderFailed = 13,
+    CrcFreeDataFailed = 14,
+    CrcFreeVectorMismatch = 15,
+    CrcFreeDecodeFailed = 16,
+    InvalidVersionHeaderFailed = 17,
+    InvalidVersionDataFailed = 18,
+    InvalidVersionSerialized = 19,
+    InvalidIdleHeaderFailed = 20,
+    InvalidIdleSecondaryHeaderFailed = 21,
+    InvalidIdleDataFailed = 22,
+    InvalidIdleSerialized = 23,
+    ValidIdleHeaderFailed = 24,
+    ValidIdleDataFailed = 25,
+    ValidIdleSerializationFailed = 26
+  };
+
+  class CustomSecondaryHeader final : public CCSDS::SecondaryHeaderAbstract {
+  public:
+    CustomSecondaryHeader() { setVariableLength(true); }
+
+    explicit CustomSecondaryHeader(const std::vector<std::uint8_t> &data) : m_data(data) {
+      setVariableLength(true);
+    }
+
+    [[nodiscard]] CCSDS::ResultBool deserialize(
+      const std::vector<std::uint8_t> &data) override {
+      m_data = data;
+      return true;
+    }
+
+    void update(CCSDS::DataField *) override {}
+
+    [[nodiscard]] std::uint16_t getSize() const override {
+      return static_cast<std::uint16_t>(m_data.size());
+    }
+
+    [[nodiscard]] std::vector<std::uint8_t> serialize() const override {
+      return m_data;
+    }
+
+    [[nodiscard]] std::string getType() const override {
+      return "CustomSecondaryHeader";
+    }
+
+  private:
+    std::vector<std::uint8_t> m_data{};
+  };
+
+  /**
+   * @brief Runs the deterministic bare-metal consumer validation suite.
+   * @return Pass, or the first non-zero ResultCode identifying the failed stage.
+   *
+   * The suite deliberately exercises std::vector, std::string, shared ownership,
+   * factory registration, packet generation, CRC16, bounded parsing, Validator,
+   * CRC-free packets, PVN enforcement, and Idle Packet rules. It therefore checks
+   * the C++ runtime and heap configuration as well as the packet logic when run on
+   * the target MCU.
+   */
+  inline int run() {
+    CCSDS::Packet templatePacket;
+    if (const auto result = templatePacket.setPrimaryHeader(CCSDS::PrimaryHeader{
+          0, 1, 0, 0x123, CCSDS::UNSEGMENTED, 5, 0
+        }); !result) {
+      return SetPrimaryHeaderFailed;
+    }
+
+    if (const auto result = templatePacket.RegisterSecondaryHeader<CustomSecondaryHeader>();
+        !result) {
+      return RegisterSecondaryHeaderFailed;
+    }
+
+    const std::vector<std::uint8_t> secondaryHeader{
+      0x77, 0xFA, 0x0B, 0x00, 0x00, 0x0B, 0x05
+    };
+    if (const auto result = templatePacket.setDataFieldHeader(
+          secondaryHeader, "CustomSecondaryHeader"); !result) {
+      return SetSecondaryHeaderFailed;
+    }
+
+    CCSDS::Manager manager;
+    if (const auto result = manager.setPacketTemplate(templatePacket); !result) {
+      return SetManagerTemplateFailed;
+    }
+    manager.setAutoValidateEnable(false);
+    manager.setDataFieldSize(1000U);
+
+    if (manager.getSequenceCount() != 5U || !manager.getAutoSequenceCountEnable()) {
+      return ManagerSequenceConfigurationFailed;
+    }
+
+    const std::vector<std::uint8_t> applicationData{0x01, 0x02, 0x03};
+    if (const auto result = manager.setApplicationData(applicationData); !result) {
+      return SetApplicationDataFailed;
+    }
+
+    const std::vector<std::uint8_t> expectedPacket{
+      0x19, 0x23, 0xC0, 0x05, 0x00, 0x0B,
+      0x77, 0xFA, 0x0B, 0x00, 0x00, 0x0B, 0x05,
+      0x01, 0x02, 0x03,
+      0xB7, 0x45
+    };
+
+    const auto packetsData = manager.getPacketsBuffer();
+    if (packetsData != expectedPacket) {
+      return WireVectorMismatch;
+    }
+    if (manager.getSequenceCount() != 6U || manager.getTotalPackets() != 1U) {
+      return ManagerSequenceAdvanceFailed;
+    }
+
+    CCSDS::Packet decoded;
+    const auto consumed = decoded.deserializeBounded(
+      packetsData, static_cast<std::uint16_t>(secondaryHeader.size()));
+    if (!consumed) {
+      return BoundedDecodeFailed;
+    }
+    if (consumed.value() != expectedPacket.size()) {
+      return BoundedDecodeSizeMismatch;
+    }
+
+    const auto &header = decoded.getPrimaryHeader();
+    if (header.getVersionNumber() != 0U
+        || header.getType() != 1U
+        || header.getDataFieldHeaderFlag() != 1U
+        || header.getAPID() != 0x123U
+        || header.getSequenceFlags() != CCSDS::UNSEGMENTED
+        || header.getSequenceCount() != 5U
+        || decoded.getDataFieldHeaderBytes() != secondaryHeader
+        || decoded.getApplicationDataBytes() != applicationData
+        || decoded.getCRC() != 0xB745U
+        || decoded.getSerializedSize() != expectedPacket.size()) {
+      return DecodedFieldsMismatch;
+    }
+
+    CCSDS::Validator validator(templatePacket);
+    validator.configure(true, false, true);
+    if (!validator.validate(decoded)) {
+      return ValidatorRejectedPacket;
+    }
+
+    CCSDS::Packet crcDisabled;
+    crcDisabled.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    if (const auto result = crcDisabled.setPrimaryHeader(CCSDS::PrimaryHeader{
+          0, 0, 0, 0x123, CCSDS::UNSEGMENTED, 7, 0
+        }); !result) {
+      return CrcFreeHeaderFailed;
+    }
+    if (const auto result = crcDisabled.setApplicationData({0xAA, 0x55}); !result) {
+      return CrcFreeDataFailed;
+    }
+
+    const std::vector<std::uint8_t> expectedCrcDisabled{
+      0x01, 0x23, 0xC0, 0x07, 0x00, 0x01, 0xAA, 0x55
+    };
+    const auto crcDisabledBytes = crcDisabled.serialize();
+    if (crcDisabledBytes != expectedCrcDisabled) {
+      return CrcFreeVectorMismatch;
+    }
+
+    CCSDS::Packet decodedCrcDisabled;
+    decodedCrcDisabled.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    const auto crcDisabledConsumed = decodedCrcDisabled.deserializeBounded(crcDisabledBytes);
+    if (!crcDisabledConsumed
+        || crcDisabledConsumed.value() != crcDisabledBytes.size()
+        || decodedCrcDisabled.getPrimaryHeader().getSequenceCount() != 7U
+        || decodedCrcDisabled.getApplicationDataBytes()
+           != std::vector<std::uint8_t>({0xAA, 0x55})
+        || decodedCrcDisabled.getCRC() != 0U) {
+      return CrcFreeDecodeFailed;
+    }
+
+    CCSDS::Packet invalidVersion;
+    if (const auto result = invalidVersion.setPrimaryHeader(CCSDS::PrimaryHeader{
+          1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0
+        }); !result) {
+      return InvalidVersionHeaderFailed;
+    }
+    if (const auto result = invalidVersion.setApplicationData({0x01}); !result) {
+      return InvalidVersionDataFailed;
+    }
+    if (!invalidVersion.serialize().empty()) {
+      return InvalidVersionSerialized;
+    }
+
+    CCSDS::Packet invalidIdle;
+    if (const auto result = invalidIdle.setPrimaryHeader(CCSDS::PrimaryHeader{
+          0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+        }); !result) {
+      return InvalidIdleHeaderFailed;
+    }
+    if (const auto result = invalidIdle.setDataFieldHeader({0x01}); !result) {
+      return InvalidIdleSecondaryHeaderFailed;
+    }
+    if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {
+      return InvalidIdleDataFailed;
+    }
+    if (!invalidIdle.serialize().empty()) {
+      return InvalidIdleSerialized;
+    }
+
+    CCSDS::Packet validIdle;
+    if (const auto result = validIdle.setPrimaryHeader(CCSDS::PrimaryHeader{
+          0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
+        }); !result) {
+      return ValidIdleHeaderFailed;
+    }
+    if (const auto result = validIdle.setApplicationData({0x00}); !result) {
+      return ValidIdleDataFailed;
+    }
+    const auto validIdleBytes = validIdle.serialize();
+    if (validIdleBytes.empty() || validIdle.getSerializedSize() != validIdleBytes.size()) {
+      return ValidIdleSerializationFailed;
+    }
+
+    return Pass;
+  }
+} // namespace CCSDSPackMcuTest
+
+#endif // CCSDSPACK_MCU_TEST_H

--- a/test/package_tester/stm32h7xx/CM7/Src/ccsdspack_mcu_compile_probe.cpp
+++ b/test/package_tester/stm32h7xx/CM7/Src/ccsdspack_mcu_compile_probe.cpp
@@ -1,0 +1,11 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ccsdspack_mcu_test.h"
+
+// This target is compiled, but not executed, by the generic arm-none-eabi build.
+// It catches public-header, CCSDS_MCU, C++17, and consumer API regressions before
+// the same validation core is built and run inside the STM32CubeIDE application.
+extern "C" int ccsdspack_mcu_compile_probe() {
+  return CCSDSPackMcuTest::run();
+}

--- a/test/package_tester/stm32h7xx/CM7/Src/main.cpp
+++ b/test/package_tester/stm32h7xx/CM7/Src/main.cpp
@@ -1,516 +1,213 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
 /**
- ******************************************************************************
- * @file    UART/UART_WakeUpFromStopUsingFIFO/CM7/Src/main.c
- * @author  MCD Application Team
- * @brief   This example shows how to use UART HAL API to wake up the MCU from
- *          STOP mode using FIFO filling level.
- ******************************************************************************
- * @attention
+ * @file main.cpp
+ * @brief STM32H745 CM7 hardware-validation harness for the CCSDSPack MCU archive.
  *
- * Copyright (c) 2018 STMicroelectronics.
- * All rights reserved.
+ * The board runs the same HAL-independent validation core that is compiled by the
+ * generic arm-none-eabi package build. UART and LEDs provide deterministic target
+ * results:
  *
- * This software is licensed under terms that can be found in the LICENSE file
- * in the root directory of this software component.
- * If no LICENSE file comes with this software, it is provided AS-IS.
- *
- ******************************************************************************
+ * - `CCSDSPACK_MCU_TEST:PASS` and LED2 on indicate success;
+ * - `CCSDSPACK_MCU_TEST:FAIL:<code>` and LED3 on identify the first failed stage.
  */
 
-/* Includes ------------------------------------------------------------------*/
 #include "main.h"
-#include "CCSDSPack.h"
+#include "ccsdspack_mcu_test.h"
 
-/** @addtogroup STM32H7xx_HAL_Examples
- * @{
- */
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
 
-/** @addtogroup UART_WakeUpFromStopUsingFIFO
- * @{
- */
+namespace {
+  constexpr std::uint32_t UART_TIMEOUT = HAL_MAX_DELAY;
 
-/* Private typedef -----------------------------------------------------------*/
-/* Private define ------------------------------------------------------------*/
-/* Private macro -------------------------------------------------------------*/
-#define HAL_TIMEOUT_VALUE 0xFFFFFFFF
-#define countof(a) (sizeof(a) / sizeof(*(a)))
+  UART_HandleTypeDef UartHandle{};
+  bool uartReady{false};
+  bool ledsReady{false};
 
-/* Private variables ---------------------------------------------------------*/
-/* UART handler declaration */
-UART_HandleTypeDef UartHandle;
-uint8_t HeaderTxBuffer[] = "\r\nUART WakeUp from stop mode using FIFO\r\n";
-uint8_t Part1TxBuffer[] =
-		"\r\nStarting CCSDS tests: please send a signal.\r\n\n";
+  void MPU_Config();
+  void SystemClock_Config();
+  void CPU_CACHE_Enable();
+  [[noreturn]] void Error_Handler();
 
-uint8_t RxBuffer[16];
+  void uartWrite(const char *text) {
+    if (!uartReady || text == nullptr) return;
+    const auto length = std::strlen(text);
+    HAL_UART_Transmit(&UartHandle,
+                      reinterpret_cast<std::uint8_t *>(const_cast<char *>(text)),
+                      static_cast<std::uint16_t>(length),
+                      UART_TIMEOUT);
+  }
 
-/* Private function prototypes -----------------------------------------------*/
-static void MPU_Config(void);
-static void SystemClock_Config(void);
-static void CPU_CACHE_Enable(void);
-static void Error_Handler(void);
+  void reportTestResult(const int result) {
+    if (result == CCSDSPackMcuTest::Pass) {
+      BSP_LED_On(LED2);
+      uartWrite("CCSDSPACK_MCU_TEST:PASS\r\n");
+      return;
+    }
 
-/* Private functions ---------------------------------------------------------*/
+    BSP_LED_On(LED3);
+    char buffer[64]{};
+    std::snprintf(buffer, sizeof(buffer), "CCSDSPACK_MCU_TEST:FAIL:%d\r\n", result);
+    uartWrite(buffer);
+  }
+} // namespace
 
-class CustomSecondaryHeader final : public CCSDS::SecondaryHeaderAbstract {
-public:
-	CustomSecondaryHeader() {
-		variableLength = true;
-	}
-	;
+int main() {
+  std::int32_t timeout = 0xFFFF;
 
-	/**
-	 * @brief Constructs a CustomSecondaryHeader object with all fields explicitly set.
-	 */
-	explicit CustomSecondaryHeader(const std::vector<uint8_t> &data) :
-			m_data(data) {
-		variableLength = true;
-	}
-	;
+  MPU_Config();
+  CPU_CACHE_Enable();
 
-	[[nodiscard]] CCSDS::ResultBool deserialize(
-			const std::vector<uint8_t> &data) override {
-		m_data = data;
-		return true;
-	}
-	;
+  // On the dual-core STM32H745, wait until the CM4 domain is in reset before
+  // configuring the CM7 clocks. This follows the original ST board example.
+  while ((__HAL_RCC_GET_FLAG(RCC_FLAG_D2CKRDY) != RESET) && (timeout-- > 0)) {
+  }
+  if (timeout < 0) {
+    Error_Handler();
+  }
 
-	[[nodiscard]] uint16_t getSize() const override {
-		return m_data.size();
-	}
-	[[nodiscard]] std::string getType() const override {
-		return m_type;
-	}
+  HAL_Init();
+  SystemClock_Config();
 
-	[[nodiscard]] std::vector<uint8_t> serialize() const override {
-		return m_data;
-	}
-	;
-	void update(CCSDS::DataField *dataField) override {
-		m_dataLength = m_data.size();
-	}
-	CCSDS::ResultBool loadFromConfig(const Config &config) override {
-		return true;
-	}
-	;
+  BSP_LED_Init(LED1);
+  BSP_LED_Init(LED2);
+  BSP_LED_Init(LED3);
+  ledsReady = true;
 
-private:
-	std::vector<uint8_t> m_data { };
-	uint16_t m_dataLength = 0;
-	const std::string m_type = "CustomSecondaryHeader";
-};
+  BSP_LED_Off(LED1);
+  BSP_LED_Off(LED2);
+  BSP_LED_Off(LED3);
+  BSP_LED_On(LED1);
 
-void uartPrintHex(const std::vector<uint8_t> &v) {
-	char buf[8];
-	for (size_t i = 0; i < v.size(); ++i) {
-		int n = snprintf(buf, sizeof(buf), "%02X ", v[i]);
-		HAL_UART_Transmit(&UartHandle, reinterpret_cast<uint8_t*>(buf), n,
-				HAL_MAX_DELAY);
-	}
-	const char crlf[] = "\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) crlf, sizeof(crlf) - 1,
-			HAL_MAX_DELAY);
+  // Standard ST-Link virtual COM settings: 115200 baud, 8 data bits, no parity,
+  // one stop bit, no flow control.
+  UartHandle.Instance = USARTx;
+  UartHandle.Init.BaudRate = 115200;
+  UartHandle.Init.WordLength = UART_WORDLENGTH_8B;
+  UartHandle.Init.StopBits = UART_STOPBITS_1;
+  UartHandle.Init.Parity = UART_PARITY_NONE;
+  UartHandle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+  UartHandle.Init.Mode = UART_MODE_TX_RX;
+  UartHandle.Init.ClockPrescaler = UART_PRESCALER_DIV1;
+  UartHandle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+  UartHandle.Init.OverSampling = UART_OVERSAMPLING_16;
+
+  if (HAL_UART_Init(&UartHandle) != HAL_OK
+      || HAL_UARTEx_SetTxFifoThreshold(&UartHandle, UART_TXFIFO_THRESHOLD_1_8) != HAL_OK
+      || HAL_UARTEx_SetRxFifoThreshold(&UartHandle, UART_RXFIFO_THRESHOLD_1_8) != HAL_OK
+      || HAL_UARTEx_DisableFifoMode(&UartHandle) != HAL_OK) {
+    Error_Handler();
+  }
+  uartReady = true;
+
+  uartWrite("\r\nCCSDSPack STM32H745 CM7 hardware validation\r\n");
+  uartWrite("Running packet generation, parsing, CRC, Manager, Validator, PVN, and Idle tests...\r\n");
+
+  const int result = CCSDSPackMcuTest::run();
+  reportTestResult(result);
+
+  uartWrite("Reset the board to run the validation again.\r\n");
+  BSP_LED_Off(LED1);
+
+  while (true) {
+    __WFI();
+  }
 }
 
-int testCCSDS(void) {
-	uint8_t bufferCreate[] = "Stage: Create CCSDS Packet Manager.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferCreate,
-	countof(bufferCreate) - 1, HAL_TIMEOUT_VALUE);
-	CCSDS::Manager mgr; // Minimal smoke test: type is visible and linkable
+namespace {
+  /**
+   * @brief Configures the CM7 system clock for 400 MHz from the 8 MHz HSE bypass.
+   */
+  void SystemClock_Config() {
+    RCC_ClkInitTypeDef clock{};
+    RCC_OscInitTypeDef oscillator{};
 
-	uint8_t bufferComplete[] = "Stage: Complete.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+    while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {
+    }
 
-	uint8_t bufferCreateTemplate[] = "Stage: Create CCSDS Template Package.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferCreateTemplate,
-	countof(bufferCreateTemplate) - 1, HAL_TIMEOUT_VALUE);
+    oscillator.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    oscillator.HSEState = RCC_HSE_BYPASS;
+    oscillator.HSIState = RCC_HSI_OFF;
+    oscillator.CSIState = RCC_CSI_OFF;
+    oscillator.PLL.PLLState = RCC_PLL_ON;
+    oscillator.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+    oscillator.PLL.PLLM = 4;
+    oscillator.PLL.PLLN = 400;
+    oscillator.PLL.PLLFRACN = 0;
+    oscillator.PLL.PLLP = 2;
+    oscillator.PLL.PLLQ = 4;
+    oscillator.PLL.PLLR = 2;
+    oscillator.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
+    oscillator.PLL.PLLRGE = RCC_PLL1VCIRANGE_1;
 
-	// generate template packet with new registered secondary header
-	CCSDS::Packet templatePacket;
-	templatePacket.setPrimaryHeader(
-			CCSDS::PrimaryHeader { 1, 2, 1, 55, 0, 0, 0 });
+    if (HAL_RCC_OscConfig(&oscillator) != HAL_OK) {
+      Error_Handler();
+    }
 
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+    clock.ClockType = RCC_CLOCKTYPE_SYSCLK
+                      | RCC_CLOCKTYPE_HCLK
+                      | RCC_CLOCKTYPE_D1PCLK1
+                      | RCC_CLOCKTYPE_PCLK1
+                      | RCC_CLOCKTYPE_PCLK2
+                      | RCC_CLOCKTYPE_D3PCLK1;
+    clock.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    clock.SYSCLKDivider = RCC_SYSCLK_DIV1;
+    clock.AHBCLKDivider = RCC_HCLK_DIV2;
+    clock.APB3CLKDivider = RCC_APB3_DIV2;
+    clock.APB1CLKDivider = RCC_APB1_DIV2;
+    clock.APB2CLKDivider = RCC_APB2_DIV2;
+    clock.APB4CLKDivider = RCC_APB4_DIV2;
 
-	uint8_t bufferCreateCustomSH[] =
-			"Stage: Register custom secondary header.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferCreateCustomSH,
-	countof(bufferCreateCustomSH) - 1, HAL_TIMEOUT_VALUE);
+    if (HAL_RCC_ClockConfig(&clock, FLASH_LATENCY_4) != HAL_OK) {
+      Error_Handler();
+    }
+  }
 
-	const std::vector<uint8_t> data { 0x77, 0xFA, 0xB, 0x0, 0x0, 0xB, 0x5 };
+  void CPU_CACHE_Enable() {
+    SCB_EnableICache();
+    SCB_EnableDCache();
+  }
 
-	if (const auto res = templatePacket.RegisterSecondaryHeader<
-			CustomSecondaryHeader>(); !res.has_value()) {
-		uint8_t bufferError[] = "Error: Register Secondary header.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferError,
-		countof(bufferError) - 1, HAL_TIMEOUT_VALUE);
-		return res.error().code();
-	}
-	if (const auto res = templatePacket.setDataFieldHeader(data,
-			"CustomSecondaryHeader"); !res.has_value()) {
-		uint8_t bufferError[] = "Error: Set CCSDS Packet data field header.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferError,
-		countof(bufferError) - 1, HAL_TIMEOUT_VALUE);
-		return res.error().code();
-	}
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+  [[noreturn]] void Error_Handler() {
+    if (ledsReady) {
+      BSP_LED_On(LED3);
+    }
+    if (uartReady) {
+      uartWrite("CCSDSPACK_MCU_TEST:HAL_FAILURE\r\n");
+    }
+    while (true) {
+      __WFI();
+    }
+  }
 
-	// add template to manager
-	uint8_t bufferAddTemplate[] =
-			"Stage: Set CCSDS Packet template package.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferAddTemplate,
-	countof(bufferAddTemplate) - 1, HAL_TIMEOUT_VALUE);
-	if (const auto res = mgr.setPacketTemplate(templatePacket); !res.has_value()) {
-		uint8_t bufferError[] = "Error: Set packet template.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferError,
-		countof(bufferError) - 1, HAL_TIMEOUT_VALUE);
-		return res.error().code();
-	}
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+  void MPU_Config() {
+    MPU_Region_InitTypeDef region{};
 
-	// Add some data to generate packets
-	uint8_t bufferAddData[] =
-			"Stage: Generate CCSDS packet with application data.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferAddData,
-	countof(bufferAddData) - 1, HAL_TIMEOUT_VALUE);
-	mgr.setDataFieldSize(1000);
-	if (const auto res = mgr.setApplicationData( { 1, 2, 3 }); !res.has_value()) {
-		uint8_t bufferError[] = "Error: set Application data.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferError,
-		countof(bufferError) - 1, HAL_TIMEOUT_VALUE);
-		return res.error().code();
-	}
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+    HAL_MPU_Disable();
 
-	// get ccsds packets
-	uint8_t bufferGetPacketBuffer[] = "Stage: Get CCSDS Packet buffer.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferGetPacketBuffer,
-	countof(bufferGetPacketBuffer) - 1, HAL_TIMEOUT_VALUE);
-	const auto packetsData = mgr.getPacketsBuffer();
-	uartPrintHex(packetsData);
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferComplete,
-	countof(bufferComplete) - 1, HAL_TIMEOUT_VALUE);
+    region.Enable = MPU_REGION_ENABLE;
+    region.BaseAddress = 0x00000000U;
+    region.Size = MPU_REGION_SIZE_4GB;
+    region.AccessPermission = MPU_REGION_NO_ACCESS;
+    region.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
+    region.IsCacheable = MPU_ACCESS_NOT_CACHEABLE;
+    region.IsShareable = MPU_ACCESS_SHAREABLE;
+    region.Number = MPU_REGION_NUMBER0;
+    region.TypeExtField = MPU_TEX_LEVEL0;
+    region.SubRegionDisable = 0x87;
+    region.DisableExec = MPU_INSTRUCTION_ACCESS_DISABLE;
 
-	uint8_t bufferTestPackage[] =
-			"Stage: Test Generated package against expected.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferTestPackage,
-	countof(bufferTestPackage) - 1, HAL_TIMEOUT_VALUE);
-	const std::vector<uint8_t> expectedPacket { 0x28, 0x37, 0x00, 0x00, 0x00,
-			0x0a, 0x77, 0xfa, 0x0b, 0x00, 0x00, 0x0b, 0x05, 0x01, 0x02, 0x03,
-			0x3e, 0x97 };
+    HAL_MPU_ConfigRegion(&region);
+    HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
+  }
+} // namespace
 
-	if (std::equal(packetsData.begin(), packetsData.end(),
-			expectedPacket.begin())) {
-		uint8_t bufferExpected[] = "Stage: -- Generated packet as expected.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferExpected,
-		countof(bufferExpected) - 1, HAL_TIMEOUT_VALUE);
-	} else {
-		uint8_t bufferExpected[] =
-				"Stage: -- Generated packet differs from expected.\r\n";
-		HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferExpected,
-		countof(bufferExpected) - 1, HAL_TIMEOUT_VALUE);
-	}
-	return 0;
-}
-
-/**
- * @brief  Main program
- * @param  None
- * @retval None
- */
-int main(void) {
-	int32_t timeout;
-	/* Configure the MPU attributes */
-	MPU_Config();
-
-	/* Enable the CPU Cache */
-	CPU_CACHE_Enable();
-	timeout = 0xFFFF;
-	while ((__HAL_RCC_GET_FLAG(RCC_FLAG_D2CKRDY) != RESET) && (timeout-- > 0))
-		;
-	if (timeout < 0) {
-		Error_Handler();
-	}
-	/* STM32H7xx HAL library initialization:
-	 - Systick timer is configured by default as source of time base, but user
-	 can eventually implement his proper time base source (a general purpose
-	 timer for example or other time source), keeping in mind that Time base
-	 duration should be kept 1ms since PPP_TIMEOUT_VALUEs are defined and
-	 handled in milliseconds basis.
-	 - Set NVIC Group Priority to 4
-	 - Low Level Initialization
-	 */
-	HAL_Init();
-
-	/* Configure the system clock to 400 MHz */
-	SystemClock_Config();
-
-	/* Initialize BSP LEDs */
-	BSP_LED_Init(LED1);
-	BSP_LED_Init(LED2);
-	BSP_LED_Init(LED3);
-
-	/* Turn LED1 on */
-	BSP_LED_On(LED1);
-
-	/*##########################################################################*/
-	/*##-1- Configure the UART peripheral ######################################*/
-	/*##########################################################################*/
-
-	/* Put the USART peripheral in the Asynchronous mode (UART Mode) */
-	/* UART configured as follows:
-	 - Word Length = 8 Bits (7 data bit + 1 parity bit) :
-	 BE CAREFUL : Program 7 data bits + 1 parity bit in PC HyperTerminal
-	 - Stop Bit    = One Stop bit
-	 - Parity      = Odd
-	 - BaudRate    = 9600 baud
-	 - Hardware flow control disabled (RTS and CTS signals) */
-	UartHandle.Instance = USARTx;
-	UartHandle.Init.BaudRate = 9600;
-	UartHandle.Init.WordLength = UART_WORDLENGTH_8B;
-	UartHandle.Init.StopBits = UART_STOPBITS_1;
-	UartHandle.Init.Parity = UART_PARITY_ODD;
-	UartHandle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-	UartHandle.Init.Mode = UART_MODE_TX_RX;
-	UartHandle.Init.ClockPrescaler = UART_PRESCALER_DIV1;
-	UartHandle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-	UartHandle.Init.OverSampling = UART_OVERSAMPLING_16;
-
-	if (HAL_UART_Init(&UartHandle) != HAL_OK) {
-		/* Initialization Error */
-		Error_Handler();
-	}
-
-	/* Set the RXFIFO threshold */
-	HAL_UARTEx_SetRxFifoThreshold(&UartHandle, UART_RXFIFO_THRESHOLD_1_4);
-
-	/* Enable the FIFO mode */
-	HAL_UARTEx_EnableFifoMode(&UartHandle);
-
-	/* Output message on hyperterminal */
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &HeaderTxBuffer,
-	countof(HeaderTxBuffer) - 1, HAL_TIMEOUT_VALUE);
-
-	/*##########################################################################*/
-	/*##-2- Wakeup first step RXFT #############################################*/
-	/*##########################################################################*/
-
-	/* Enable MCU wakeup by UART */
-	HAL_UARTEx_EnableStopMode(&UartHandle);
-
-	/* Enable the UART RX FIFO threshold interrupt */
-	__HAL_UART_ENABLE_IT(&UartHandle, UART_IT_RXFT);
-
-	/* Enable the UART wakeup from stop mode interrupt */
-	__HAL_UART_ENABLE_IT(&UartHandle, UART_IT_WUF);
-
-	/* Output message on hyperterminal */
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &Part1TxBuffer,
-	countof(Part1TxBuffer) - 1, HAL_TIMEOUT_VALUE);
-
-	/* Put UART peripheral in reception process */
-	HAL_UART_Receive_IT(&UartHandle, (uint8_t*) &RxBuffer, 1);
-
-	/* Turn LED1 off */
-	BSP_LED_Off(LED1);
-
-	/* Enter STOP mode */
-	HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI);
-
-	/* ... STOP Mode ... */
-
-	while (HAL_UART_GetState(&UartHandle) != HAL_UART_STATE_READY) {
-	}
-
-	/* Turn LED1 on */
-	BSP_LED_On(LED1);
-
-	/* Disable the UART wakeup from stop mode interrupt */
-	__HAL_UART_DISABLE_IT(&UartHandle, UART_IT_WUF);
-
-	/* Disable the UART RX FIFO threshold interrupt */
-	__HAL_UART_DISABLE_IT(&UartHandle, UART_IT_RXFT);
-
-	/* Disable UART Stop Mode */
-	HAL_UARTEx_DisableStopMode(&UartHandle);
-
-	//test CCSDS library.
-	if (testCCSDS() != 0) {
-		Error_Handler();
-	};
-
-	/* Turn LED1 on */
-	BSP_LED_On(LED2);
-
-	uint8_t bufferEnd[] = "\r\nTest End. Reset STM32 to start test again.\r\n";
-	HAL_UART_Transmit(&UartHandle, (uint8_t*) &bufferEnd,
-	countof(bufferEnd) - 1, HAL_TIMEOUT_VALUE);
-
-	/* Infinite loop */
-	while (1) {
-		;
-	}
-}
-
-/**
- * @brief  System Clock Configuration
- *         The system Clock is configured as follow :
- *            System Clock source            = PLL (HSE BYPASS)
- *            SYSCLK(Hz)                     = 400000000 (CPU Clock)
- *            HCLK(Hz)                       = 200000000 (AXI and AHBs Clock)
- *            AHB Prescaler                  = 2
- *            D1 APB3 Prescaler              = 2 (APB3 Clock  100MHz)
- *            D2 APB1 Prescaler              = 2 (APB1 Clock  100MHz)
- *            D2 APB2 Prescaler              = 2 (APB2 Clock  100MHz)
- *            D3 APB4 Prescaler              = 2 (APB4 Clock  100MHz)
- *            HSE Frequency(Hz)              = 8000000
- *            PLL_M                          = 4
- *            PLL_N                          = 400
- *            PLL_P                          = 2
- *            PLL_Q                          = 4
- *            PLL_R                          = 2
- *            VDD(V)                         = 3.3
- *            Flash Latency(WS)              = 4
- * @param  None
- * @retval None
- */
-static void SystemClock_Config(void) {
-	RCC_ClkInitTypeDef RCC_ClkInitStruct;
-	RCC_OscInitTypeDef RCC_OscInitStruct;
-	HAL_StatusTypeDef ret = HAL_OK;
-	/* The voltage scaling allows optimizing the power consumption when the device is
-	 clocked below the maximum system frequency, to update the voltage scaling value
-	 regarding system frequency refer to product datasheet.  */
-	__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-
-	while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {
-	}
-
-	/* Enable HSE Oscillator and activate PLL with HSE as source */
-	RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-	RCC_OscInitStruct.HSEState = RCC_HSE_BYPASS;
-	RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
-	RCC_OscInitStruct.CSIState = RCC_CSI_OFF;
-	RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-	RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-
-	RCC_OscInitStruct.PLL.PLLM = 4;
-	RCC_OscInitStruct.PLL.PLLN = 400;
-	RCC_OscInitStruct.PLL.PLLFRACN = 0;
-	RCC_OscInitStruct.PLL.PLLP = 2;
-	RCC_OscInitStruct.PLL.PLLR = 2;
-	RCC_OscInitStruct.PLL.PLLQ = 4;
-
-	RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
-	RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_1;
-	ret = HAL_RCC_OscConfig(&RCC_OscInitStruct);
-	if (ret != HAL_OK) {
-		Error_Handler();
-	}
-
-	/* Select PLL as system clock source and configure  bus clocks dividers */
-	RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK
-			| RCC_CLOCKTYPE_D1PCLK1 | RCC_CLOCKTYPE_PCLK1 |
-			RCC_CLOCKTYPE_PCLK2 | RCC_CLOCKTYPE_D3PCLK1);
-
-	RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-	RCC_ClkInitStruct.SYSCLKDivider = RCC_SYSCLK_DIV1;
-	RCC_ClkInitStruct.AHBCLKDivider = RCC_HCLK_DIV2;
-	RCC_ClkInitStruct.APB3CLKDivider = RCC_APB3_DIV2;
-	RCC_ClkInitStruct.APB1CLKDivider = RCC_APB1_DIV2;
-	RCC_ClkInitStruct.APB2CLKDivider = RCC_APB2_DIV2;
-	RCC_ClkInitStruct.APB4CLKDivider = RCC_APB4_DIV2;
-	ret = HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4);
-	if (ret != HAL_OK) {
-		Error_Handler();
-	}
-
-}
-
-/**
- * @brief  CPU L1-Cache enable.
- * @param  None
- * @retval None
- */
-static void CPU_CACHE_Enable(void) {
-	/* Enable I-Cache */
-	SCB_EnableICache();
-
-	/* Enable D-Cache */
-	SCB_EnableDCache();
-}
-
-/**
- * @brief  This function is executed in case of error occurrence.
- * @param  None
- * @retval None
- */
-static void Error_Handler(void) {
-	/* Turn LED3 on */
-	BSP_LED_On(LED3);
-	while (1) {
-		;
-	}
-}
-
-/**
- * @brief  Configure the MPU attributes
- * @param  None
- * @retval None
- */
-static void MPU_Config(void) {
-	MPU_Region_InitTypeDef MPU_InitStruct;
-
-	/* Disable the MPU */
-	HAL_MPU_Disable();
-
-	/* Configure the MPU as Strongly ordered for not defined regions */
-	MPU_InitStruct.Enable = MPU_REGION_ENABLE;
-	MPU_InitStruct.BaseAddress = 0x00;
-	MPU_InitStruct.Size = MPU_REGION_SIZE_4GB;
-	MPU_InitStruct.AccessPermission = MPU_REGION_NO_ACCESS;
-	MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
-	MPU_InitStruct.IsCacheable = MPU_ACCESS_NOT_CACHEABLE;
-	MPU_InitStruct.IsShareable = MPU_ACCESS_SHAREABLE;
-	MPU_InitStruct.Number = MPU_REGION_NUMBER0;
-	MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
-	MPU_InitStruct.SubRegionDisable = 0x87;
-	MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_DISABLE;
-
-	HAL_MPU_ConfigRegion(&MPU_InitStruct);
-
-	/* Enable the MPU */
-	HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
-}
-
-#ifdef  USE_FULL_ASSERT
-/**
-  * @brief  Reports the name of the source file and the source line number
-  *         where the assert_param error has occurred.
-  * @param  file: pointer to the source file name
-  * @param  line: assert_param error line source number
-  * @retval None
-  */
-void assert_failed(uint8_t* file, uint32_t line)
-{
-  /* User can add his own implementation to report the file name and line number,
-     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-
-  /* Infinite loop */
-  while(1) { ; }
+#ifdef USE_FULL_ASSERT
+extern "C" void assert_failed(std::uint8_t *, std::uint32_t) {
+  Error_Handler();
 }
 #endif
-
-/**
- * @}
- */
-
-/**
- * @}
- */
-

--- a/test/package_tester/stm32h7xx/CM7/Src/main.cpp
+++ b/test/package_tester/stm32h7xx/CM7/Src/main.cpp
@@ -20,8 +20,10 @@
 #include <cstdio>
 #include <cstring>
 
-// Referenced by stm32h7xx_it.c. Keep external linkage.
-UART_HandleTypeDef UartHandle{};
+// Referenced from stm32h7xx_it.c, so the symbol must use C linkage.
+extern "C" {
+  UART_HandleTypeDef UartHandle{};
+}
 
 namespace {
   constexpr std::uint32_t UART_TIMEOUT = HAL_MAX_DELAY;

--- a/test/package_tester/stm32h7xx/CM7/Src/main.cpp
+++ b/test/package_tester/stm32h7xx/CM7/Src/main.cpp
@@ -20,10 +20,12 @@
 #include <cstdio>
 #include <cstring>
 
+// Referenced by stm32h7xx_it.c. Keep external linkage.
+UART_HandleTypeDef UartHandle{};
+
 namespace {
   constexpr std::uint32_t UART_TIMEOUT = HAL_MAX_DELAY;
 
-  UART_HandleTypeDef UartHandle{};
   bool uartReady{false};
   bool ledsReady{false};
 

--- a/test/package_tester/stm32h7xx/H755_INTEGRATION.md
+++ b/test/package_tester/stm32h7xx/H755_INTEGRATION.md
@@ -1,0 +1,97 @@
+# STM32H755 hardware-validation integration
+
+The committed STM32CubeIDE example under `STM32CubeIDE/CM7` targets the
+**STM32H745ZITx / NUCLEO-H745ZI-Q**. Do not reuse its startup assembly, linker
+script, device define, or generated CubeIDE metadata for an STM32H755 image.
+
+The CCSDSPack validation logic itself is board-independent and lives in:
+
+```text
+CM7/Inc/ccsdspack_mcu_test.h
+```
+
+Use that header from a native **STM32H755ZITx / NUCLEO-H755ZI-Q CM7** project.
+
+## Required H755 project setup
+
+Create or use a working STM32H755 CM7 project generated for the exact board and
+retain its own:
+
+- `startup_stm32h755xx.s` startup implementation;
+- STM32H755 system file and HAL configuration;
+- STM32H755 linker script and memory layout;
+- CM4/CM7 boot coordination;
+- board-specific clock and power setup;
+- ST-Link virtual COM UART configuration.
+
+Do not copy `STM32H745ZITX_FLASH.ld` into the H755 project.
+
+## CCSDSPack build compatibility
+
+Build the archive using the same ABI as the H755 CM7 application:
+
+```bash
+./package.sh \
+  -t cmake/toolchains/arm-none-eabi.cmake \
+  -p MCU \
+  -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
+```
+
+The application configuration must use:
+
+- C++17;
+- `CCSDS_MCU`;
+- `-fno-exceptions`;
+- `-fno-rtti`;
+- the same `-mcpu`, `-mfpu`, `-mfloat-abi`, and Thumb settings as the archive;
+- the installed package headers;
+- `libccsdspack.a`, linked as `ccsdspack`.
+
+## Calling the validation core
+
+After the H755 project has completed HAL, clock, memory, UART, and LED
+initialization, run:
+
+```cpp
+#include "ccsdspack_mcu_test.h"
+
+const int result = CCSDSPackMcuTest::run();
+```
+
+Report the result deterministically over UART, debugger memory, or LEDs. The
+release gate expects the equivalent of:
+
+```text
+CCSDSPACK_MCU_TEST:PASS
+```
+
+A non-zero value is one of the documented failure codes in `readme.txt`.
+
+## What remains board-specific
+
+The shared validation core does not configure:
+
+- clocks or voltage scaling;
+- MPU/cache regions;
+- UART pins and peripheral clocks;
+- CM4/CM7 boot synchronization;
+- the linker script, heap, or stack;
+- fault handlers or watchdog behavior.
+
+Those must remain native to the H755 project. This separation is intentional:
+the same packet test is compiled in CI and executed on hardware, while the board
+project remains responsible for proving its own startup, runtime, and memory
+configuration.
+
+## H755 release evidence
+
+Record at least:
+
+1. exact NUCLEO-H755ZI-Q board and STM32H755 device revision;
+2. arm-none-eabi compiler version;
+3. archive/package commit SHA;
+4. CM7 compile and link success;
+5. flash and reset success;
+6. UART or debugger result `CCSDSPACK_MCU_TEST:PASS`;
+7. final ELF flash/RAM/heap/stack usage;
+8. absence of HardFault, MemManage, BusFault, or allocation failure during the test.

--- a/test/package_tester/stm32h7xx/readme.txt
+++ b/test/package_tester/stm32h7xx/readme.txt
@@ -1,150 +1,185 @@
-/**
-  @page UART_WakeUpFromStopUsingFIFO  wake up from STOP mode using UART FIFO level example
-  
-  @verbatim
-  ******************************************************************************
-  * @file    UART/UART_WakeUpFromStopUsingFIFO/readme.txt 
-  * @author  MCD Application Team
-  * @brief   Description of the wake up from STOP mode using UART FIFO level example.
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2018 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  @endverbatim
+CCSDSPack v1.2.0 STM32H745 CM7 hardware validation
+====================================================
 
-@par Example Description
+Purpose
+-------
 
-This example shows how to use UART HAL API to wake up the MCU from STOP mode
-using the UART FIFO level.
+This project validates the CCSDSPack bare-metal static archive on a real
+NUCLEO-H745ZI-Q. It is derived from an STMicroelectronics STM32CubeH7 example,
+but the old UART wake-from-STOP demonstration is no longer part of the test.
+The validation starts automatically after reset.
 
-This CCSDS library test has been extendeed from the Examples/UART example project
-provided by STMicroelectronics git repository link beloew:
-https://github.com/STMicroelectronics/STM32CubeH7
+The HAL-independent validation core is located at:
 
-Follow instructions install STM32CubeIDE and Programmer. 
-NOTE: Make sure all paths are as expected. CCSDSPack is expected to be under middleware.
-The library is built with expected flags.
-Example: Build static library with the following command:
+  CM7/Inc/ccsdspack_mcu_test.h
 
-./package.sh -t cmake/toolchains/arm-none-eabi.cmake -p MCU -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
+The generic arm-none-eabi package build compiles the same core through:
 
-Extract the generated package under Middleware/3rdParty
+  CM7/Src/ccsdspack_mcu_compile_probe.cpp
 
-Fix paths and build stm32 project. Program the device and test.
+That compile-only check catches stale API calls and MCU preprocessor errors.
+Only execution on the STM32 validates startup, final linking, C++ runtime,
+heap behavior, UART reporting, and operation on silicon.
 
-connect to device using ST-Link via
+Target
+------
 
-picocom -b 9600 -d 7 -p o -f n /dev/ttyACM0
+- Board: NUCLEO-H745ZI-Q
+- Device: STM32H745ZITx
+- Core under test: Cortex-M7
+- CPU flags: cortex-m7, Thumb, FPv5-D16, hard-float ABI
+- Language: C++17
+- Exceptions: disabled
+- RTTI: disabled
 
-Once this has been achieved any button can be hit to start CCSDS pack auto tester.
+Build the MCU package
+---------------------
 
-Producer notes continued:
+From the CCSDSPack repository root:
 
-Board: NUCLEO-H745ZI-Q
-Tx Pin: PD.8
-Rx Pin: PD.9
-   _________________________
-  |           ______________|                       _______________
-  |          |USART         |                      | HyperTerminal |
-  |          |              |                      |               |
-  |          |           TX |______________________|RX             |
-  |          |              |                      |               |
-  |          |              |     ST-Link Cable    |               |
-  |          |              |                      |               |
-  |          |           RX |______________________|TX             |
-  |          |              |                      |               |
-  |          |______________|                      |_______________|
-  |                         |
-  |                         |
-  |                         |
-  |                         |
-  |_STM32_Board_____________|
+  ./package.sh \
+    -t cmake/toolchains/arm-none-eabi.cmake \
+    -p MCU \
+    -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
 
-LED1 is ON when MCU is not in STOP mode.
-LED3 is ON when there is an error occurrence.
+The archive contains the installed public headers and `libccsdspack.a`.
+The application and library must use the same CPU, FPU, float-ABI, exception,
+RTTI, and `CCSDS_MCU` settings.
 
-The UART is configured as follows:
-    - BaudRate = 9600 baud  
-    - Word Length = 8 Bits (7 data bit + 1 parity bit)
-    - One Stop Bit
-    - Odd parity
-    - Hardware flow control disabled (RTS and CTS signals)
-    - Reception and transmission are enabled in the time
+STM32CubeIDE configuration
+--------------------------
 
-@note USARTx/UARTx instance used and associated resources can be updated in "main.h"
-      file depending hardware configuration used.
+Extract or copy the package into a stable directory. A convenient project-local
+layout is:
 
-@note When the parity is enabled, the computed parity is inserted at the MSB
-      position of the transmitted data.
+  test/package_tester/stm32h7xx/
+    Middlewares/Third_Party/CCSDSPack/
+      include/CCSDSPack.h
+      lib/libccsdspack.a
 
-@note Care must be taken when using HAL_Delay(), this function provides accurate delay (in milliseconds)
-      based on variable incremented in SysTick ISR. This implies that if HAL_Delay() is called from
-      a peripheral ISR process, then the SysTick interrupt must have higher priority (numerically lower)
-      than the peripheral interrupt. Otherwise the caller ISR process will be blocked.
-      To change the SysTick interrupt priority you have to use HAL_NVIC_SetPriority() function.
-      
-@note The application needs to ensure that the SysTick time base is always set to 1 millisecond
-      to have correct HAL operation.
+For both Debug and Release CM7 configurations, verify these settings in
+STM32CubeIDE. Do not rely on paths generated on another workstation.
 
-@Note If the  application is using the DTCM/ITCM memories (@0x20000000/ 0x0000000: not cacheable and only accessible
-      by the Cortex M7 and the �MDMA), no need for cache maintenance when the Cortex M7 and the MDMA access these RAMs.
-����� If the application needs to use DMA(or other masters) based access or requires more RAM, then �the user has to:
-����������� � - Use a non TCM SRAM. (example : D1 AXI-SRAM @ 0x24000000)
-����������� � - Add a cache maintenance mechanism to ensure the cache coherence between CPU and other masters(DMAs,DMA2D,LTDC,MDMA).
-�������       - The addresses and the size of cacheable buffers (shared between CPU and other masters)
-                must be	properly�defined to be aligned to L1-CACHE line size (32 bytes). 
-�
-@Note It is recommended to enable the cache and maintain its coherence.
-      Depending on the use case it is also possible to configure the cache attributes using the MPU.
-������Please refer to the AN4838 "Managing memory protection unit (MPU) in STM32 MCUs"
-������Please refer to the AN4839 "Level 1 cache on STM32F7 Series"
+C++ compiler:
 
-@par Keywords
+- Preprocessor symbol: `CCSDS_MCU`
+- Include path from the CM7 build directory:
 
-Connectivity, UART, Baud rate, RS-232, Full-duplex, Parity, Stop bit, Transmission, Reception, FIFO, Threshold, Interruption, STOP, Low power, Wakeup, HyperTerminal
+    ../../../Middlewares/Third_Party/CCSDSPack/include
 
-@par Directory contents 
+- Language standard: GNU C++17 or C++17
+- Other flags:
 
-  - UART/UART_WakeUpFromStopUsingFIFO/Inc/stm32h7xx_hal_conf.h    HAL configuration file
-  - UART/UART_WakeUpFromStopUsingFIFO/Inc/stm32h7xx_it.h          Interrupt handlers header file
-  - UART/UART_WakeUpFromStopUsingFIFO/Inc/main.h                  Header for main.c module
-  - UART/UART_WakeUpFromStopUsingFIFO/Src/stm32h7xx_it.c          Interrupt handlers
-  - UART/UART_WakeUpFromStopUsingFIFO/Src/main.c                  Main program
-  - UART/UART_WakeUpFromStopUsingFIFO/Src/stm32h7xx_hal_msp.c     HAL MSP module
-  - UART/UART_WakeUpFromStopUsingFIFO/Src/system_stm32h7xx.c      STM32H7xx system source file
+    -fno-exceptions -fno-rtti -fno-use-cxa-atexit
 
+C++ linker:
 
-@par Hardware and Software environment
+- Library search path from the CM7 build directory:
 
-  - This example runs on STM32H745xx devices.
-    
-  - This example has been tested with NUCLEO-H745ZI-Q board and can be
-    easily tailored to any other supported device and development board.
+    ../../../Middlewares/Third_Party/CCSDSPack/lib
 
-  - NUCLEO-H745ZI-Q Set-up
-      Connect a USB cable between the ST-Link usb connector CN1
-	  and PC todisplay data on the HyperTerminal.
+- Library name:
 
-  - Hyperterminal configuration:
-    - Data Length = 7 Bits
-    - One Stop Bit
-    - Odd parity
-    - BaudRate = 9600 baud
-    - Flow control: None
+    ccsdspack
 
-@par How to use it ? 
+This corresponds to `libccsdspack.a`. The obsolete library name
+`ccsdspack_mcu` is not produced by the current CMake build.
 
-In order to make the program work, you must do the following :
- - Open your preferred toolchain
- - Rebuild all files and load your image into target memory
- - Run the example
+Important: older committed/generated STM32CubeIDE metadata may contain absolute
+`/home/dev/...` paths. Replace them with the project-local paths above before
+building. Generated Debug/Release makefiles and compile_commands files should
+not be treated as portable configuration.
 
+Memory model
+------------
 
- */
+CCSDSPack's API is exception-free, but it is not allocation-free. The library
+and this validation use `std::vector`, `std::string`, `std::shared_ptr`, and the
+secondary-header factory. A working newlib heap and sufficient RAM are required.
+
+The supplied linker script reserves a minimum stack area and permits `_sbrk()`
+to grow the heap from `_end` toward the reserved stack boundary. Review heap and
+stack usage for the final mission application; a successful smoke test is not a
+worst-case memory proof.
+
+Build, flash, and observe
+-------------------------
+
+1. Import/open the dual-core STM32CubeIDE project.
+2. Build the CM7 image with the configuration above.
+3. Flash the board using ST-Link/STM32CubeProgrammer.
+4. Connect to the ST-Link virtual COM port:
+
+     picocom -b 115200 -d 8 -p n -f n /dev/ttyACM0
+
+5. Reset the board.
+
+Expected successful output:
+
+  CCSDSPack STM32H745 CM7 hardware validation
+  Running packet generation, parsing, CRC, Manager, Validator, PVN, and Idle tests...
+  CCSDSPACK_MCU_TEST:PASS
+  Reset the board to run the validation again.
+
+LED behavior:
+
+- LED1: test is running
+- LED2: validation passed
+- LED3: validation or HAL initialization failed
+
+A packet-test failure is printed as:
+
+  CCSDSPACK_MCU_TEST:FAIL:<code>
+
+A board/HAL initialization failure is printed as:
+
+  CCSDSPACK_MCU_TEST:HAL_FAILURE
+
+Failure codes
+-------------
+
+  1  set primary header
+  2  register custom secondary header
+  3  set custom secondary header bytes
+  4  set Manager template
+  5  Manager sequence configuration
+  6  generate application-data packet
+  7  generated wire vector mismatch
+  8  Manager sequence-count advancement
+  9  bounded decode
+  10 consumed-byte count
+  11 decoded logical fields or CRC
+  12 Validator rejected valid packet
+  13 CRC-free primary header
+  14 CRC-free application data
+  15 CRC-free wire vector
+  16 CRC-free bounded decode
+  17 non-zero PVN test setup
+  18 non-zero PVN application data
+  19 non-zero PVN was serialized
+  20 invalid Idle Packet setup
+  21 invalid Idle secondary-header setup
+  22 invalid Idle application data
+  23 invalid Idle Packet was serialized
+  24 valid Idle Packet setup
+  25 valid Idle application data
+  26 valid Idle Packet serialization
+
+What the test covers
+--------------------
+
+- Cortex-M7 consumer compilation with `CCSDS_MCU`
+- custom variable-length secondary-header registration
+- Manager template and automatic sequence-count advancement
+- exact independent CRC16 packet vector
+- bounded parsing and consumed-byte reporting
+- decoded primary-header, secondary-header, application-data, and CRC fields
+- Validator template/coherence checks
+- CRC-disabled packet generation and parsing
+- rejection of non-zero Packet Version Number serialization
+- Idle Packet restrictions and valid Idle Packet generation
+- C++ container/shared-ownership allocation on the configured target runtime
+
+The test does not prove timing bounds, fragmentation behavior over long mission
+operation, worst-case memory use, interrupt safety, thread safety, radiation
+tolerance, or suitability of the project's linker layout for another STM32.


### PR DESCRIPTION
## Summary

Prepares the CCSDSPack v1.2.0 release candidate on top of `develop` for final hardware validation before the maintainer manually merges the validated state to `main`.

This PR is intentionally a **draft targeting `develop`**. Cross-compilation and package creation are automated, but release approval still requires runtime validation on:

- an aarch64 Raspberry Pi using the generated arm64 package;
- the selected STM32H7 Cortex-M7 target using the bare-metal static archive and deterministic packet test.

The included complete CubeIDE harness targets STM32H745ZITx/NUCLEO-H745ZI-Q. For the currently used STM32H755ZITx/NUCLEO-H755ZI-Q, reuse the HAL-independent test core from a native H755 project as documented in `test/package_tester/stm32h7xx/H755_INTEGRATION.md`; do not reuse the H745 startup or linker files.

## Version and release material

- project and package version `1.2.0`;
- exact installed-package consumer gate using `find_package(CCSDSPack 1.2.0 EXACT CONFIG REQUIRED)`;
- `CHANGELOG.md` and tag-ready `docs/releases/v1.2.0.md`;
- release workflow wiring for packages and GHCR publication after a future tag.

## Automated validation complete

Final automated head: `05608aba5e5a7b6bd3c3e7267eb09d55862d8912`.

- [x] Ubuntu 22.04 native build, 93 tests, CLI integration, exact-version installed consumer, native package, arm64 package, and MCU archive generation.
- [x] The Ubuntu 22.04 MCU packaging path compiles and relocatably links the HAL-independent STM32 validation core against `libccsdspack.a` with `arm-none-eabi`, C++17, explicit `CCSDS_MCU`, Cortex-M7 hard-float flags, exceptions disabled, and RTTI disabled.
- [x] Ubuntu 24.04 build, tests, CLI integration, and exact-version installed consumer.
- [x] `ubuntu-latest` build, tests, CLI integration, and exact-version installed consumer.
- [x] Windows MinGW build, 93 tests, CLI integration, installation, exact-version external consumer, and DLL loading.
- [x] Doxygen generation.
- [x] Native DEB, arm64 DEB, and Cortex-M7 TGZ are uploaded as the Actions artifact `ccsdspack-v1.2.0-hardware-ea7fbde4da9791c1282a06412d4a1af0aa9da19e` for 14 days.

## Raspberry Pi validation

Added `test/package_tester/aarch64_validate.sh`.

Run it natively on a 64-bit Raspberry Pi OS installation from this repository checkout:

```bash
bash test/package_tester/aarch64_validate.sh /path/to/ccsdspack-v1.2.0-Linux-arm64.deb
```

It checks the package architecture and version, installs it, then runs:

- the installed `CCSDSPack_tester`;
- encoder/decoder/validator CLI integration using the installed executables;
- an external CMake consumer requiring CCSDSPack 1.2.0 exactly.

The required success marker is:

```text
CCSDSPACK_AARCH64_TEST:PASS
```

## STM32 validation

The previous STM32 source was not a valid v1.2 release test. It used an invalid PVN/type header, stale expected bytes, unsafe comparison, ignored mismatches, depended on an unrelated UART wake-from-STOP flow, and used non-portable CubeIDE paths/library names.

The replacement consists of:

- `CM7/Inc/ccsdspack_mcu_test.h`: HAL-independent deterministic validation core that fails compilation unless `CCSDS_MCU` is explicitly configured;
- `CM7/Src/ccsdspack_mcu_compile_probe.cpp`: compile/link CI consumer;
- `CM7/Src/main.cpp`: STM32H745 CM7 UART/LED hardware harness with correct linkage for the HAL UART handle;
- `readme.txt`: H745 package, CubeIDE, heap/runtime, flash, UART, and failure-code instructions;
- `H755_INTEGRATION.md`: H755-native startup/linker/project integration using the same packet test core.

The on-target suite checks exact CRC16 and CRC-free vectors, Manager sequencing, bounded parsing, decoded fields, Validator, PVN rejection, Idle Packet rules, dynamic C++ allocation, and the configured newlib runtime.

Expected success indication:

```text
CCSDSPACK_MCU_TEST:PASS
```

The included H745 harness uses LED2 for pass and LED3 for packet-test or HAL failure. Other board integrations must provide an equally deterministic result channel. Failures are returned as documented numeric codes.

## Hardware validation still required

- [ ] Raspberry Pi reports `CCSDSPACK_AARCH64_TEST:PASS`.
- [ ] The STM32 project uses the exact target's startup code, linker script, device define, memory map, and dual-core boot flow.
- [ ] STM32CubeIDE configuration uses explicit `CCSDS_MCU`, `libccsdspack.a`, portable package paths, matching Cortex-M7/FPU flags, exceptions disabled, and RTTI disabled.
- [ ] The CM7 image builds and links against the v1.2.0 MCU archive.
- [ ] The image flashes and starts on the selected STM32H7 board.
- [ ] UART or equivalent deterministic reporting produces `CCSDSPACK_MCU_TEST:PASS`.
- [ ] The configured heap, stack, startup code, C++ runtime, and linker layout operate correctly for the validation workload.

## Maintainer release sequence

1. Complete Raspberry Pi and STM32 hardware validation.
2. Fix target-specific defects in this draft PR.
3. Merge this PR into `develop` after hardware validation passes.
4. Manually merge the validated `develop` state into `main`.
5. Confirm `main` CI.
6. Tag and publish `v1.2.0`.
7. Verify artifacts, then close #95 and #46.

Merging this PR does not publish or tag the release.