### PR TITLE
docs: record Raspberry Pi v1.2 hardware validation

### DIFF
--- a/cmake/tester.cmake
+++ b/cmake/tester.cmake
@@ -15,7 +15,8 @@ set(TEST_RESOURCE_DIR "${CMAKE_SOURCE_DIR}/test/test_resources")
 file(GLOB TEST_SOURCES "${TEST_SOURCE_DIR}/*.cpp")
 
 
-# Collect all test test_resources from the test/test_resources directory
+# Collect the regression-test fixtures used only by CCSDSPack_tester.
+# They are not runtime data or dependencies of libccsdspack or the CLI tools.
 file(GLOB TEST_RESOURCES "${TEST_RESOURCE_DIR}/*")
 
 file(MAKE_DIRECTORY "${BINARY_OUTPUT_DIR}/test_resources")
@@ -55,6 +56,8 @@ install(TARGETS ${TESTER_EXEC}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# Install test_resources to the bin directory
+# Install tester-only fixtures next to CCSDSPack_tester because the current
+# regression suite resolves them through relative test_resources/... paths.
+# Consumers of CCSDSPack do not depend on this directory.
 install(DIRECTORY ${TEST_RESOURCE_DIR}
         DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -31,6 +31,8 @@ rpmbuild --version
 
 ## Installing a DEB
 
+System package installation requires root permissions:
+
 ```bash
 sudo dpkg -i packages/ccsdspack-v<version>-Linux-<architecture>.deb
 ```
@@ -47,6 +49,20 @@ Remove it with:
 ```bash
 sudo dpkg --remove ccsdspack
 ```
+
+## Installed test fixtures
+
+Packages that include `CCSDSPack_tester` also install a sibling `test_resources` directory under the executable installation directory. The tester uses relative `test_resources/...` paths for committed fixtures and temporary file-I/O round trips.
+
+These resources belong only to the regression tester. They are not a dependency of:
+
+- `libccsdspack`;
+- `ccsds_encoder`;
+- `ccsds_decoder`;
+- `ccsds_validator`;
+- applications linking `ccsdspack::CCSDSPack`.
+
+Applications must not treat the installed test resources as public runtime data or API assets.
 
 ## CMake package consumption
 
@@ -74,7 +90,7 @@ bash test/package_tester/aarch64_validate.sh "$ARM64_DEB" \
   2>&1 | tee ~/ccsdspack-aarch64-validation.log
 ```
 
-Run the script as a normal user. It invokes `sudo` internally only for `dpkg -i` and executes file-writing regression tests from a writable temporary directory.
+Launch the script as a normal user. It invokes `sudo dpkg -i` because package installation requires root permissions. It then copies the installed test-only fixtures into a writable temporary directory, preserves their expected relative layout, and runs the tester unprivileged without writing into `/bin`.
 
 The required final marker is:
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -19,7 +19,7 @@ Supported options:
 
 Successful packages are written under `packages/`.
 
-Do not build with `sudo`. Root privileges are only required when installing or removing a system package. Building as root creates root-owned repository files and contributes nothing except future irritation.
+Do not build with `sudo`. Root privileges are only required when installing or removing a system package. Building as root can leave root-owned files in the repository checkout.
 
 ### RPM prerequisite
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -1,64 +1,95 @@
 # Packages
 
-[../](README.md) - CCSDSPack Documentation
+[Documentation index](README.md) | [Cross-build guide](CROSSBUILD.md) | [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md)
 
-## Linux
-A sample bash script has been prepared to generate .deb package using cpack.
+## Linux packages
 
-The script can be launched using the following command, note for generation
-super/user privileges might be required. In that case use `sudo` command 
-before running `bash`.
+`package.sh` configures the project, builds it, and invokes CPack. Run the build as a normal user:
 
 ```bash
-
-bash package.sh
+./package.sh -p DEB
 ```
-Parameters can be passed to the package.sh script:
-- `-p` or `--package-type` : to specify type of package to build `[DEB, RPM, TGZ, MCU]`, default `DEB`.
-- `-t` or `--toolchain` : optionally to specify toolchain file for cross builds, default is none i.e. use system.
-- `-m` or `--mcu-flags` : optionally and if MCU type is used, custom flags can be provided. 
-- `--help` : prints the help menu and examples.
 
-***NOTE:*** For cross-build prerequisites and setup, see the consolidated [Cross-Build Guide](CROSSBUILD.md).
+Supported options:
 
-If successful, the generated package will be placed under the `packages` directory.
+- `-p` or `--package-type`: package type, one of `DEB`, `RPM`, `TGZ`, or `MCU`; default is `DEB`.
+- `-t` or `--toolchain`: optional CMake toolchain file for cross-builds.
+- `-m` or `--mcu-flags`: additional MCU compiler flags when producing an `MCU` package.
+- `--help`: show command usage and examples.
 
-to build RPM packages, please make sure that rpm is installed.
+Successful packages are written under `packages/`.
+
+Do not build with `sudo`. Root privileges are only required when installing or removing a system package. Building as root creates root-owned repository files and contributes nothing except future irritation.
+
+### RPM prerequisite
 
 ```bash
-
 sudo apt-get update
 sudo apt-get install -y rpm
-# sanity check
 rpmbuild --version
-
 ```
 
-On debian system, the generated package can be installed using the following command:
+## Installing a DEB
+
 ```bash
-
-dpkg -i ccsdspack-v{version}-{system}-{architecture}.deb
+sudo dpkg -i packages/ccsdspack-v<version>-Linux-<architecture>.deb
 ```
 
-and uninstalled using `dpkg`
+Inspect the installed package:
+
 ```bash
-
-dpkg --remove ccsdspack
+dpkg -s ccsdspack
+dpkg -L ccsdspack
 ```
-Once installed, cmake `find_package()` can be used to find the library and link it as follows:
+
+Remove it with:
+
+```bash
+sudo dpkg --remove ccsdspack
+```
+
+## CMake package consumption
+
+After installation, use the exported CMake package:
+
 ```cmake
-
 find_package(CCSDSPack CONFIG REQUIRED)
 target_link_libraries(my_app PRIVATE ccsdspack::CCSDSPack)
 ```
 
-### Cross-build
-For cross-compilation to aarch64/arm64 (Linux) and for MCU targets, please refer to the consolidated guide:
+A release consumer can require the exact version:
 
-- [Cross-Build Guide (aarch64 Linux and Bare-metal MCU)](CROSSBUILD.md)
+```cmake
+find_package(CCSDSPack 1.2.0 EXACT CONFIG REQUIRED)
+```
 
-It contains per-Ubuntu release prerequisites (22.04 vs 20.04), toolchain setup, and `package.sh` examples.
+## Raspberry Pi arm64 validation
 
-### Bare-metal
-For bare-metal cross-compilation and static library, see the [Cross-Build Guide](CROSSBUILD.md).
+On a native 64-bit Raspberry Pi system, run the complete installed-package validation from a checkout matching the package candidate:
 
+```bash
+ARM64_DEB="$(find ./packages -type f -name '*arm64*.deb' -print -quit)"
+
+bash test/package_tester/aarch64_validate.sh "$ARM64_DEB" \
+  2>&1 | tee ~/ccsdspack-aarch64-validation.log
+```
+
+Run the script as a normal user. It invokes `sudo` internally only for `dpkg -i` and executes file-writing regression tests from a writable temporary directory.
+
+The required final marker is:
+
+```text
+CCSDSPACK_AARCH64_TEST:PASS
+```
+
+The recorded v1.2 Raspberry Pi 5 result and complete reproduction procedure are in [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md).
+
+## Cross-builds and bare metal
+
+For aarch64 Linux cross-compilation and bare-metal Cortex-M packaging, see the [Cross-build guide](CROSSBUILD.md). It documents toolchain prerequisites and `package.sh` examples.
+
+The STM32H745 reference harness and STM32H755-native integration guidance are under:
+
+```text
+test/package_tester/stm32h7xx/
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ CCSDSPack is a C++17 library for creating, serializing, parsing, validating, and
 ## Integration and delivery
 
 - [Packages](PACKAGES.md): native packages and CMake package consumption.
+- [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md): Raspberry Pi arm64 evidence, reproduction procedure, and STM32 validation status.
 - [Cross-build guide](CROSSBUILD.md): aarch64 Linux and bare-metal Cortex-M builds.
 - [Legacy cross-compilation notes](CROSSCOMPILE.md): older environment-specific guidance retained for reference.
 - [Container image](../docker/README.md): Docker build and runtime usage.

--- a/docs/V1_2_HARDWARE_VALIDATION.md
+++ b/docs/V1_2_HARDWARE_VALIDATION.md
@@ -1,0 +1,165 @@
+<!--
+Copyright 2025-2026 ExoSpaceLabs
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CCSDSPack v1.2 hardware validation
+
+[Documentation index](README.md) | [Packages](PACKAGES.md) | [v1.2 release notes](releases/v1.2.0.md)
+
+This page records the release-candidate hardware evidence for CCSDSPack v1.2.0 and provides the repeatable validation procedure. Hardware execution complements the Linux and Windows CI evidence; it does not extend the compliance claim beyond the CCSDS Space Packet PDU profile described in [COMPLIANCE.md](../COMPLIANCE.md).
+
+## Status
+
+| Target | Status | Required marker |
+|---|---|---|
+| Raspberry Pi 5, native arm64 Linux | **PASS** | `CCSDSPACK_AARCH64_TEST:PASS` |
+| STM32H755ZITx / NUCLEO-H755ZI-Q CM7 | Pending | `CCSDSPACK_MCU_TEST:PASS` |
+
+The Raspberry Pi release gate is accepted. The STM32H755 CM7 execution test is the remaining hardware-validation gate.
+
+## Raspberry Pi 5 validation record
+
+Validation date: **2026-07-26**
+
+### Platform
+
+- Board: Raspberry Pi 5
+- Host name: `exn-cam`
+- Architecture: `aarch64`
+- Operating system: Debian GNU/Linux 13.5 (`trixie`), 64-bit
+- Kernel: `6.18.34+rpt-rpi-2712`
+- C++ compiler used by the external consumer: GNU C++ 14.2.0
+
+### Candidate and package
+
+- Source commit: `761e64d9ac912ea2504b0f1462118ce71c6b56cb`
+- Package: `ccsdspack`
+- Package version: `1.2.0`
+- Package architecture: `arm64`
+- Package file: `ccsdspack-v1.2.0-Linux-arm64.deb`
+- SHA-256: `066993bd8355fef2c8fa57e0a0058efa7886da52ef84ee7015b93d9480505fdf`
+
+An arm64 DEB transferred to the Raspberry Pi installed successfully and its installed `CCSDSPack_tester` passed all 93 tests. Because the downloadable workflow artifact was not available during the final evidence run, the repository was then checked out at the exact candidate commit and the DEB was rebuilt natively on the Raspberry Pi using the same `package.sh`/CPack packaging path. The complete validation script was run against that package.
+
+### Results
+
+The complete native validation passed:
+
+- installed regression tester: **93 passed, 0 failed**;
+- installed encoder/decoder/validator integration suite: **PASS**;
+- external CMake consumer resolved the installed package as CCSDSPack `1.2.0` and built successfully;
+- external consumer CTest result: **1 passed, 0 failed**;
+- final marker: `CCSDSPACK_AARCH64_TEST:PASS`.
+
+The test covers native package installation, dynamic-library loading, packet regression and conformance behaviour, installed command-line tools, CMake package metadata, exact-version resolution, external compilation, linking, and execution on Raspberry Pi arm64.
+
+### Privilege note
+
+The recorded full validation was launched with `sudo bash` because the original script changed its working directory to the installed executable directory, `/bin`. Test 14 and other file-I/O checks create relative temporary files, so an ordinary user could not write there and four tests failed.
+
+This was a validation-script working-directory defect, not a CCSDSPack runtime or package defect. Running as root does not change packet serialization, parsing, CRC, CLI integration, CMake discovery, or external-consumer results, so the recorded PASS remains valid.
+
+The script has been corrected to execute `CCSDSPack_tester` from a writable temporary directory. Future validation runs must launch the script as a normal user; the script invokes `sudo` only for `dpkg -i`.
+
+## Reproducing the Raspberry Pi validation
+
+### 1. Check out the candidate
+
+```bash
+git clone https://github.com/ExoSpaceLabs/CCSDSPack.git
+cd CCSDSPack
+git checkout <candidate-commit>
+```
+
+Confirm that the host is native arm64:
+
+```bash
+uname -m
+```
+
+Expected:
+
+```text
+aarch64
+```
+
+### 2. Obtain or build the package
+
+Use the arm64 DEB produced by CI, or build it natively on the Raspberry Pi:
+
+```bash
+./package.sh -p DEB
+```
+
+Building the package does not require root privileges. The resulting package is placed under `packages/`.
+
+```bash
+ARM64_DEB="$(find ./packages -type f -name '*arm64*.deb' -print -quit)"
+```
+
+### 3. Record package metadata
+
+```bash
+dpkg-deb -f "$ARM64_DEB" Package
+dpkg-deb -f "$ARM64_DEB" Version
+dpkg-deb -f "$ARM64_DEB" Architecture
+sha256sum "$ARM64_DEB"
+```
+
+Required metadata:
+
+```text
+Package: ccsdspack
+Version: 1.2.0
+Architecture: arm64
+```
+
+### 4. Run the complete validation as a normal user
+
+```bash
+bash test/package_tester/aarch64_validate.sh "$ARM64_DEB" \
+  2>&1 | tee ~/ccsdspack-aarch64-validation.log
+```
+
+Do not prefix the command with `sudo`. The script uses `sudo` only to install the package.
+
+The required final line is:
+
+```text
+CCSDSPACK_AARCH64_TEST:PASS
+```
+
+### 5. Preserve release evidence
+
+Record:
+
+```bash
+uname -a
+cat /etc/os-release
+git rev-parse HEAD
+dpkg-deb -f "$ARM64_DEB" Package Version Architecture
+sha256sum "$ARM64_DEB"
+```
+
+Preserve the complete validation log with the release records.
+
+## Acceptance boundary
+
+This result establishes that the v1.2.0 package and installed interfaces execute successfully on the tested Raspberry Pi 5 arm64 environment. It does not claim qualification of every Raspberry Pi model, Linux distribution, kernel, compiler, timing condition, long-duration workload, or future release artifact.
+
+The packages generated by the final `v1.2.0` tag must still be downloaded and checked as part of publication verification.
+
+## STM32 next step
+
+Use the board-independent validation core in:
+
+```text
+test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+```
+
+from a native STM32H755 CM7 project following [H755_INTEGRATION.md](../test/package_tester/stm32h7xx/H755_INTEGRATION.md). Record the board revision, compiler version, candidate commit, archive hash, memory usage, flash/reset result, absence of runtime faults, and final UART marker:
+
+```text
+CCSDSPACK_MCU_TEST:PASS
+```

--- a/docs/V1_2_HARDWARE_VALIDATION.md
+++ b/docs/V1_2_HARDWARE_VALIDATION.md
@@ -54,13 +54,17 @@ The complete native validation passed:
 
 The test covers native package installation, dynamic-library loading, packet regression and conformance behaviour, installed command-line tools, CMake package metadata, exact-version resolution, external compilation, linking, and execution on Raspberry Pi arm64.
 
-### Privilege note
+### Installed test resources and privileges
 
-The recorded full validation was launched with `sudo bash` because the original script changed its working directory to the installed executable directory, `/bin`. Test 14 and other file-I/O checks create relative temporary files, so an ordinary user could not write there and four tests failed.
+The package installs `CCSDSPack_tester` together with a sibling `test_resources` directory under the executable installation directory. These files are regression-test fixtures only. They are not required by `libccsdspack`, the encoder, decoder, validator, or applications that link CCSDSPack.
 
-This was a validation-script working-directory defect, not a CCSDSPack runtime or package defect. Running as root does not change packet serialization, parsing, CRC, CLI integration, CMake discovery, or external-consumer results, so the recorded PASS remains valid.
+The tester intentionally uses relative paths such as `test_resources/core_packet.bin` and `test_resources/myPackets.bin`. It reads committed fixtures from that directory and creates temporary round-trip files there during the file-I/O tests.
 
-The script has been corrected to execute `CCSDSPack_tester` from a writable temporary directory. Future validation runs must launch the script as a normal user; the script invokes `sudo` only for `dpkg -i`.
+The recorded validation was launched with `sudo bash` because the original script ran the installed tester from `/bin`. The installed `/bin/test_resources` directory is root-owned, so an ordinary user could read the fixtures but could not create the temporary test files. Four tests consequently failed without elevation.
+
+This was a validation-harness working-directory and permissions issue, not a CCSDSPack library or package failure. The root-run PASS remains valid because elevation did not change packet serialization, parsing, CRC behaviour, CLI integration, CMake discovery, or external-consumer execution.
+
+The validation script now copies the installed `test_resources` fixtures into a writable temporary work directory while preserving the expected relative layout, runs `CCSDSPack_tester` there as the invoking user, and removes the copy afterward. Package installation still requires root permissions; the script invokes `sudo dpkg -i` for that operation only.
 
 ## Reproducing the Raspberry Pi validation
 
@@ -115,14 +119,14 @@ Version: 1.2.0
 Architecture: arm64
 ```
 
-### 4. Run the complete validation as a normal user
+### 4. Run the complete validation
 
 ```bash
 bash test/package_tester/aarch64_validate.sh "$ARM64_DEB" \
   2>&1 | tee ~/ccsdspack-aarch64-validation.log
 ```
 
-Do not prefix the command with `sudo`. The script uses `sudo` only to install the package.
+Launch the script as a normal user. It requests elevation for `dpkg -i`, because system package installation requires root permissions, then runs all validation tests unprivileged from writable locations.
 
 The required final line is:
 

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -10,6 +10,8 @@ Run this script from a CCSDSPack source checkout on an aarch64/arm64 Linux
 system, such as a 64-bit Raspberry Pi OS installation. It installs the package,
 runs the installed regression tester and CLI integration suite, then builds and
 runs an external CMake consumer against the installed package metadata.
+
+Run the script as a normal user. It invokes sudo only for package installation.
 EOF
 }
 
@@ -27,12 +29,16 @@ case "$(uname -m)" in
     ;;
 esac
 
-for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath; do
+for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath mktemp; do
   command -v "${tool}" >/dev/null || {
     echo "ERROR: required command not found: ${tool}" >&2
     exit 4
   }
 done
+
+if [[ ${EUID} -eq 0 ]]; then
+  echo "WARNING: run this script as a normal user; it invokes sudo only for dpkg." >&2
+fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
@@ -108,9 +114,12 @@ for executable in "${tester}" "${encoder}" "${decoder}" "${validator}"; do
   fi
 done
 
+validation_work_dir="$(mktemp -d "${TMPDIR:-/tmp}/ccsdspack-aarch64-validation.XXXXXX")"
+trap 'rm -rf "${validation_work_dir}"' EXIT
+
 echo "Running installed native regression tester"
 (
-  cd "${bin_dir}"
+  cd "${validation_work_dir}"
   "${tester}"
 )
 

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -11,7 +11,8 @@ system, such as a 64-bit Raspberry Pi OS installation. It installs the package,
 runs the installed regression tester and CLI integration suite, then builds and
 runs an external CMake consumer against the installed package metadata.
 
-Run the script as a normal user. It invokes sudo only for package installation.
+Run the script as a normal user. Package installation still requires elevation,
+so the script invokes sudo for dpkg -i and runs the tests unprivileged.
 EOF
 }
 
@@ -29,7 +30,7 @@ case "$(uname -m)" in
     ;;
 esac
 
-for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath mktemp; do
+for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath mktemp cp; do
   command -v "${tool}" >/dev/null || {
     echo "ERROR: required command not found: ${tool}" >&2
     exit 4
@@ -37,7 +38,7 @@ for tool in sudo dpkg dpkg-deb cmake python3 ctest g++ realpath mktemp; do
 done
 
 if [[ ${EUID} -eq 0 ]]; then
-  echo "WARNING: run this script as a normal user; it invokes sudo only for dpkg." >&2
+  echo "WARNING: launch this script as a normal user; it elevates only dpkg -i." >&2
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -99,6 +100,10 @@ cmake_config="$(find_installed '/cmake/CCSDSPack/CCSDSPackConfig.cmake$')" || {
   echo "ERROR: installed CCSDSPackConfig.cmake not found" >&2
   exit 12
 }
+test_resources="$(find_installed '/test_resources$')" || {
+  echo "ERROR: installed CCSDSPack_tester resources not found" >&2
+  exit 13
+}
 library_file="$(find_installed '/libccsdspack\.so(\.1(\.2\.0)?)?$' || true)"
 
 bin_dir="$(dirname "${tester}")"
@@ -110,12 +115,22 @@ fi
 for executable in "${tester}" "${encoder}" "${decoder}" "${validator}"; do
   if [[ ! -x "${executable}" ]]; then
     echo "ERROR: installed executable is not runnable: ${executable}" >&2
-    exit 13
+    exit 14
   fi
 done
 
+if [[ ! -d "${test_resources}" ]]; then
+  echo "ERROR: installed tester resource path is not a directory: ${test_resources}" >&2
+  exit 15
+fi
+
 validation_work_dir="$(mktemp -d "${TMPDIR:-/tmp}/ccsdspack-aarch64-validation.XXXXXX")"
 trap 'rm -rf "${validation_work_dir}"' EXIT
+
+# CCSDSPack_tester expects test-only fixtures under ./test_resources and also
+# creates temporary files there. Copy the installed fixtures into a writable
+# work directory so the tester remains unprivileged and /bin stays untouched.
+cp -a "${test_resources}" "${validation_work_dir}/test_resources"
 
 echo "Running installed native regression tester"
 (

--- a/test/package_tester/aarch64_validate.sh
+++ b/test/package_tester/aarch64_validate.sh
@@ -130,7 +130,7 @@ trap 'rm -rf "${validation_work_dir}"' EXIT
 # CCSDSPack_tester expects test-only fixtures under ./test_resources and also
 # creates temporary files there. Copy the installed fixtures into a writable
 # work directory so the tester remains unprivileged and /bin stays untouched.
-cp -a "${test_resources}" "${validation_work_dir}/test_resources"
+cp -R "${test_resources}" "${validation_work_dir}/test_resources"
 
 echo "Running installed native regression tester"
 (


### PR DESCRIPTION
## Summary

Records the completed Raspberry Pi 5 arm64 validation for CCSDSPack v1.2.0 and fixes the validation harness so future runs preserve the installed tester resource layout without requiring the tests themselves to run as root.

## Validation evidence

The release candidate was validated on a Raspberry Pi 5 running native aarch64 Debian 13.5 at source commit `761e64d9ac912ea2504b0f1462118ce71c6b56cb`.

Package evidence:

- package: `ccsdspack`;
- version: `1.2.0`;
- architecture: `arm64`;
- SHA-256: `066993bd8355fef2c8fa57e0a0058efa7886da52ef84ee7015b93d9480505fdf`.

Results:

- installed regression tester: 93 passed, 0 failed;
- installed CLI integration suite: passed;
- external CMake consumer resolved `CCSDSPack 1.2.0` and built, linked, and ran;
- final marker: `CCSDSPACK_AARCH64_TEST:PASS`.

## Installed test resources

The package installs `CCSDSPack_tester` together with a sibling `test_resources` directory. The tester expects those fixtures through relative `test_resources/...` paths and also creates temporary round-trip files there.

The directory is test-only. It is not a dependency of `libccsdspack`, the encoder, decoder, validator, or applications linking the library.

## Privilege and working-directory fix

Package installation correctly requires root permissions, so the script continues to invoke `sudo dpkg -i`.

The original validation script then executed `CCSDSPack_tester` from `/bin`. Although the installed fixtures were readable, the tester could not create its temporary files under the root-owned `/bin/test_resources` directory when run by an ordinary user. This caused four file-I/O-related test failures.

The script now:

- locates the installed `test_resources` directory from package metadata;
- copies those fixtures to a writable temporary work directory;
- preserves the required relative `test_resources/...` layout;
- runs the tester unprivileged from that directory;
- removes the temporary copy on exit;
- uses elevation only for package installation.

The recorded root-run PASS remains valid because elevation did not change packet serialization, parsing, CRC, CLI integration, CMake package discovery, or external-consumer execution.

## Documentation

- adds `docs/V1_2_HARDWARE_VALIDATION.md` with the exact platform, candidate, package hash, results, privilege explanation, acceptance boundary, and repeatable procedure;
- explicitly classifies installed `test_resources` as tester fixtures rather than library runtime dependencies;
- links the evidence from the documentation index;
- clarifies that package builds run as a normal user while `dpkg` installation requires root permissions.

After this PR, the STM32H755 CM7 execution result is the remaining hardware-validation gate tracked by #95 and parent #46.