### PR TITLE
feat(CCSDSPack): validate canonical PUS selectors

### DIFF
--- a/V2_TRANSITION_ACCEPTANCE_LIST.md
+++ b/V2_TRANSITION_ACCEPTANCE_LIST.md
@@ -26,6 +26,7 @@
 - [x] Custom headers remain direction-neutral and extensible.
 - [x] Custom and PUS factories are separate.
 - [x] Standards selectors are fixed and cannot be overridden.
+- [x] All four canonical selectors are covered through the string factory path.
 - [x] Factory creation returns fresh mutable objects.
 - [x] Duplicate custom keys and custom `PUS:` keys are rejected.
 
@@ -66,16 +67,16 @@
 
 ## Local validation
 
-- [x] 96 native tests pass.
+- [x] 97 native tests pass.
 - [x] AddressSanitizer and UndefinedBehaviorSanitizer pass.
 - [x] MCU sources compile with `-fno-exceptions -fno-rtti`.
 - [x] `git diff --check` passes.
 
 ## Integration and release gates
 
-- [ ] `v2.0.0-dev` merged into `develop`.
-- [ ] Linux, Windows, and Doxygen CI pass on `develop`.
-- [ ] Installed-consumer/package gates use v2 version expectations.
+- [x] `v2.0.0-dev` merged into `develop` through PR #111.
+- [x] Linux, Windows, and Doxygen CI pass on `develop`.
+- [x] Installed-consumer/package gates use v2 version expectations.
 - [ ] Encoder, decoder, and validator accept/report complete PUS profiles.
 - [ ] Manager higher-level PUS profile workflows are covered.
 - [ ] Fuzz smoke jobs pass.

--- a/V2_TRANSITION_ROADMAP.md
+++ b/V2_TRANSITION_ROADMAP.md
@@ -18,6 +18,7 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 - `SecondaryHeaderFactory` handles custom, direction-neutral extensions.
 - fixed `PusSecondaryHeaderFactory` owns the reserved canonical selectors.
 - both factory paths create fresh mutable instances.
+- all four canonical selector paths are covered directly by the PUS factory tests.
 
 ## Stage 2: Mission profiles — implemented for the codec boundary
 
@@ -44,17 +45,18 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 
 ## Stage 5: Evidence — codec evidence implemented, release evidence ongoing
 
-Completed locally:
+Completed and integrated:
 
-- 96 native tests;
+- 97 native tests, including the four-selector PUS factory matrix;
 - PUS-A/PUS-C fixed byte vectors and negative vectors;
 - ASan/UBSan validation;
 - MCU compile with `-fno-exceptions -fno-rtti`;
-- diff hygiene.
+- diff hygiene;
+- Linux, Windows, and Doxygen workflows on `develop`;
+- installed-package consumer validation with v2 version expectations.
 
 Remaining release-level evidence:
 
-- repository Linux/Windows/Doxygen workflows after integration;
 - installed-package and CLI PUS-profile integration;
 - bounded fuzz smoke jobs;
 - arm64 and STM32 hardware repetition with representative PUS vectors.
@@ -68,8 +70,8 @@ Remaining release-level evidence:
 
 ## Stage 7: Release preparation
 
-1. Merge `v2.0.0-dev` into `develop` and use the existing integration CI.
+1. Continue reviewed v2 changes through pull requests from `v2.0.0-dev` to `develop`.
 2. Resolve integration failures without weakening fixed vectors or profile checks.
-3. Complete remaining CLI/package/fuzz/hardware gates.
+3. Complete remaining CLI/profile/fuzz/hardware gates.
 4. Synchronize release notes and final compliance traceability.
 5. Merge approved `develop` into `main` and tag `v2.0.0` from `main` only.

--- a/inc/CCSDSMissionProfile.h
+++ b/inc/CCSDSMissionProfile.h
@@ -10,27 +10,31 @@
 
 namespace CCSDS {
 
+  /** @brief Packet error-control mode selected by a mission profile. */
   enum class PacketErrorControlMode : std::uint8_t {
-    None = 0,
-    CRC16 = 1
+    None = 0,  ///< No packet error-control field.
+    CRC16 = 1  ///< CRC-16 packet error-control field.
   };
 
+  /** @brief Supported ECSS PUS revisions. */
   enum class PusRevision : std::uint8_t {
-    Unspecified = 0,
-    A = 1,
-    C = 2
+    Unspecified = 0,  ///< No PUS revision selected.
+    A = 1,            ///< ECSS-E-70-41A.
+    C = 2             ///< ECSS-E-ST-70-41C.
   };
 
+  /** @brief Packet direction used by a PUS secondary header. */
   enum class PacketDirection : std::uint8_t {
-    Unspecified = 0,
-    Telemetry = 1,
-    Telecommand = 2
+    Unspecified = 0,  ///< No packet direction selected.
+    Telemetry = 1,    ///< Telemetry packet type.
+    Telecommand = 2   ///< Telecommand packet type.
   };
 
+  /** @brief Supported CCSDS time-code families for PUS telemetry. */
   enum class TimeCodeFormat : std::uint8_t {
-    None = 0,
-    Cuc = 1,
-    Cds = 2
+    None = 0,  ///< No telemetry time code.
+    Cuc = 1,   ///< CCSDS Unsegmented Time Code.
+    Cds = 2    ///< CCSDS Day Segmented Time Code.
   };
 
   /**
@@ -54,11 +58,15 @@ namespace CCSDS {
     std::uint8_t secondaryHeaderSpareOctets{0};
   };
 
+  /** @brief Builds a default PUS profile for one revision and direction. */
   [[nodiscard]] MissionProfile makePusProfile(PusRevision revision,
                                               PacketDirection direction);
+  /** @brief Validates all generic CCSDS and PUS mission-profile fields. */
   [[nodiscard]] ResultBool validateMissionProfile(const MissionProfile &profile);
+  /** @brief Returns whether two mission profiles select identical wire tailoring. */
   [[nodiscard]] bool missionProfilesEqual(const MissionProfile &lhs,
                                           const MissionProfile &rhs);
+  /** @brief Returns the canonical selector for a supported PUS revision and direction. */
   [[nodiscard]] std::string pusSelector(PusRevision revision,
                                         PacketDirection direction);
 

--- a/inc/PusSecondaryHeaderFactory.h
+++ b/inc/PusSecondaryHeaderFactory.h
@@ -10,14 +10,18 @@
 
 namespace CCSDS {
 
-  /** Fixed, non-extensible registry for standards-defined PUS codecs. */
+  /** @brief Fixed, non-extensible registry for standards-defined PUS codecs. */
   class PusSecondaryHeaderFactory {
   public:
+    /** @brief Creates a PUS codec from typed revision and direction values. */
     [[nodiscard]] Result<std::shared_ptr<SecondaryHeaderAbstract>> create(
       PusRevision revision, PacketDirection direction, const MissionProfile &profile) const;
+    /** @brief Creates a PUS codec from its canonical selector. */
     [[nodiscard]] Result<std::shared_ptr<SecondaryHeaderAbstract>> create(
       const std::string &selector, const MissionProfile &profile) const;
+    /** @brief Returns whether a canonical PUS selector is supported. */
     [[nodiscard]] bool typeIsSupported(const std::string &selector) const;
+    /** @brief Returns whether a selector belongs to the reserved PUS namespace. */
     [[nodiscard]] static bool isPusSelector(const std::string &selector) {
       return selector.rfind("PUS:", 0U) == 0U;
     }

--- a/inc/PusSecondaryHeaders.h
+++ b/inc/PusSecondaryHeaders.h
@@ -1,6 +1,10 @@
 // Copyright 2025-2026 ExoSpaceLabs
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @file PusSecondaryHeaders.h
+ * @brief Defines standards-oriented PUS-A and PUS-C TC/TM secondary headers.
+ */
 #ifndef PUS_SECONDARY_HEADERS_H
 #define PUS_SECONDARY_HEADERS_H
 
@@ -12,24 +16,34 @@
 
 namespace CCSDS {
 
+  /** @brief Common profile-aware base for standards-defined PUS headers. */
   class PusSecondaryHeader : public SecondaryHeaderAbstract {
   public:
+    /** @brief Returns the ECSS PUS revision selected by the mission profile. */
     [[nodiscard]] PusRevision getRevision() const { return m_profile.pusRevision; }
+    /** @brief Returns the packet direction selected by the mission profile. */
     [[nodiscard]] PacketDirection getDirection() const { return m_profile.direction; }
+    /** @brief Returns the immutable mission profile used by this header. */
     [[nodiscard]] const MissionProfile &getMissionProfile() const { return m_profile; }
+    /** @brief Returns the canonical PUS revision/direction selector. */
     [[nodiscard]] std::string getType() const override {
       return pusSelector(m_profile.pusRevision, m_profile.direction);
     }
+    /** @brief Identifies this instance as a standards-defined PUS header. */
     [[nodiscard]] bool isPusHeader() const override { return true; }
+    /** @brief Returns whether the supplied profile matches this header exactly. */
     [[nodiscard]] bool matchesMissionProfile(const MissionProfile &profile) const override {
       return missionProfilesEqual(m_profile, profile);
     }
+    /** @brief Compatibility alias for matchesMissionProfile(). */
     [[nodiscard]] bool matchesProfile(const MissionProfile &profile) const {
       return matchesMissionProfile(profile);
     }
+    /** @brief Performs no application-data-derived update for fixed PUS fields. */
     void update(DataField *dataField) override { (void)dataField; }
 
 #ifndef CCSDS_MCU
+    /** @brief Rejects legacy configuration loading for profile-defined PUS headers. */
     ResultBool loadFromConfig(const Config &config) override;
 #endif
 
@@ -48,16 +62,25 @@ namespace CCSDS {
     MissionProfile m_profile;
   };
 
+  /** @brief Shared service and source fields for PUS telecommand headers. */
   class PusTcSecondaryHeader : public PusSecondaryHeader {
   public:
+    /** @brief Returns the four PUS acknowledgement flags. */
     [[nodiscard]] std::uint8_t getAcknowledgementFlags() const { return m_acknowledgementFlags; }
+    /** @brief Returns the PUS service type. */
     [[nodiscard]] std::uint8_t getServiceType() const { return m_serviceType; }
+    /** @brief Returns the PUS service subtype. */
     [[nodiscard]] std::uint8_t getServiceSubtype() const { return m_serviceSubtype; }
+    /** @brief Returns the mission-tailored source identifier. */
     [[nodiscard]] std::uint32_t getSourceId() const { return m_sourceId; }
 
+    /** @brief Sets the four PUS acknowledgement flags. */
     ResultBool setAcknowledgementFlags(std::uint8_t flags);
+    /** @brief Sets the PUS service type. */
     void setServiceType(std::uint8_t value) { m_serviceType = value; }
+    /** @brief Sets the PUS service subtype. */
     void setServiceSubtype(std::uint8_t value) { m_serviceSubtype = value; }
+    /** @brief Sets the source identifier when it fits the mission profile. */
     ResultBool setSourceId(std::uint32_t value);
 
   protected:
@@ -74,16 +97,25 @@ namespace CCSDS {
     std::uint32_t m_sourceId{0};
   };
 
+  /** @brief Shared service, destination, and time fields for PUS telemetry headers. */
   class PusTmSecondaryHeader : public PusSecondaryHeader {
   public:
+    /** @brief Returns the PUS service type. */
     [[nodiscard]] std::uint8_t getServiceType() const { return m_serviceType; }
+    /** @brief Returns the PUS service subtype. */
     [[nodiscard]] std::uint8_t getServiceSubtype() const { return m_serviceSubtype; }
+    /** @brief Returns the mission-tailored destination identifier. */
     [[nodiscard]] std::uint32_t getDestinationId() const { return m_destinationId; }
+    /** @brief Returns the serialized telemetry timestamp bytes. */
     [[nodiscard]] const std::vector<std::uint8_t> &getTimestamp() const { return m_timestamp; }
 
+    /** @brief Sets the PUS service type. */
     void setServiceType(std::uint8_t value) { m_serviceType = value; }
+    /** @brief Sets the PUS service subtype. */
     void setServiceSubtype(std::uint8_t value) { m_serviceSubtype = value; }
+    /** @brief Sets the destination identifier when it fits the mission profile. */
     ResultBool setDestinationId(std::uint32_t value);
+    /** @brief Sets timestamp bytes when their size matches the mission profile. */
     ResultBool setTimestamp(const std::vector<std::uint8_t> &timestamp);
 
   protected:
@@ -100,47 +132,66 @@ namespace CCSDS {
     std::vector<std::uint8_t> m_timestamp{};
   };
 
+  /** @brief ECSS-E-70-41A telecommand secondary header. */
   class PusATcHeader final : public PusTcSecondaryHeader {
   public:
+    /** @brief Constructs a PUS-A telecommand secondary header. */
     explicit PusATcHeader(MissionProfile profile = makePusProfile(
                             PusRevision::A, PacketDirection::Telecommand),
                           std::uint8_t serviceType = 0, std::uint8_t serviceSubtype = 0,
                           std::uint32_t sourceId = 0, std::uint8_t acknowledgementFlags = 0);
+    /** @brief Parses a complete PUS-A telecommand secondary header. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data) override;
+    /** @brief Returns the profile-derived encoded header size. */
     [[nodiscard]] std::uint16_t getSize() const override { return tcSize(); }
+    /** @brief Serializes the PUS-A telecommand secondary header. */
     [[nodiscard]] std::vector<std::uint8_t> serialize() const override;
   };
 
+  /** @brief ECSS-E-ST-70-41C telecommand secondary header. */
   class PusCTcHeader final : public PusTcSecondaryHeader {
   public:
+    /** @brief Constructs a PUS-C telecommand secondary header. */
     explicit PusCTcHeader(MissionProfile profile = makePusProfile(
                             PusRevision::C, PacketDirection::Telecommand),
                           std::uint8_t serviceType = 0, std::uint8_t serviceSubtype = 0,
                           std::uint32_t sourceId = 0, std::uint8_t acknowledgementFlags = 0);
+    /** @brief Parses a complete PUS-C telecommand secondary header. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data) override;
+    /** @brief Returns the profile-derived encoded header size. */
     [[nodiscard]] std::uint16_t getSize() const override { return tcSize(); }
+    /** @brief Serializes the PUS-C telecommand secondary header. */
     [[nodiscard]] std::vector<std::uint8_t> serialize() const override;
   };
 
+  /** @brief ECSS-E-70-41A telemetry secondary header. */
   class PusATmHeader final : public PusTmSecondaryHeader {
   public:
+    /** @brief Constructs a PUS-A telemetry secondary header. */
     explicit PusATmHeader(MissionProfile profile = makePusProfile(
                             PusRevision::A, PacketDirection::Telemetry),
                           std::uint8_t serviceType = 0, std::uint8_t serviceSubtype = 0,
                           std::uint8_t packetSubcounter = 0, std::uint32_t destinationId = 0,
                           std::vector<std::uint8_t> timestamp = {});
+    /** @brief Returns the optional PUS-A packet subcounter. */
     [[nodiscard]] std::uint8_t getPacketSubcounter() const { return m_packetSubcounter; }
+    /** @brief Sets the optional PUS-A packet subcounter. */
     void setPacketSubcounter(std::uint8_t value) { m_packetSubcounter = value; }
+    /** @brief Parses a complete PUS-A telemetry secondary header. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data) override;
+    /** @brief Returns the profile-derived encoded header size. */
     [[nodiscard]] std::uint16_t getSize() const override;
+    /** @brief Serializes the PUS-A telemetry secondary header. */
     [[nodiscard]] std::vector<std::uint8_t> serialize() const override;
 
   private:
     std::uint8_t m_packetSubcounter{0};
   };
 
+  /** @brief ECSS-E-ST-70-41C telemetry secondary header. */
   class PusCTmHeader final : public PusTmSecondaryHeader {
   public:
+    /** @brief Constructs a PUS-C telemetry secondary header. */
     explicit PusCTmHeader(MissionProfile profile = makePusProfile(
                             PusRevision::C, PacketDirection::Telemetry),
                           std::uint8_t serviceType = 0, std::uint8_t serviceSubtype = 0,
@@ -148,12 +199,19 @@ namespace CCSDS {
                           std::uint32_t destinationId = 0,
                           std::uint8_t timeReferenceStatus = 0,
                           std::vector<std::uint8_t> timestamp = {});
+    /** @brief Returns the PUS-C message-type counter. */
     [[nodiscard]] std::uint16_t getMessageTypeCounter() const { return m_messageTypeCounter; }
+    /** @brief Returns the PUS-C time-reference status. */
     [[nodiscard]] std::uint8_t getTimeReferenceStatus() const { return m_timeReferenceStatus; }
+    /** @brief Sets the PUS-C message-type counter. */
     void setMessageTypeCounter(std::uint16_t value) { m_messageTypeCounter = value; }
+    /** @brief Sets the three-bit PUS-C time-reference status. */
     ResultBool setTimeReferenceStatus(std::uint8_t value);
+    /** @brief Parses a complete PUS-C telemetry secondary header. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data) override;
+    /** @brief Returns the profile-derived encoded header size. */
     [[nodiscard]] std::uint16_t getSize() const override;
+    /** @brief Serializes the PUS-C telemetry secondary header. */
     [[nodiscard]] std::vector<std::uint8_t> serialize() const override;
 
   private:

--- a/test/src/testGroupPus.cpp
+++ b/test/src/testGroupPus.cpp
@@ -4,6 +4,7 @@
 #include "PusSecondaryHeaderFactory.h"
 #include "tests.h"
 #include <CCSDSPacket.h>
+#include <array>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -36,18 +37,48 @@ namespace {
 void testGroupPus(TestManager *tester, const std::string &description) {
   std::cout << "  testGroupPus: " << description << std::endl;
 
-  tester->unitTest("PUS factory returns fresh fixed codecs and custom registration reserves PUS:.", [] {
-    CCSDS::PusSecondaryHeaderFactory factory;
-    const auto profile = CCSDS::makePusProfile(CCSDS::PusRevision::C,
-                                               CCSDS::PacketDirection::Telecommand);
-    const auto first = factory.create("PUS:revC:TC", profile);
-    const auto second = factory.create("PUS:revC:TC", profile);
-    if (!first || !second || first.value() == second.value()) return false;
+  tester->unitTest("PUS factory resolves every canonical selector to a fresh matching codec.", [] {
+    struct SelectorCase {
+      const char *selector;
+      CCSDS::PusRevision revision;
+      CCSDS::PacketDirection direction;
+    };
 
+    constexpr std::array<SelectorCase, 4U> cases{{
+      {"PUS:revA:TC", CCSDS::PusRevision::A, CCSDS::PacketDirection::Telecommand},
+      {"PUS:revA:TM", CCSDS::PusRevision::A, CCSDS::PacketDirection::Telemetry},
+      {"PUS:revC:TC", CCSDS::PusRevision::C, CCSDS::PacketDirection::Telecommand},
+      {"PUS:revC:TM", CCSDS::PusRevision::C, CCSDS::PacketDirection::Telemetry}
+    }};
+
+    CCSDS::PusSecondaryHeaderFactory factory;
+    for (const auto &entry : cases) {
+      const auto profile = CCSDS::makePusProfile(entry.revision, entry.direction);
+      const auto first = factory.create(entry.selector, profile);
+      const auto second = factory.create(entry.selector, profile);
+      if (!first || !second || first.value() == second.value()) return false;
+
+      const auto header = std::dynamic_pointer_cast<CCSDS::PusSecondaryHeader>(first.value());
+      if (!header || header->getType() != entry.selector
+          || header->getRevision() != entry.revision
+          || header->getDirection() != entry.direction
+          || !header->matchesMissionProfile(profile)) return false;
+    }
+
+    const auto aTcProfile = CCSDS::makePusProfile(CCSDS::PusRevision::A,
+                                                  CCSDS::PacketDirection::Telecommand);
+    if (factory.create("PUS:revA:TM", aTcProfile)
+        || factory.create("PUS:revB:TC", aTcProfile)
+        || factory.typeIsSupported("PUS:reva:TC")) return false;
+
+    return true;
+  });
+
+  tester->unitTest("Custom header registration rejects the reserved PUS namespace.", [] {
     CCSDS::SecondaryHeaderFactory custom;
     return !custom.registerType<ReservedCustomHeader>()
-           && factory.typeIsSupported("PUS:revA:TC")
-           && !factory.typeIsSupported("PUS:revB:TC");
+           && CCSDS::PusSecondaryHeaderFactory::isPusSelector("PUS:mission:custom")
+           && !CCSDS::PusSecondaryHeaderFactory::isPusSelector("MissionHeader");
   });
 
   tester->unitTest("PUS-A TC matches the ECSS-E-70-41A field layout.", [] {


### PR DESCRIPTION
## Summary

- exercise all four canonical PUS selectors through the public string factory path
- verify fresh codec instances, exact revision/direction matching, case-sensitive rejection, and profile mismatch errors
- add concise Doxygen `@brief` coverage to the public mission-profile, PUS factory, and PUS header API
- synchronize the v2 roadmap and acceptance list with PR #111 and the validated 97-test baseline

## Rationale

The four selectors were implemented by PR #111, but only `PUS:revC:TC` exercised the complete selector-to-factory path. This closes that evidence gap while preserving the split between the fixed PUS factory and the direction-neutral custom-header factory.

## User impact

No wire-format or runtime API behavior changes. The public selector contract is now directly tested and more clearly documented.

## Validation

- native C++17 suite: 97/97
- ASan/UBSan: 97/97 (`detect_leaks=0`; LeakSanitizer is unavailable under the runtime's ptrace wrapper)
- MCU syntax gate: `CCSDS_MCU`, `-fno-exceptions`, `-fno-rtti`
- `git diff --check`

## Tracking

Updates evidence for #56, #68, #85, and #109. Doxygen validation is delegated to the existing PR workflow because Doxygen is not installed in the local runtime.