### PR TITLE
feat(CCSDSPack): standardize secondary header API and add examples

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -84,6 +84,11 @@ jobs:
         run: |
           LD_LIBRARY_PATH="$PWD/build/install/lib:$PWD/build/install/lib64:${LD_LIBRARY_PATH:-}" \
             ctest --test-dir build/package_tester/shared_lib --output-on-failure
+
+      - name: Build and run installed-package examples
+        run: |
+          LD_LIBRARY_PATH="$PWD/build/install/lib:$PWD/build/install/lib64:${LD_LIBRARY_PATH:-}" \
+            ./example/build_examples.sh all "$PWD/build/install"
         
       - name: Install cross and packaging deps (22.04 only)
         if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,3 +95,20 @@ jobs:
           $installPrefix = Join-Path $PWD "build/install"
           $env:PATH = "$(Join-Path $installPrefix 'bin');$env:PATH"
           ctest --test-dir build/package_tester/shared_lib --output-on-failure
+
+      - name: Configure installed-package examples
+        shell: pwsh
+        run: |
+          $installPrefix = Join-Path $PWD "build/install"
+          cmake -S example `
+            -B build/examples/all `
+            -G "MinGW Makefiles" `
+            "-DCMAKE_PREFIX_PATH=$installPrefix"
+
+      - name: Build and run installed-package examples
+        shell: pwsh
+        run: |
+          $installPrefix = Join-Path $PWD "build/install"
+          cmake --build build/examples/all --
+          $env:PATH = "$(Join-Path $installPrefix 'bin');$env:PATH"
+          ctest --test-dir build/examples/all --output-on-failure

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ For a non-standard install prefix:
 cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/install/prefix
 ```
 
+The [`example/`](example/README.md) directory contains independent installed-package
+consumers for a generic packet, a custom secondary header, and PUS-C telecommand
+and telemetry packets.
+Build all of them, or select one by directory name:
+
+```bash
+./example/build_examples.sh all /path/to/install/prefix
+./example/build_examples.sh pus_c_telecommand /path/to/install/prefix
+```
+
 ## C++ example
 
 ```cpp
@@ -285,7 +295,7 @@ auto profile = CCSDS::makePusProfile(
 CCSDS::Packet packet;
 packet.setPrimaryHeader({0, 1, 0, 0x123, CCSDS::UNSEGMENTED, 0, 0});
 packet.setMissionProfile(profile);
-packet.setDataFieldHeader(std::make_shared<CCSDS::PusCTcHeader>(
+packet.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(
   profile, 17, 1, 0x1234, 0x09));
 packet.setApplicationData({0x10, 0x20});
 const auto wire = packet.serialize();

--- a/V2_TRANSITION_ACCEPTANCE_LIST.md
+++ b/V2_TRANSITION_ACCEPTANCE_LIST.md
@@ -63,11 +63,12 @@
 - [x] Legacy configuration selectors rejected with migration guidance.
 - [x] Current tests and diagrams no longer present legacy codecs as supported.
 - [x] `docs/MIGRATION_V1_TO_V2.md` documents API, selector, and wire changes.
+- [x] Public secondary-header APIs and configuration use CCSDS secondary-header terminology.
 - [x] Project version and SOVERSION set to 2.0.0/2.
 
 ## Local validation
 
-- [x] 97 native tests pass.
+- [x] 98 native tests pass.
 - [x] AddressSanitizer and UndefinedBehaviorSanitizer pass.
 - [x] MCU sources compile with `-fno-exceptions -fno-rtti`.
 - [x] `git diff --check` passes.
@@ -77,6 +78,7 @@
 - [x] `v2.0.0-dev` merged into `develop` through PR #111.
 - [x] Linux, Windows, and Doxygen CI pass on `develop`.
 - [x] Installed-consumer/package gates use v2 version expectations.
+- [x] Standalone generic, custom-header, PUS-C TC, and PUS-C TM examples consume the installed package in Linux and Windows CI.
 - [ ] Encoder, decoder, and validator accept/report complete PUS profiles.
 - [ ] Manager higher-level PUS profile workflows are covered.
 - [ ] Fuzz smoke jobs pass.

--- a/V2_TRANSITION_ROADMAP.md
+++ b/V2_TRANSITION_ROADMAP.md
@@ -39,6 +39,7 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 
 - removed the legacy `PusA`, `PusB`, and `PusC` public/runtime classes;
 - removed `PusServices.h/.cpp` and automatic registration;
+- renamed the public attachment, inspection, factory, and primary-header flag APIs to use CCSDS secondary-header terminology;
 - removed current tests and fixtures for the legacy formats;
 - legacy configuration selectors fail with migration guidance;
 - documented the breaking API/wire migration.
@@ -47,13 +48,14 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 
 Completed and integrated:
 
-- 97 native tests, including the four-selector PUS factory matrix;
+- 98 native tests, including the four-selector PUS factory matrix and v2 configuration naming;
 - PUS-A/PUS-C fixed byte vectors and negative vectors;
 - ASan/UBSan validation;
 - MCU compile with `-fno-exceptions -fno-rtti`;
 - diff hygiene;
 - Linux, Windows, and Doxygen workflows on `develop`;
 - installed-package consumer validation with v2 version expectations.
+- standalone generic, custom, PUS-C TC, and PUS-C TM `find_package` examples, built and executed as installed-package consumers on Linux and Windows.
 
 Remaining release-level evidence:
 

--- a/docs/CCSDS_133_0_B_2_PROFILE.md
+++ b/docs/CCSDS_133_0_B_2_PROFILE.md
@@ -122,11 +122,16 @@ CCSDS 133.0-B-2 permits optional secondary-header information. CCSDSPack support
 
 - opaque `BufferHeader` bytes;
 - user-registered secondary-header classes;
-- legacy project-specific `PusA`, `PusB`, and `PusC` classes.
+- standards-oriented `PusATcHeader`, `PusATmHeader`, `PusCTcHeader`, and
+  `PusCTmHeader` classes selected by an explicit `MissionProfile`.
 
-The bundled `PusA`, `PusB`, and `PusC` names are retained for v1 compatibility. Their layouts are not claimed to implement an official ECSS Packet Utilisation Standard revision.
+The v1 project-specific `PusA`, `PusB`, and `PusC` classes are removed. There is
+no PUS-B revision. PUS-A and PUS-C parsing uses the canonical revision/direction
+selectors documented in the [examples](EXAMPLES.md).
 
-The `PusC` byte sequence described as a time-code field is not automatically a conformant CCSDS time code. Mission software must select and validate any required time-code format separately.
+PUS telemetry timestamp presence, family, and encoded width are profile-driven.
+CCSDSPack validates the serialized timestamp width but does not invent mission
+epoch or P-field policy.
 
 ## CCSDSPack CRC16 mission profile
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -68,7 +68,7 @@ A normal v1.2 packet profile can begin with:
 ```ini
 ccsds_version_number:int=0
 ccsds_type:bool=false
-ccsds_data_field_header_flag:bool=false
+ccsds_secondary_header_flag:bool=false
 ccsds_APID:int=0x123
 ccsds_segmented:bool=false
 
@@ -96,7 +96,7 @@ The encoder, decoder, and validator also provide the additive `--packet-error-co
 |---|---|---:|---|
 | `ccsds_version_number` | int | yes | must be `0` for CCSDS 133.0-B-2 Space Packets |
 | `ccsds_type` | bool | yes | `false` telemetry, `true` telecommand |
-| `ccsds_data_field_header_flag` | bool | yes | indicates optional secondary-header presence |
+| `ccsds_secondary_header_flag` | bool | yes | indicates optional secondary-header presence |
 | `ccsds_APID` | int | yes | `0..2047`; `2047` is the Idle Packet APID |
 | `ccsds_segmented` | bool | yes | selects initial segmented or unsegmented template state |
 
@@ -108,7 +108,7 @@ CCSDSPack uses Packet Sequence Count semantics for telemetry and telecommand pac
 
 APID `0x7FF` is reserved for Idle Packets. A valid Idle Packet configuration must:
 
-- set `ccsds_data_field_header_flag` to `false`;
+- set `ccsds_secondary_header_flag` to `false`;
 - set `define_secondary_header` to `false`;
 - include non-empty mission-defined idle bytes in `application_data`.
 
@@ -117,7 +117,7 @@ Example:
 ```ini
 ccsds_version_number:int=0
 ccsds_type:bool=false
-ccsds_data_field_header_flag:bool=false
+ccsds_secondary_header_flag:bool=false
 ccsds_APID:int=0x7FF
 ccsds_segmented:bool=false
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ The existing result-assignment macros may also be used where appropriate.
 
 ## Packet template configuration
 
-A normal v1.2 packet profile can begin with:
+A generic v2 packet profile can begin with:
 
 ```ini
 ccsds_version_number:int=0
@@ -154,14 +154,15 @@ The receiving packet, decoder, or validator must be configured with the expected
 |---|---|---:|
 | `define_secondary_header` | bool | yes |
 | `secondary_header_type` | string | when enabled |
-| `pus_version` | int | legacy PusA/PusB/PusC profiles |
-| `pus_service_type` | int | legacy PusA/PusB/PusC profiles |
-| `pus_service_sub_type` | int | legacy PusA/PusB/PusC profiles |
-| `pus_source_id` | int | legacy PusA/PusB/PusC profiles |
-| `pus_event_id` | int | legacy PusB only |
-| `pus_time_code` | bytes | legacy PusC only |
 
-The built-in `PusA`, `PusB`, and `PusC` layouts are project-specific legacy formats. Their names do not constitute an ECSS PUS compliance claim. `pus_time_code` bytes are not automatically validated as a CCSDS time-code format.
+This configuration path currently constructs generic or registered custom
+secondary headers. The complete PUS mission-profile schema and CLI integration
+remain tracked by issues #79–#83. Use the C++ `MissionProfile` and canonical PUS
+selector APIs for standards PUS packets until that integration is complete.
+
+The v1 `pus_version`, `pus_service_type`, `pus_service_sub_type`, `pus_source_id`,
+`pus_event_id`, and `pus_time_code` keys are no longer consumed. Legacy
+`secondary_header_type=PusA|PusB|PusC` values fail with a migration diagnostic.
 
 ## Packet Data Length
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Examples
 
-[Documentation index](README.md) | [Configuration](CONFIG.md) | [v1.2 profile](CCSDS_133_0_B_2_PROFILE.md)
+[Documentation index](README.md) | [Configuration](CONFIG.md) | [Space Packet profile](CCSDS_133_0_B_2_PROFILE.md)
 
-These examples use the current v1.2 C++17 API. They create CCSDS Space Packets with Packet Version Number `000`. The default packet-error-control profile is the project-specific CRC16 trailer; configure `PacketErrorControlMode::None` explicitly for CRC-free packets.
+These examples use the v2 C++17 API. They create CCSDS Space Packets with Packet Version Number `000`. The default packet-error-control profile is the project-specific CRC16 trailer; configure `PacketErrorControlMode::None` explicitly for CRC-free packets.
 
 ## Build integration
 
@@ -19,6 +19,15 @@ find_package(CCSDSPack CONFIG REQUIRED)
 add_executable(example main.cpp)
 target_link_libraries(example PRIVATE ccsdspack::CCSDSPack)
 target_compile_features(example PRIVATE cxx_std_17)
+```
+
+Four complete installed-package consumers are maintained under [`example/`](../example/README.md).
+Each has its own `CMakeLists.txt` and uses `find_package(CCSDSPack 2.0 CONFIG REQUIRED)`.
+After installing the library, build every example or one target directory:
+
+```bash
+./example/build_examples.sh all /path/to/install/prefix
+./example/build_examples.sh custom_secondary_header /path/to/install/prefix
 ```
 
 ## Create and parse one packet
@@ -210,14 +219,14 @@ if (!consumed) return consumed.error().code();
 
 ## Add an opaque secondary header
 
-For mission-specific bytes that are not one of the legacy typed formats, use the `BufferHeader` path through `setDataFieldHeader()`.
+For mission-specific bytes that are not one of the legacy typed formats, use the `BufferHeader` path through `setSecondaryHeader()`.
 
 ```cpp
 CCSDS::Packet packet;
 packet.setDataFieldSize(1024);
 packet.setPrimaryHeader({0, 0, 1, 0x123, CCSDS::UNSEGMENTED, 0, 0});
 
-const auto secondaryResult = packet.setDataFieldHeader(
+const auto secondaryResult = packet.setSecondaryHeader(
   std::vector<std::uint8_t>{0xAA, 0x55}
 );
 if (!secondaryResult) return secondaryResult.error().code();
@@ -245,7 +254,7 @@ A minimal template configuration is:
 ```ini
 ccsds_version_number:int=0
 ccsds_type:bool=false
-ccsds_data_field_header_flag:bool=false
+ccsds_secondary_header_flag:bool=false
 ccsds_APID:int=0x123
 ccsds_segmented:bool=false
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -219,7 +219,8 @@ if (!consumed) return consumed.error().code();
 
 ## Add an opaque secondary header
 
-For mission-specific bytes that are not one of the legacy typed formats, use the `BufferHeader` path through `setSecondaryHeader()`.
+For mission-specific opaque bytes that do not use a registered typed header, use
+the `BufferHeader` path through `setSecondaryHeader()`.
 
 ```cpp
 CCSDS::Packet packet;
@@ -244,8 +245,6 @@ CCSDS::Packet decoded;
 const auto consumed = decoded.deserializeBounded(wire, 2U);
 if (!consumed) return consumed.error().code();
 ```
-
-The bundled `PusA`, `PusB`, and `PusC` types are legacy project-specific formats, not official ECSS PUS implementations.
 
 ## Use a configuration file
 

--- a/docs/MIGRATION_V1_TO_V2.md
+++ b/docs/MIGRATION_V1_TO_V2.md
@@ -15,12 +15,31 @@ CCSDSPack v2 deliberately breaks the legacy secondary-header API. The old classe
 
 The standards-facing selectors are `PUS:revA:TC`, `PUS:revA:TM`, `PUS:revC:TC`, and `PUS:revC:TM`. The `PUS:` namespace is reserved and cannot be registered by custom headers.
 
+## Secondary-header API naming
+
+v2 uses CCSDS “secondary header” terminology consistently across the public API:
+
+| Removed name | v2 name |
+|---|---|
+| `setDataFieldHeader(...)` | `setSecondaryHeader(...)` |
+| `getDataFieldHeader()` | `getSecondaryHeader()` |
+| `getDataFieldHeaderBytes()` | `getSecondaryHeaderBytes()` |
+| `getDataFieldHeaderFactory()` | `getSecondaryHeaderFactory()` |
+| `getPusDataFieldHeaderFactory()` | `getPusSecondaryHeaderFactory()` |
+| `getDataFieldHeaderFlag()` | `getSecondaryHeaderFlag()` |
+| `setDataFieldHeaderFlag(...)` | `setSecondaryHeaderFlag(...)` |
+
+The packet-template key is likewise renamed from `ccsds_data_field_header_flag` to
+`ccsds_secondary_header_flag`. v2 does not retain aliases for the former names.
+`getSecondaryHeader()` returns a nullable shared pointer; the former unchecked
+reference getter is removed.
+
 ## Construction
 
 Before:
 
 ```cpp
-packet.setDataFieldHeader(std::make_shared<PusC>(...));
+packet.setSecondaryHeader(std::make_shared<PusC>(...));
 ```
 
 After:
@@ -36,7 +55,7 @@ CCSDS::Packet packet;
 if (auto result = packet.setMissionProfile(profile); !result) {
   // handle result.error()
 }
-if (auto result = packet.setDataFieldHeader(
+if (auto result = packet.setSecondaryHeader(
       std::make_shared<CCSDS::PusCTmHeader>(
         profile, 3, 25, 1, 0x0001, 0, std::vector<std::uint8_t>{0, 0, 0, 0}));
     !result) {
@@ -44,7 +63,7 @@ if (auto result = packet.setDataFieldHeader(
 }
 ```
 
-`Packet::setDataFieldHeader(shared_ptr)` now returns `ResultBool`, because profile, namespace, type, and capacity mismatches are checked.
+`Packet::setSecondaryHeader(shared_ptr)` now returns `ResultBool`, because profile, namespace, type, and capacity mismatches are checked.
 
 ## Parsing
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 ExoSpaceLabs
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+project(CCSDSPackExamples LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+
+enable_testing()
+add_subdirectory(basic_packet)
+add_subdirectory(custom_secondary_header)
+add_subdirectory(pus_c_telecommand)
+add_subdirectory(pus_c_telemetry)

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,28 @@
+# CCSDSPack standalone examples
+
+Each example is an independent CMake consumer of an installed CCSDSPack package. None of them links the source-tree target directly.
+
+Install the library, then build every example:
+
+```bash
+cmake -S . -B ../build
+cmake --build ../build
+cmake --install ../build --prefix ../build/install
+
+./example/build_examples.sh all ../build/install
+```
+
+Build one example by directory name:
+
+```bash
+./example/build_examples.sh pus_c_telecommand ../build/install
+```
+
+The installation prefix argument is optional when `CCSDSPACK_PREFIX` or `CMAKE_PREFIX_PATH` already identifies the package. The script builds into `build/examples/<selection>` by default; override that root with `CCSDSPACK_EXAMPLE_BUILD_DIR`.
+
+Available examples:
+
+- `basic_packet`: creates and parses a generic CRC-free Space Packet.
+- `custom_secondary_header`: registers, serializes, and parses a mission-specific header.
+- `pus_c_telecommand`: creates and parses a PUS-C telecommand using `PUS:revC:TC`.
+- `pus_c_telemetry`: creates and parses timestamped PUS-C telemetry using `PUS:revC:TM`.

--- a/example/basic_packet/CMakeLists.txt
+++ b/example/basic_packet/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 ExoSpaceLabs
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(CCSDSPackBasicPacketExample LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+  enable_testing()
+endif()
+
+add_executable(ccsdspack_example_basic_packet main.cpp)
+target_link_libraries(ccsdspack_example_basic_packet PRIVATE ccsdspack::CCSDSPack)
+add_test(NAME example_basic_packet COMMAND ccsdspack_example_basic_packet)

--- a/example/basic_packet/main.cpp
+++ b/example/basic_packet/main.cpp
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPack.h>
+#include <iostream>
+#include <vector>
+
+namespace {
+  int fail(const char *operation, const CCSDS::Error &error) {
+    std::cerr << operation << ": " << error.message() << '\n';
+    return error.code() == CCSDS::NONE ? 1 : error.code();
+  }
+}
+
+int main() {
+  CCSDS::Packet packet;
+  packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+
+  if (const auto result = packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0U, 0U, 0U, 0x123U, CCSDS::UNSEGMENTED, 42U, 0U}); !result) {
+    return fail("setPrimaryHeader", result.error());
+  }
+  if (const auto result = packet.setApplicationData({0x10U, 0x20U, 0x30U}); !result) {
+    return fail("setApplicationData", result.error());
+  }
+
+  const auto wire = packet.serialize();
+  if (wire.empty()) {
+    std::cerr << "serialize: packet finalization failed\n";
+    return 1;
+  }
+
+  CCSDS::Packet decoded;
+  decoded.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+  const auto consumed = decoded.deserializeBounded(wire);
+  if (!consumed) return fail("deserializeBounded", consumed.error());
+
+  if (consumed.value() != wire.size()
+      || decoded.getPrimaryHeader().getAPID() != 0x123U
+      || decoded.getPrimaryHeader().getSequenceCount() != 42U
+      || decoded.getApplicationDataBytes() != std::vector<std::uint8_t>({0x10U, 0x20U, 0x30U})) {
+    std::cerr << "decoded packet differs from the source packet\n";
+    return 1;
+  }
+
+  std::cout << "Generic packet: " << wire.size() << " bytes\n";
+  return 0;
+}

--- a/example/build_examples.sh
+++ b/example/build_examples.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_dir="$(cd "${script_dir}/.." && pwd)"
+selection="${1:-all}"
+install_prefix="${2:-${CCSDSPACK_PREFIX:-}}"
+build_root="${CCSDSPACK_EXAMPLE_BUILD_DIR:-${repository_dir}/build/examples}"
+
+case "${selection}" in
+  all)
+    source_dir="${script_dir}"
+    ;;
+  basic_packet|custom_secondary_header|pus_c_telecommand|pus_c_telemetry)
+    source_dir="${script_dir}/${selection}"
+    ;;
+  *)
+    echo "Usage: $0 [all|basic_packet|custom_secondary_header|pus_c_telecommand|pus_c_telemetry] [install-prefix]" >&2
+    exit 2
+    ;;
+esac
+
+cmake_args=(-S "${source_dir}" -B "${build_root}/${selection}" -DCMAKE_BUILD_TYPE=Release)
+if [[ -n "${install_prefix}" ]]; then
+  cmake_args+=("-DCMAKE_PREFIX_PATH=${install_prefix}")
+  export PATH="${install_prefix}/bin:${PATH}"
+  export LD_LIBRARY_PATH="${install_prefix}/lib:${install_prefix}/lib64:${LD_LIBRARY_PATH:-}"
+  export DYLD_LIBRARY_PATH="${install_prefix}/lib:${install_prefix}/lib64:${DYLD_LIBRARY_PATH:-}"
+fi
+
+cmake "${cmake_args[@]}"
+cmake --build "${build_root}/${selection}" --config Release --parallel
+ctest --test-dir "${build_root}/${selection}" -C Release --output-on-failure

--- a/example/custom_secondary_header/CMakeLists.txt
+++ b/example/custom_secondary_header/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 ExoSpaceLabs
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(CCSDSPackCustomSecondaryHeaderExample LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+  enable_testing()
+endif()
+
+add_executable(ccsdspack_example_custom_secondary_header main.cpp)
+target_link_libraries(ccsdspack_example_custom_secondary_header PRIVATE ccsdspack::CCSDSPack)
+add_test(NAME example_custom_secondary_header COMMAND ccsdspack_example_custom_secondary_header)

--- a/example/custom_secondary_header/main.cpp
+++ b/example/custom_secondary_header/main.cpp
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPack.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+class MissionSecondaryHeader final : public CCSDS::SecondaryHeaderAbstract {
+public:
+  [[nodiscard]] CCSDS::ResultBool deserialize(
+      const std::vector<std::uint8_t> &data) override {
+    if (data.size() != getSize()) {
+      return CCSDS::Error{CCSDS::INVALID_SECONDARY_HEADER_DATA,
+                          "MissionSecondaryHeader requires two bytes"};
+    }
+    m_data = data;
+    return true;
+  }
+
+  void update(CCSDS::DataField *) override {}
+  [[nodiscard]] std::uint16_t getSize() const override { return 2U; }
+  [[nodiscard]] std::vector<std::uint8_t> serialize() const override { return m_data; }
+  [[nodiscard]] std::string getType() const override { return "MissionSecondaryHeader"; }
+#ifndef CCSDS_MCU
+  CCSDS::ResultBool loadFromConfig(const Config &) override { return true; }
+#endif
+
+private:
+  std::vector<std::uint8_t> m_data{0U, 0U};
+};
+
+namespace {
+  int fail(const char *operation, const CCSDS::Error &error) {
+    std::cerr << operation << ": " << error.message() << '\n';
+    return error.code() == CCSDS::NONE ? 1 : error.code();
+  }
+}
+
+int main() {
+  CCSDS::Packet packet;
+  if (const auto result = packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0U, 0U, 0U, 0x321U, CCSDS::UNSEGMENTED, 0U, 0U}); !result) {
+    return fail("setPrimaryHeader", result.error());
+  }
+  if (const auto result = packet.RegisterSecondaryHeader<MissionSecondaryHeader>(); !result) {
+    return fail("RegisterSecondaryHeader", result.error());
+  }
+  if (const auto result = packet.setSecondaryHeader(
+        std::vector<std::uint8_t>{0xA5U, 0x5AU}, "MissionSecondaryHeader"); !result) {
+    return fail("setSecondaryHeader", result.error());
+  }
+  if (const auto result = packet.setApplicationData({0x01U, 0x02U}); !result) {
+    return fail("setApplicationData", result.error());
+  }
+
+  const auto wire = packet.serialize();
+  CCSDS::Packet decoded;
+  if (const auto result = decoded.RegisterSecondaryHeader<MissionSecondaryHeader>(); !result) {
+    return fail("RegisterSecondaryHeader decoder", result.error());
+  }
+  const auto consumed = decoded.deserializeBounded(wire, "MissionSecondaryHeader");
+  if (!consumed) return fail("deserializeBounded", consumed.error());
+
+  const auto secondaryHeader = decoded.getSecondaryHeader();
+  if (consumed.value() != wire.size() || !secondaryHeader
+      || secondaryHeader->serialize() != std::vector<std::uint8_t>({0xA5U, 0x5AU})) {
+    std::cerr << "custom secondary header did not round-trip\n";
+    return 1;
+  }
+
+  std::cout << "Custom secondary header: " << secondaryHeader->getType() << '\n';
+  return 0;
+}

--- a/example/pus_c_telecommand/CMakeLists.txt
+++ b/example/pus_c_telecommand/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 ExoSpaceLabs
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(CCSDSPackPusCTelecommandExample LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+  enable_testing()
+endif()
+
+add_executable(ccsdspack_example_pus_c_telecommand main.cpp)
+target_link_libraries(ccsdspack_example_pus_c_telecommand PRIVATE ccsdspack::CCSDSPack)
+add_test(NAME example_pus_c_telecommand COMMAND ccsdspack_example_pus_c_telecommand)

--- a/example/pus_c_telecommand/main.cpp
+++ b/example/pus_c_telecommand/main.cpp
@@ -1,0 +1,56 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPack.h>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace {
+  int fail(const char *operation, const CCSDS::Error &error) {
+    std::cerr << operation << ": " << error.message() << '\n';
+    return error.code() == CCSDS::NONE ? 1 : error.code();
+  }
+}
+
+int main() {
+  auto profile = CCSDS::makePusProfile(
+    CCSDS::PusRevision::C, CCSDS::PacketDirection::Telecommand);
+  profile.sourceIdOctets = 2U;
+
+  CCSDS::Packet packet;
+  if (const auto result = packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0U, 1U, 0U, 0x123U, CCSDS::UNSEGMENTED, 7U, 0U}); !result) {
+    return fail("setPrimaryHeader", result.error());
+  }
+  if (const auto result = packet.setMissionProfile(profile); !result) {
+    return fail("setMissionProfile", result.error());
+  }
+  if (const auto result = packet.setSecondaryHeader(
+        std::make_shared<CCSDS::PusCTcHeader>(profile, 17U, 1U, 0x1234U, 0x09U)); !result) {
+    return fail("setSecondaryHeader", result.error());
+  }
+  if (const auto result = packet.setApplicationData({0x60U, 0x70U}); !result) {
+    return fail("setApplicationData", result.error());
+  }
+
+  const auto wire = packet.serialize();
+  CCSDS::Packet decoded;
+  if (const auto result = decoded.setMissionProfile(profile); !result) {
+    return fail("setMissionProfile decoder", result.error());
+  }
+  const auto consumed = decoded.deserializeBounded(wire, "PUS:revC:TC");
+  if (!consumed) return fail("deserializeBounded", consumed.error());
+
+  const auto header = std::dynamic_pointer_cast<const CCSDS::PusCTcHeader>(
+    decoded.getSecondaryHeader());
+  if (consumed.value() != wire.size() || !header
+      || header->getServiceType() != 17U || header->getServiceSubtype() != 1U
+      || header->getSourceId() != 0x1234U || header->getAcknowledgementFlags() != 0x09U) {
+    std::cerr << "PUS-C telecommand did not round-trip\n";
+    return 1;
+  }
+
+  std::cout << header->getType() << ": " << wire.size() << " bytes\n";
+  return 0;
+}

--- a/example/pus_c_telemetry/CMakeLists.txt
+++ b/example/pus_c_telemetry/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 ExoSpaceLabs
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(CCSDSPackPusCTelemetryExample LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+  enable_testing()
+endif()
+
+add_executable(ccsdspack_example_pus_c_telemetry main.cpp)
+target_link_libraries(ccsdspack_example_pus_c_telemetry PRIVATE ccsdspack::CCSDSPack)
+add_test(NAME example_pus_c_telemetry COMMAND ccsdspack_example_pus_c_telemetry)

--- a/example/pus_c_telemetry/main.cpp
+++ b/example/pus_c_telemetry/main.cpp
@@ -1,0 +1,64 @@
+// Copyright 2025-2026 ExoSpaceLabs
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CCSDSPack.h>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace {
+  int fail(const char *operation, const CCSDS::Error &error) {
+    std::cerr << operation << ": " << error.message() << '\n';
+    return error.code() == CCSDS::NONE ? 1 : error.code();
+  }
+}
+
+int main() {
+  auto profile = CCSDS::makePusProfile(
+    CCSDS::PusRevision::C, CCSDS::PacketDirection::Telemetry);
+  profile.destinationIdOctets = 2U;
+  profile.telemetryTimestampPresent = true;
+  profile.telemetryTimeCode = CCSDS::TimeCodeFormat::Cuc;
+  profile.telemetryTimeCodeOctets = 4U;
+
+  CCSDS::Packet packet;
+  if (const auto result = packet.setPrimaryHeader(CCSDS::PrimaryHeader{
+        0U, 0U, 0U, 0x456U, CCSDS::UNSEGMENTED, 8U, 0U}); !result) {
+    return fail("setPrimaryHeader", result.error());
+  }
+  if (const auto result = packet.setMissionProfile(profile); !result) {
+    return fail("setMissionProfile", result.error());
+  }
+  if (const auto result = packet.setSecondaryHeader(
+        std::make_shared<CCSDS::PusCTmHeader>(
+          profile, 3U, 25U, 7U, 0x0102U, 5U,
+          std::vector<std::uint8_t>{0x11U, 0x22U, 0x33U, 0x44U})); !result) {
+    return fail("setSecondaryHeader", result.error());
+  }
+  if (const auto result = packet.setApplicationData({0x80U, 0x81U}); !result) {
+    return fail("setApplicationData", result.error());
+  }
+
+  const auto wire = packet.serialize();
+  CCSDS::Packet decoded;
+  if (const auto result = decoded.setMissionProfile(profile); !result) {
+    return fail("setMissionProfile decoder", result.error());
+  }
+  const auto consumed = decoded.deserializeBounded(wire, "PUS:revC:TM");
+  if (!consumed) return fail("deserializeBounded", consumed.error());
+
+  const auto header = std::dynamic_pointer_cast<const CCSDS::PusCTmHeader>(
+    decoded.getSecondaryHeader());
+  if (consumed.value() != wire.size() || !header
+      || header->getServiceType() != 3U || header->getServiceSubtype() != 25U
+      || header->getMessageTypeCounter() != 7U || header->getDestinationId() != 0x0102U
+      || header->getTimeReferenceStatus() != 5U
+      || header->getTimestamp()
+         != std::vector<std::uint8_t>({0x11U, 0x22U, 0x33U, 0x44U})) {
+    std::cerr << "PUS-C telemetry did not round-trip\n";
+    return 1;
+  }
+
+  std::cout << header->getType() << ": " << wire.size() << " bytes\n";
+  return 0;
+}

--- a/inc/CCSDSDataField.h
+++ b/inc/CCSDSDataField.h
@@ -85,7 +85,7 @@ namespace CCSDS {
      * @param sizeData Number of bytes to copy; must be non-zero.
      * @return Success, or a null-pointer, empty-span, or capacity error.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::uint8_t *pData,
                                                 const std::size_t &sizeData);
 
     /**
@@ -95,7 +95,7 @@ namespace CCSDS {
      * @param pType Registered getType() string.
      * @return Success, or a null-pointer, unknown-type, size, or deserialization error.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::uint8_t *pData,
                                                 const std::size_t &sizeData,
                                                 const std::string &pType);
 
@@ -105,22 +105,22 @@ namespace CCSDS {
      * @param pType Registered getType() string.
      * @return Success, or an unknown-type, size, capacity, or deserialization error.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::vector<std::uint8_t> &data,
                                                 const std::string &pType);
 
     /**
      * @brief Stores opaque secondary-header bytes using BufferHeader.
-     * @param dataFieldHeader Header bytes to copy.
+     * @param secondaryHeader Header bytes to copy.
      * @return Success, or INVALID_SECONDARY_HEADER_DATA when capacity is exceeded.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &dataFieldHeader);
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::vector<std::uint8_t> &secondaryHeader);
 #ifndef CCSDS_MCU
     /**
      * @brief Creates and loads a registered secondary header from Config.
      * @param cfg Configuration containing secondary_header_type and type-specific fields.
      * @return Success, or a configuration/registration/header error.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const Config &cfg);
+    [[nodiscard]] ResultBool setSecondaryHeader(const Config &cfg);
 #endif
 
     /**
@@ -128,29 +128,19 @@ namespace CCSDS {
      * @param header Shared instance, or nullptr to remove the secondary header.
      * @note The DataField shares ownership and marks the header dirty for future update().
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(std::shared_ptr<SecondaryHeaderAbstract> header);
+    [[nodiscard]] ResultBool setSecondaryHeader(std::shared_ptr<SecondaryHeaderAbstract> header);
 
     /** @brief Returns mutable access to the per-DataField secondary-header registry. */
-    SecondaryHeaderFactory &getDataFieldHeaderFactory() { return m_secondaryHeaderFactory; }
+    SecondaryHeaderFactory &getSecondaryHeaderFactory() { return m_secondaryHeaderFactory; }
     /** @brief Returns read-only access to the per-DataField secondary-header registry. */
-    [[nodiscard]] const SecondaryHeaderFactory &getDataFieldHeaderFactory() const {
+    [[nodiscard]] const SecondaryHeaderFactory &getSecondaryHeaderFactory() const {
       return m_secondaryHeaderFactory;
     }
 
-    [[nodiscard]] const PusSecondaryHeaderFactory &getPusDataFieldHeaderFactory() const {
+    /** @brief Returns read-only access to the fixed standards PUS codec registry. */
+    [[nodiscard]] const PusSecondaryHeaderFactory &getPusSecondaryHeaderFactory() const {
       return m_pusSecondaryHeaderFactory;
     }
-
-    /**
-     * @brief Returns a reference to the installed secondary header.
-     * @warning Dereferencing is undefined when no header is installed; check getDataFieldHeaderFlag() first.
-     */
-    SecondaryHeaderAbstract &getDataFieldHeader() { return *m_secondaryHeader; }
-    /**
-     * @brief Returns a read-only reference to the installed secondary header.
-     * @warning Dereferencing is undefined when no header is installed; check getDataFieldHeaderFlag() first.
-     */
-    [[nodiscard]] const SecondaryHeaderAbstract &getDataFieldHeader() const { return *m_secondaryHeader; }
 
     /**
      * @brief Sets total capacity shared by secondary-header and application-data bytes.
@@ -163,7 +153,9 @@ namespace CCSDS {
      * @brief Enables or disables calls to SecondaryHeaderAbstract::update().
      * @param enable True to let DataField::update()/serialize() refresh the header.
      */
-    void setDataFieldHeaderAutoUpdateStatus(const bool enable) { m_enableDataFieldUpdate = enable; }
+    void setSecondaryHeaderAutoUpdateStatus(const bool enable) {
+      m_enableSecondaryHeaderUpdate = enable;
+    }
 
     /** @brief Returns configured total packet data-field content capacity. */
     [[nodiscard]] std::uint16_t getDataFieldAbsoluteBytesSize() const;
@@ -178,9 +170,9 @@ namespace CCSDS {
     [[nodiscard]] std::uint16_t getDataFieldAvailableBytesSize() const;
 
     /** @brief Returns currently stored secondary-header bytes without finalizing. */
-    std::vector<std::uint8_t> getDataFieldHeaderBytes();
-    /** @brief Const overload of getDataFieldHeaderBytes(). */
-    [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
+    std::vector<std::uint8_t> getSecondaryHeaderBytes();
+    /** @brief Const overload of getSecondaryHeaderBytes(). */
+    [[nodiscard]] std::vector<std::uint8_t> getSecondaryHeaderBytes() const;
 
     /**
      * @brief Finalizes the secondary header and serializes the complete data-field content.
@@ -194,10 +186,12 @@ namespace CCSDS {
     [[nodiscard]] std::vector<std::uint8_t> getApplicationData() const;
 
     /** @brief Returns whether automatic secondary-header update is enabled. */
-    [[nodiscard]] bool getDataFieldHeaderAutoUpdateStatus() const { return m_enableDataFieldUpdate; }
+    [[nodiscard]] bool getSecondaryHeaderAutoUpdateStatus() const {
+      return m_enableSecondaryHeaderUpdate;
+    }
 
     /** @brief Returns true when a secondary-header object is installed. */
-    [[nodiscard]] bool getDataFieldHeaderFlag() const { return m_secondaryHeader != nullptr; }
+    [[nodiscard]] bool getSecondaryHeaderFlag() const { return m_secondaryHeader != nullptr; }
 
     /** @brief Returns shared mutable ownership of the installed secondary header, or nullptr. */
     std::shared_ptr<SecondaryHeaderAbstract> getSecondaryHeader();
@@ -219,10 +213,10 @@ namespace CCSDS {
     PusSecondaryHeaderFactory m_pusSecondaryHeaderFactory;       ///< Fixed standards PUS codec registry.
     MissionProfile m_missionProfile{};                           ///< Explicit generic/PUS tailoring.
     std::vector<std::uint8_t> m_applicationData{};               ///< Application-data bytes only.
-    std::string m_dataFieldHeaderType{};                         ///< Lookup name of the installed header type.
+    std::string m_secondaryHeaderType{};                         ///< Lookup name of the installed header type.
     std::uint16_t m_dataPacketSize{2024};                        ///< Shared header/data capacity in bytes.
-    bool m_dataFieldHeaderUpdated{false};                        ///< True after the latest explicit update.
-    bool m_enableDataFieldUpdate{true};                          ///< Controls secondary-header update callbacks.
+    bool m_secondaryHeaderUpdated{false};                        ///< True after the latest explicit update.
+    bool m_enableSecondaryHeaderUpdate{true};                    ///< Controls secondary-header update callbacks.
   };
 }
 

--- a/inc/CCSDSHeader.h
+++ b/inc/CCSDSHeader.h
@@ -56,7 +56,7 @@ namespace CCSDS {
   struct PrimaryHeader {
     std::uint8_t versionNumber{};       ///< 3-bit protocol version; Space Packet parsing supports value 0.
     std::uint8_t type{};                ///< 1-bit packet type.
-    std::uint8_t dataFieldHeaderFlag{}; ///< 1-bit secondary-header presence flag.
+    std::uint8_t secondaryHeaderFlag{}; ///< 1-bit secondary-header presence flag.
     std::uint16_t APID{};               ///< 11-bit Application Process Identifier.
     std::uint8_t sequenceFlags{};       ///< 2-bit ESequenceFlag value.
     std::uint16_t sequenceCount{};      ///< 14-bit stream sequence count.
@@ -66,7 +66,7 @@ namespace CCSDS {
      * @brief Constructs a field structure from explicit values.
      * @param versionNumber_value Protocol version.
      * @param type_value Packet type.
-     * @param dataFieldHeaderFlag_value Secondary-header flag.
+     * @param secondaryHeaderFlag_value Secondary-header flag.
      * @param APID_value Application Process Identifier.
      * @param sequenceFlag_value Sequence flags.
      * @param sequenceCount_value Sequence count.
@@ -74,14 +74,14 @@ namespace CCSDS {
      */
     PrimaryHeader(const std::uint8_t versionNumber_value,
                   const std::uint8_t type_value,
-                  const std::uint8_t dataFieldHeaderFlag_value,
+                  const std::uint8_t secondaryHeaderFlag_value,
                   const std::uint16_t APID_value,
                   const std::uint8_t sequenceFlag_value,
                   const std::uint16_t sequenceCount_value,
                   const std::uint16_t dataLength_value)
       : versionNumber(versionNumber_value),
         type(type_value),
-        dataFieldHeaderFlag(dataFieldHeaderFlag_value),
+        secondaryHeaderFlag(secondaryHeaderFlag_value),
         APID(APID_value),
         sequenceFlags(sequenceFlag_value),
         sequenceCount(sequenceCount_value),
@@ -116,7 +116,7 @@ namespace CCSDS {
     /** @brief Returns the stored 1-bit packet type. */
     [[nodiscard]] std::uint8_t getType() const { return m_type; }
     /** @brief Returns the stored 1-bit secondary-header presence flag. */
-    [[nodiscard]] std::uint8_t getDataFieldHeaderFlag() const { return m_dataFieldHeaderFlag; }
+    [[nodiscard]] std::uint8_t getSecondaryHeaderFlag() const { return m_secondaryHeaderFlag; }
     /** @brief Returns the stored 11-bit Application Process Identifier. */
     [[nodiscard]] std::uint16_t getAPID() const { return m_APID; }
     /** @brief Returns the stored 2-bit sequence-flags value. */
@@ -164,7 +164,7 @@ namespace CCSDS {
      * @param value Value 0 or 1.
      * @return Success, or INVALID_HEADER_DATA for any other value.
      */
-    [[nodiscard]] ResultBool setDataFieldHeaderFlag(const std::uint8_t &value);
+    [[nodiscard]] ResultBool setSecondaryHeaderFlag(const std::uint8_t &value);
 
     /**
      * @brief Sets the 11-bit Application Process Identifier.
@@ -221,7 +221,7 @@ namespace CCSDS {
 
     std::uint8_t m_versionNumber{};
     std::uint8_t m_type{};
-    std::uint8_t m_dataFieldHeaderFlag{};
+    std::uint8_t m_secondaryHeaderFlag{};
     std::uint16_t m_APID{};
     std::uint8_t m_sequenceFlags{UNSEGMENTED};
     std::uint16_t m_sequenceCount{};

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -128,7 +128,7 @@ namespace CCSDS {
      * @param header Shared secondary-header instance, or nullptr to remove it.
      * @note The Packet shares ownership of the supplied object. Idle Packets may not serialize with one.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(
+    [[nodiscard]] ResultBool setSecondaryHeader(
       const std::shared_ptr<SecondaryHeaderAbstract> &header);
 
     [[nodiscard]] ResultBool setMissionProfile(const MissionProfile &profile);
@@ -140,7 +140,7 @@ namespace CCSDS {
      * @return Success, or a registration error.
      *
      * The registered object's getType() value is the lookup key used by typed
-     * setDataFieldHeader() and deserializeBounded() overloads.
+     * setSecondaryHeader() and deserializeBounded() overloads.
      */
     template <typename T>
     ResultBool RegisterSecondaryHeader() {
@@ -154,7 +154,7 @@ namespace CCSDS {
      * @param headerType Value returned by the registered type's getType().
      * @return Success, or INVALID_SECONDARY_HEADER_DATA.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::vector<std::uint8_t> &data,
                                                 const std::string &headerType);
 
     /**
@@ -164,7 +164,7 @@ namespace CCSDS {
      * @param headerType Registered type name.
      * @return Success, or an error for a null pointer, size mismatch, or unknown type.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData,
                                                 const std::string &headerType);
 
@@ -173,7 +173,7 @@ namespace CCSDS {
      * @param data Secondary-header bytes.
      * @return Success, or INVALID_SECONDARY_HEADER_DATA when the data exceeds capacity.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::vector<std::uint8_t> &data);
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::vector<std::uint8_t> &data);
 
     /**
      * @brief Stores an opaque raw secondary header from a byte span.
@@ -181,7 +181,7 @@ namespace CCSDS {
      * @param sizeData Number of bytes to copy.
      * @return Success, or an error for a null pointer, empty span, or insufficient capacity.
      */
-    [[nodiscard]] ResultBool setDataFieldHeader(const std::uint8_t *pData,
+    [[nodiscard]] ResultBool setSecondaryHeader(const std::uint8_t *pData,
                                                 std::size_t sizeData);
 
     /**
@@ -349,10 +349,15 @@ namespace CCSDS {
     /** @brief Const overload of getPrimaryHeaderBytes(). */
     [[nodiscard]] std::vector<std::uint8_t> getPrimaryHeaderBytes() const;
 
+    /** @brief Returns shared mutable ownership of the installed secondary header, or nullptr. */
+    std::shared_ptr<SecondaryHeaderAbstract> getSecondaryHeader();
+    /** @brief Returns shared read-only ownership of the installed secondary header, or nullptr. */
+    [[nodiscard]] std::shared_ptr<const SecondaryHeaderAbstract> getSecondaryHeader() const;
+
     /** @brief Returns the currently stored secondary-header bytes without finalizing. */
-    std::vector<std::uint8_t> getDataFieldHeaderBytes();
-    /** @brief Const overload of getDataFieldHeaderBytes(). */
-    [[nodiscard]] std::vector<std::uint8_t> getDataFieldHeaderBytes() const;
+    std::vector<std::uint8_t> getSecondaryHeaderBytes();
+    /** @brief Const overload of getSecondaryHeaderBytes(). */
+    [[nodiscard]] std::vector<std::uint8_t> getSecondaryHeaderBytes() const;
 
     /** @brief Returns a copy of the current application-data bytes without finalizing. */
     std::vector<std::uint8_t> getApplicationDataBytes();
@@ -382,9 +387,9 @@ namespace CCSDS {
     [[nodiscard]] std::uint16_t getDataFieldMaximumSize() const;
 
     /** @brief Returns whether the primary header currently asserts a secondary header. */
-    bool getDataFieldHeaderFlag();
-    /** @brief Const overload of getDataFieldHeaderFlag(). */
-    [[nodiscard]] bool getDataFieldHeaderFlag() const;
+    bool getSecondaryHeaderFlag();
+    /** @brief Const overload of getSecondaryHeaderFlag(). */
+    [[nodiscard]] bool getSecondaryHeaderFlag() const;
 
     /**
      * @brief Returns mutable access to the owned DataField.

--- a/inc/CCSDSSecondaryHeaderAbstract.h
+++ b/inc/CCSDSSecondaryHeaderAbstract.h
@@ -122,7 +122,7 @@ namespace CCSDS {
    * @class BufferHeader
    * @brief Opaque secondary header that stores bytes without interpreting them.
    *
-   * BufferHeader is used by setDataFieldHeader(bytes) and explicit-size parsing
+   * BufferHeader is used by setSecondaryHeader(bytes) and explicit-size parsing
    * overloads. It is suitable when a project needs a secondary-header boundary but
    * no typed decoder. Its registered type name is "DataOnlyHeader".
    */

--- a/src/CCSDSDataField.cpp
+++ b/src/CCSDSDataField.cpp
@@ -7,10 +7,10 @@
 
 std::vector<std::uint8_t> CCSDS::DataField::serialize() {
   update();
-  const auto dataFieldHeader = static_cast<const DataField &>(*this).getDataFieldHeaderBytes();
+  const auto secondaryHeader = static_cast<const DataField &>(*this).getSecondaryHeaderBytes();
   std::vector<std::uint8_t> fullData{};
-  fullData.reserve(dataFieldHeader.size() + m_applicationData.size());
-  fullData.insert(fullData.end(), dataFieldHeader.begin(), dataFieldHeader.end());
+  fullData.reserve(secondaryHeader.size() + m_applicationData.size());
+  fullData.insert(fullData.end(), secondaryHeader.begin(), secondaryHeader.end());
   fullData.insert(fullData.end(), m_applicationData.begin(), m_applicationData.end());
   return fullData;
 }
@@ -51,9 +51,9 @@ std::shared_ptr<const CCSDS::SecondaryHeaderAbstract> CCSDS::DataField::getSecon
 }
 
 void CCSDS::DataField::update() {
-  if (!m_dataFieldHeaderUpdated && m_enableDataFieldUpdate) {
+  if (!m_secondaryHeaderUpdated && m_enableSecondaryHeaderUpdate) {
     if (m_secondaryHeader) m_secondaryHeader->update(this);
-    m_dataFieldHeaderUpdated = true;
+    m_secondaryHeaderUpdated = true;
   }
 }
 
@@ -70,15 +70,15 @@ CCSDS::ResultBool CCSDS::DataField::setMissionProfile(const MissionProfile &prof
     }
   }
   m_missionProfile = profile;
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
 void CCSDS::DataField::clearContent() {
   m_secondaryHeader.reset();
   m_applicationData.clear();
-  m_dataFieldHeaderType.clear();
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderType.clear();
+  m_secondaryHeaderUpdated = false;
 }
 
 CCSDS::ResultBool CCSDS::DataField::setApplicationData(const std::uint8_t *pData,
@@ -93,7 +93,7 @@ CCSDS::ResultBool CCSDS::DataField::setApplicationData(const std::uint8_t *pData
                  "Application data field exceeds available size");
 
   m_applicationData.assign(pData, pData + sizeData);
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
@@ -105,11 +105,11 @@ CCSDS::ResultBool CCSDS::DataField::setApplicationData(
                  ErrorCode::INVALID_APPLICATION_DATA,
                  "Application data field exceeds available size");
   m_applicationData = applicationData;
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(const std::uint8_t *pData,
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(const std::uint8_t *pData,
                                                        const std::size_t &sizeData) {
   RET_IF_ERR_MSG(!pData, ErrorCode::NULL_POINTER, "Secondary header data is nullptr");
   RET_IF_ERR_MSG(sizeData < 1U, ErrorCode::INVALID_SECONDARY_HEADER_DATA,
@@ -119,20 +119,20 @@ CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(const std::uint8_t *pData
                  "Secondary header data exceeds available size");
 
   const std::vector<std::uint8_t> data(pData, pData + sizeData);
-  FORWARD_RESULT(setDataFieldHeader(data));
+  FORWARD_RESULT(setSecondaryHeader(data));
   return true;
 }
 
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(const std::uint8_t *pData,
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(const std::uint8_t *pData,
                                                        const std::size_t &sizeData,
                                                        const std::string &pType) {
   RET_IF_ERR_MSG(!pData, ErrorCode::NULL_POINTER, "Secondary header data is nullptr");
   const std::vector<std::uint8_t> data(pData, pData + sizeData);
-  FORWARD_RESULT(setDataFieldHeader(data, pType));
+  FORWARD_RESULT(setSecondaryHeader(data, pType));
   return true;
 }
 
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(
     const std::vector<std::uint8_t> &data, const std::string &pType) {
   RET_IF_ERR_MSG(data.size() + m_applicationData.size() > m_dataPacketSize,
                  ErrorCode::INVALID_SECONDARY_HEADER_DATA,
@@ -157,27 +157,27 @@ CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(
 
   FORWARD_RESULT(header->deserialize(data));
   m_secondaryHeader = std::move(header);
-  m_dataFieldHeaderType = pType;
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderType = pType;
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(
-    const std::vector<std::uint8_t> &dataFieldHeader) {
-  RET_IF_ERR_MSG(dataFieldHeader.size() + m_applicationData.size() > m_dataPacketSize,
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(
+    const std::vector<std::uint8_t> &secondaryHeader) {
+  RET_IF_ERR_MSG(secondaryHeader.size() + m_applicationData.size() > m_dataPacketSize,
                  ErrorCode::INVALID_SECONDARY_HEADER_DATA,
                  "Secondary header data exceeds available size");
 
-  auto header = std::make_shared<BufferHeader>(dataFieldHeader);
-  FORWARD_RESULT(header->deserialize(dataFieldHeader));
+  auto header = std::make_shared<BufferHeader>(secondaryHeader);
+  FORWARD_RESULT(header->deserialize(secondaryHeader));
   m_secondaryHeader = std::move(header);
-  m_dataFieldHeaderType = m_secondaryHeader->getType();
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderType = m_secondaryHeader->getType();
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
 #ifndef CCSDS_MCU
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(const Config &cfg) {
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(const Config &cfg) {
   RET_IF_ERR_MSG(!cfg.isKey("secondary_header_type"), ErrorCode::CONFIG_FILE_ERROR,
                  "Config: Missing string field: secondary_header_type");
   std::string type{};
@@ -200,13 +200,13 @@ CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(const Config &cfg) {
                  "Failed to create secondary header of type: " + type);
   FORWARD_RESULT(header->loadFromConfig(cfg));
   m_secondaryHeader = std::move(header);
-  m_dataFieldHeaderType = m_secondaryHeader->getType();
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderType = m_secondaryHeader->getType();
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 #endif
 
-CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(
+CCSDS::ResultBool CCSDS::DataField::setSecondaryHeader(
     std::shared_ptr<SecondaryHeaderAbstract> header) {
   if (header) {
     RET_IF_ERR_MSG(static_cast<std::size_t>(header->getSize()) + m_applicationData.size()
@@ -227,8 +227,8 @@ CCSDS::ResultBool CCSDS::DataField::setDataFieldHeader(
     }
   }
   m_secondaryHeader = std::move(header);
-  m_dataFieldHeaderType = m_secondaryHeader ? m_secondaryHeader->getType() : std::string{};
-  m_dataFieldHeaderUpdated = false;
+  m_secondaryHeaderType = m_secondaryHeader ? m_secondaryHeader->getType() : std::string{};
+  m_secondaryHeaderUpdated = false;
   return true;
 }
 
@@ -236,10 +236,10 @@ void CCSDS::DataField::setDataPacketSize(const std::uint16_t &value) {
   m_dataPacketSize = value;
 }
 
-std::vector<std::uint8_t> CCSDS::DataField::getDataFieldHeaderBytes() {
-  return static_cast<const DataField &>(*this).getDataFieldHeaderBytes();
+std::vector<std::uint8_t> CCSDS::DataField::getSecondaryHeaderBytes() {
+  return static_cast<const DataField &>(*this).getSecondaryHeaderBytes();
 }
 
-std::vector<std::uint8_t> CCSDS::DataField::getDataFieldHeaderBytes() const {
+std::vector<std::uint8_t> CCSDS::DataField::getSecondaryHeaderBytes() const {
   return m_secondaryHeader ? m_secondaryHeader->serialize() : std::vector<std::uint8_t>{};
 }

--- a/src/CCSDSHeader.cpp
+++ b/src/CCSDSHeader.cpp
@@ -27,12 +27,12 @@ CCSDS::ResultBool CCSDS::Header::setType(const std::uint8_t &value) {
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Header::setDataFieldHeaderFlag(const std::uint8_t &value) {
+CCSDS::ResultBool CCSDS::Header::setSecondaryHeaderFlag(const std::uint8_t &value) {
   if (value > 0x01U) {
     m_status = INVALID;
-    return Error(INVALID_HEADER_DATA, "Invalid data field header flag, value > 1");
+    return Error(INVALID_HEADER_DATA, "Invalid secondary header flag, value > 1");
   }
-  m_dataFieldHeaderFlag = value;
+  m_secondaryHeaderFlag = value;
   refreshStatus();
   return true;
 }
@@ -97,7 +97,7 @@ CCSDS::ResultBool CCSDS::Header::setData(const std::uint64_t &data) {
 
   m_versionNumber = static_cast<std::uint8_t>(m_packetIdentificationAndVersion >> 13);
   m_type = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 12) & 0x01U);
-  m_dataFieldHeaderFlag = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 11) & 0x01U);
+  m_secondaryHeaderFlag = static_cast<std::uint8_t>((m_packetIdentificationAndVersion >> 11) & 0x01U);
   m_APID = m_packetIdentificationAndVersion & 0x07FFU;
   m_sequenceFlags = static_cast<std::uint8_t>(m_packetSequenceControl >> 14);
   m_sequenceCount = m_packetSequenceControl & 0x3FFFU;
@@ -119,7 +119,7 @@ std::vector<std::uint8_t> CCSDS::Header::serialize() const {
   const auto packetIdentificationAndVersion = static_cast<std::uint16_t>(
     (static_cast<std::uint16_t>(m_versionNumber) << 13U)
     | (static_cast<std::uint16_t>(m_type) << 12U)
-    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | (static_cast<std::uint16_t>(m_secondaryHeaderFlag) << 11U)
     | m_APID);
 
   return {
@@ -145,7 +145,7 @@ std::uint64_t CCSDS::Header::getFullHeader() const {
   const auto packetIdentificationAndVersion = static_cast<std::uint16_t>(
     (static_cast<std::uint16_t>(m_versionNumber) << 13U)
     | (static_cast<std::uint16_t>(m_type) << 12U)
-    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | (static_cast<std::uint16_t>(m_secondaryHeaderFlag) << 11U)
     | m_APID);
   return (static_cast<std::uint64_t>(packetIdentificationAndVersion) << 32U)
          | (static_cast<std::uint32_t>(packetSequenceControl) << 16U)
@@ -161,9 +161,9 @@ CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
     m_status = INVALID;
     return Error(INVALID_HEADER_DATA, "Invalid type, value > 1");
   }
-  if (data.dataFieldHeaderFlag > 0x01U) {
+  if (data.secondaryHeaderFlag > 0x01U) {
     m_status = INVALID;
-    return Error(INVALID_HEADER_DATA, "Invalid data field header flag, value > 1");
+    return Error(INVALID_HEADER_DATA, "Invalid secondary header flag, value > 1");
   }
   if (data.APID > IDLE_APID) {
     m_status = INVALID;
@@ -180,7 +180,7 @@ CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
 
   m_versionNumber = data.versionNumber;
   m_type = data.type;
-  m_dataFieldHeaderFlag = data.dataFieldHeaderFlag;
+  m_secondaryHeaderFlag = data.secondaryHeaderFlag;
   m_APID = data.APID;
   m_sequenceFlags = data.sequenceFlags;
   m_sequenceCount = data.sequenceCount;
@@ -190,7 +190,7 @@ CCSDS::ResultBool CCSDS::Header::setData(const PrimaryHeader &data) {
   m_packetIdentificationAndVersion = static_cast<std::uint16_t>(
     (static_cast<std::uint16_t>(m_versionNumber) << 13U)
     | (static_cast<std::uint16_t>(m_type) << 12U)
-    | (static_cast<std::uint16_t>(m_dataFieldHeaderFlag) << 11U)
+    | (static_cast<std::uint16_t>(m_secondaryHeaderFlag) << 11U)
     | m_APID);
   refreshStatus();
   return true;

--- a/src/CCSDSManager.cpp
+++ b/src/CCSDSManager.cpp
@@ -27,7 +27,7 @@ std::uint16_t CCSDS::Manager::packetIdentifier(const Packet &packet) {
   return static_cast<std::uint16_t>(
     (static_cast<std::uint16_t>(header.getVersionNumber()) << 13U)
     | (static_cast<std::uint16_t>(header.getType()) << 12U)
-    | (static_cast<std::uint16_t>(header.getDataFieldHeaderFlag()) << 11U)
+    | (static_cast<std::uint16_t>(header.getSecondaryHeaderFlag()) << 11U)
     | header.getAPID());
 }
 

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -25,8 +25,8 @@ namespace {
                                         const CCSDS::PacketErrorControlMode errorControl) {
     if (header.getVersionNumber() != 0U) return false;
     if (header.getAPID() == CCSDS::IDLE_APID) {
-      return !profile.pusEnabled && header.getDataFieldHeaderFlag() == 0U
-             && !dataField.getDataFieldHeaderFlag()
+      return !profile.pusEnabled && header.getSecondaryHeaderFlag() == 0U
+             && !dataField.getSecondaryHeaderFlag()
              && dataField.getApplicationDataBytesSize() > 0U;
     }
 
@@ -37,7 +37,7 @@ namespace {
     if (!secondary || !secondary->isPusHeader()
         || !secondary->matchesMissionProfile(profile)
         || errorControl != profile.packetErrorControl
-        || header.getDataFieldHeaderFlag() == 0U) return false;
+        || header.getSecondaryHeaderFlag() == 0U) return false;
     const auto expectedType = profile.direction == CCSDS::PacketDirection::Telecommand ? 1U : 0U;
     return header.getType() == expectedType;
   }
@@ -114,7 +114,7 @@ namespace {
     }
 
     if (parsed.header.getAPID() == CCSDS::IDLE_APID) {
-      if (parsed.header.getDataFieldHeaderFlag() != 0U) {
+      if (parsed.header.getSecondaryHeaderFlag() != 0U) {
         return CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
                             "Cannot deserialize Idle Packet: secondary-header flag must be zero."};
       }
@@ -168,7 +168,7 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
   int versionNumber{};
   bool type{};
   int APID{};
-  bool dataFieldHeaderFlag{};
+  bool secondaryHeaderFlag{};
   std::uint16_t sequenceCount{};
   ESequenceFlag sequenceFlag{};
   bool segmented{};
@@ -177,8 +177,8 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
                  "Config: Missing int field: ccsds_version_number");
   RET_IF_ERR_MSG(!cfg.isKey("ccsds_type"), ErrorCode::CONFIG_FILE_ERROR,
                  "Config: Missing bool field: ccsds_type");
-  RET_IF_ERR_MSG(!cfg.isKey("ccsds_data_field_header_flag"), ErrorCode::CONFIG_FILE_ERROR,
-                 "Config: Missing bool field: ccsds_data_field_header_flag");
+  RET_IF_ERR_MSG(!cfg.isKey("ccsds_secondary_header_flag"), ErrorCode::CONFIG_FILE_ERROR,
+                 "Config: Missing bool field: ccsds_secondary_header_flag");
   RET_IF_ERR_MSG(!cfg.isKey("ccsds_APID"), ErrorCode::CONFIG_FILE_ERROR,
                  "Config: Missing int field: ccsds_APID");
   RET_IF_ERR_MSG(!cfg.isKey("ccsds_segmented"), ErrorCode::CONFIG_FILE_ERROR,
@@ -186,7 +186,7 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
 
   ASSIGN_CP(versionNumber, cfg.get<int>("ccsds_version_number"));
   ASSIGN_CP(type, cfg.get<bool>("ccsds_type"));
-  ASSIGN_CP(dataFieldHeaderFlag, cfg.get<bool>("ccsds_data_field_header_flag"));
+  ASSIGN_CP(secondaryHeaderFlag, cfg.get<bool>("ccsds_secondary_header_flag"));
   ASSIGN_CP(APID, cfg.get<int>("ccsds_APID"));
   ASSIGN_CP(segmented, cfg.get<bool>("ccsds_segmented"));
 
@@ -197,7 +197,7 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
 
   FORWARD_RESULT(m_primaryHeader.setVersionNumber(static_cast<std::uint8_t>(versionNumber)));
   FORWARD_RESULT(m_primaryHeader.setType(static_cast<std::uint8_t>(type)));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(static_cast<std::uint8_t>(dataFieldHeaderFlag)));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(static_cast<std::uint8_t>(secondaryHeaderFlag)));
   FORWARD_RESULT(m_primaryHeader.setAPID(static_cast<std::uint16_t>(APID)));
 
   if (segmented) {
@@ -239,8 +239,8 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
     bool secondaryHeaderFlag{false};
     ASSIGN_CP(secondaryHeaderFlag, cfg.get<bool>("define_secondary_header"));
     if (secondaryHeaderFlag) {
-      FORWARD_RESULT(m_dataField.setDataFieldHeader(cfg));
-      FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
+      FORWARD_RESULT(m_dataField.setSecondaryHeader(cfg));
+      FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(1U));
     }
   }
 
@@ -275,12 +275,12 @@ std::uint16_t CCSDS::Packet::getDataFieldMaximumSize() const {
   return m_dataField.getDataFieldAvailableBytesSize();
 }
 
-bool CCSDS::Packet::getDataFieldHeaderFlag() {
-  return static_cast<const Packet &>(*this).getDataFieldHeaderFlag();
+bool CCSDS::Packet::getSecondaryHeaderFlag() {
+  return static_cast<const Packet &>(*this).getSecondaryHeaderFlag();
 }
 
-bool CCSDS::Packet::getDataFieldHeaderFlag() const {
-  return m_primaryHeader.getDataFieldHeaderFlag() != 0U;
+bool CCSDS::Packet::getSecondaryHeaderFlag() const {
+  return m_primaryHeader.getSecondaryHeaderFlag() != 0U;
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getCRCVectorBytes() {
@@ -315,12 +315,20 @@ std::vector<std::uint8_t> CCSDS::Packet::getPrimaryHeaderBytes() const {
   return m_primaryHeader.serialize();
 }
 
-std::vector<std::uint8_t> CCSDS::Packet::getDataFieldHeaderBytes() {
-  return static_cast<const Packet &>(*this).getDataFieldHeaderBytes();
+std::shared_ptr<CCSDS::SecondaryHeaderAbstract> CCSDS::Packet::getSecondaryHeader() {
+  return m_dataField.getSecondaryHeader();
 }
 
-std::vector<std::uint8_t> CCSDS::Packet::getDataFieldHeaderBytes() const {
-  return m_dataField.getDataFieldHeaderBytes();
+std::shared_ptr<const CCSDS::SecondaryHeaderAbstract> CCSDS::Packet::getSecondaryHeader() const {
+  return m_dataField.getSecondaryHeader();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getSecondaryHeaderBytes() {
+  return static_cast<const Packet &>(*this).getSecondaryHeaderBytes();
+}
+
+std::vector<std::uint8_t> CCSDS::Packet::getSecondaryHeaderBytes() const {
+  return m_dataField.getSecondaryHeaderBytes();
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getApplicationDataBytes() {
@@ -336,7 +344,7 @@ std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() {
 }
 
 std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() const {
-  auto data = m_dataField.getDataFieldHeaderBytes();
+  auto data = m_dataField.getSecondaryHeaderBytes();
   const auto applicationData = m_dataField.getApplicationData();
   data.insert(data.end(), applicationData.begin(), applicationData.end());
   return data;
@@ -391,8 +399,8 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
                  "Cannot deserialize packet: BufferHeader requires an explicit byte size.");
   const bool isPus = PusSecondaryHeaderFactory::isPusSelector(headerType);
   RET_IF_ERR_MSG(isPus
-                   ? !m_dataField.getPusDataFieldHeaderFactory().typeIsSupported(headerType)
-                   : !m_dataField.getDataFieldHeaderFactory().typeIsRegistered(headerType),
+                   ? !m_dataField.getPusSecondaryHeaderFactory().typeIsSupported(headerType)
+                   : !m_dataField.getSecondaryHeaderFactory().typeIsRegistered(headerType),
                  ErrorCode::INVALID_SECONDARY_HEADER_DATA,
                  "Cannot deserialize packet: unsupported secondary header: " + headerType);
 
@@ -420,12 +428,12 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
   parsedField.clearContent();
   std::shared_ptr<SecondaryHeaderAbstract> secondaryHeader;
   if (isPus) {
-    auto createResult = parsedField.getPusDataFieldHeaderFactory().create(
+    auto createResult = parsedField.getPusSecondaryHeaderFactory().create(
       headerType, parsedField.getMissionProfile());
     if (!createResult) return createResult.error();
     secondaryHeader = createResult.value();
   } else {
-    secondaryHeader = parsedField.getDataFieldHeaderFactory().create(headerType);
+    secondaryHeader = parsedField.getSecondaryHeaderFactory().create(headerType);
   }
   RET_IF_ERR_MSG(!secondaryHeader, ErrorCode::INVALID_SECONDARY_HEADER_DATA,
                  "Cannot deserialize packet: failed to create secondary header: " + headerType);
@@ -441,7 +449,7 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
     parsed.dataField.begin(), parsed.dataField.begin() + static_cast<std::ptrdiff_t>(secondaryHeaderSize));
   const auto secondaryResult = secondaryHeader->deserialize(secondaryBytes);
   if (!secondaryResult) return secondaryResult.error();
-  const auto attachResult = parsedField.setDataFieldHeader(secondaryHeader);
+  const auto attachResult = parsedField.setSecondaryHeader(secondaryHeader);
   if (!attachResult) return attachResult.error();
 
   const std::vector<std::uint8_t> applicationData(
@@ -480,7 +488,7 @@ CCSDS::Result<std::size_t> CCSDS::Packet::deserializeBounded(
     parsed.dataField.begin(),
     parsed.dataField.begin() + static_cast<std::ptrdiff_t>(headerDataSizeBytes));
   if (!secondaryBytes.empty()) {
-    const auto secondaryResult = parsedField.setDataFieldHeader(secondaryBytes);
+    const auto secondaryResult = parsedField.setSecondaryHeader(secondaryBytes);
     if (!secondaryResult) return secondaryResult.error();
   }
   const std::vector<std::uint8_t> applicationData(
@@ -580,10 +588,10 @@ CCSDS::ResultBool CCSDS::Packet::setPrimaryHeader(const PrimaryHeader data) {
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
+CCSDS::ResultBool CCSDS::Packet::setSecondaryHeader(
     const std::shared_ptr<SecondaryHeaderAbstract> &header) {
-  FORWARD_RESULT(m_dataField.setDataFieldHeader(header));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(header ? 1U : 0U));
+  FORWARD_RESULT(m_dataField.setSecondaryHeader(header));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(header ? 1U : 0U));
   m_updateStatus = false;
   return true;
 }
@@ -596,35 +604,35 @@ CCSDS::ResultBool CCSDS::Packet::setMissionProfile(const MissionProfile &profile
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
+CCSDS::ResultBool CCSDS::Packet::setSecondaryHeader(
     const std::vector<std::uint8_t> &data, const std::string &headerType) {
-  FORWARD_RESULT(m_dataField.setDataFieldHeader(data, headerType));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
+  FORWARD_RESULT(m_dataField.setSecondaryHeader(data, headerType));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(const std::uint8_t *pData,
+CCSDS::ResultBool CCSDS::Packet::setSecondaryHeader(const std::uint8_t *pData,
                                                      const std::size_t sizeData,
                                                      const std::string &headerType) {
-  FORWARD_RESULT(m_dataField.setDataFieldHeader(pData, sizeData, headerType));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
+  FORWARD_RESULT(m_dataField.setSecondaryHeader(pData, sizeData, headerType));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(
+CCSDS::ResultBool CCSDS::Packet::setSecondaryHeader(
     const std::vector<std::uint8_t> &data) {
-  FORWARD_RESULT(m_dataField.setDataFieldHeader(data));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
+  FORWARD_RESULT(m_dataField.setSecondaryHeader(data));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
 
-CCSDS::ResultBool CCSDS::Packet::setDataFieldHeader(const std::uint8_t *pData,
+CCSDS::ResultBool CCSDS::Packet::setSecondaryHeader(const std::uint8_t *pData,
                                                      const std::size_t sizeData) {
-  FORWARD_RESULT(m_dataField.setDataFieldHeader(pData, sizeData));
-  FORWARD_RESULT(m_primaryHeader.setDataFieldHeaderFlag(1U));
+  FORWARD_RESULT(m_dataField.setSecondaryHeader(pData, sizeData));
+  FORWARD_RESULT(m_primaryHeader.setSecondaryHeaderFlag(1U));
   m_updateStatus = false;
   return true;
 }
@@ -664,7 +672,7 @@ void CCSDS::Packet::setDataFieldSize(const std::uint16_t size) {
 
 void CCSDS::Packet::setUpdatePacketEnable(const bool enable) {
   m_enableUpdatePacket = enable;
-  m_dataField.setDataFieldHeaderAutoUpdateStatus(enable);
+  m_dataField.setSecondaryHeaderAutoUpdateStatus(enable);
 }
 
 void CCSDS::Packet::setPacketErrorControlMode(const PacketErrorControlMode mode) {

--- a/src/CCSDSUtils.cpp
+++ b/src/CCSDSUtils.cpp
@@ -88,20 +88,20 @@ void printBufferData(const std::vector<std::uint8_t> &buffer, const std::int32_t
 }
 
 void printData(CCSDS::DataField dataField) {
-  const auto dataFieldHeader = dataField.getDataFieldHeaderBytes();
+  const auto secondaryHeader = dataField.getSecondaryHeaderBytes();
   auto applicationData = dataField.getApplicationData();
-  const std::uint16_t maxSize = (applicationData.size() > dataFieldHeader.size())
+  const std::uint16_t maxSize = (applicationData.size() > secondaryHeader.size())
                              ? applicationData.size()
-                             : dataFieldHeader.size();
+                             : secondaryHeader.size();
 
-  std::cout << " [CCSDS DATA] Data Field Length              : " << applicationData.size() + dataFieldHeader.size() << " bytes" << std::endl;
-  std::cout << " [CCSDS DATA] Secondary Header Present       : [ " << (dataField.getDataFieldHeaderFlag()
+  std::cout << " [CCSDS DATA] Data Field Length              : " << applicationData.size() + secondaryHeader.size() << " bytes" << std::endl;
+  std::cout << " [CCSDS DATA] Secondary Header Present       : [ " << (dataField.getSecondaryHeaderFlag()
                                                                          ? "True"
                                                                          : "False") << " ]" << std::endl;
-  if (!dataFieldHeader.empty()) {
+  if (!secondaryHeader.empty()) {
     std::cout << " [CCSDS DATA] Secondary Header         [Hex] : " << getBitsSpaces(
-    (maxSize - static_cast<std::uint16_t>(dataFieldHeader.size())) * 4);
-    printBufferData(dataFieldHeader);
+    (maxSize - static_cast<std::uint16_t>(secondaryHeader.size())) * 4);
+    printBufferData(secondaryHeader);
   }
 
   std::cout << " [CCSDS DATA] Application Data         [Hex] : ";
@@ -122,9 +122,9 @@ void printHeader(CCSDS::Header &header) {
       getBinaryString(header.getType(), 1) << " ]";
   std::cout << " - [Dec] : "<< std::dec << static_cast<int>( header.getType()) << std::endl;
 
-  std::cout << " [CCSDS HEADER] Data Field Header Flag       : [ " << getBitsSpaces(19 - 4) << getBinaryString(
-  header.getDataFieldHeaderFlag(), 1) << " ]";
-  std::cout << " -       : " << (header.getDataFieldHeaderFlag() ? "True" : "False")  << std::endl;
+  std::cout << " [CCSDS HEADER] Secondary Header Flag       : [ " << getBitsSpaces(19 - 4) << getBinaryString(
+  header.getSecondaryHeaderFlag(), 1) << " ]";
+  std::cout << " -       : " << (header.getSecondaryHeaderFlag() ? "True" : "False")  << std::endl;
 
   std::cout << " [CCSDS HEADER] APID                         : [ " << getBitsSpaces(17 - 12) <<
     getBinaryString(header.getAPID(), 11) << " ]";

--- a/src/exec_validator.cpp
+++ b/src/exec_validator.cpp
@@ -196,7 +196,7 @@ PacketChecks validatePacketBytes(const std::vector<std::uint8_t> &packetBytes,
     checks.apid = header.getAPID() == templateHeader.getAPID();
     checks.packetType = header.getType() == templateHeader.getType();
     checks.secondaryHeaderFlag =
-      header.getDataFieldHeaderFlag() == templateHeader.getDataFieldHeaderFlag();
+      header.getSecondaryHeaderFlag() == templateHeader.getSecondaryHeaderFlag();
   }
 
   updateSequenceState(header, sequenceState, checks);

--- a/test/cli_integration.py
+++ b/test/cli_integration.py
@@ -46,7 +46,7 @@ def packet_config(apid: int, data_field_size: int = 2, *, pec: str | None = None
         "validation_enable:bool=true",
         "ccsds_version_number:int=0",
         "ccsds_type:bool=false",
-        "ccsds_data_field_header_flag:bool=false",
+        "ccsds_secondary_header_flag:bool=false",
         f"ccsds_APID:int={apid}",
         "ccsds_segmented:bool=false",
         "define_secondary_header:bool=false",

--- a/test/package_tester/shared_lib/src/main.cpp
+++ b/test/package_tester/shared_lib/src/main.cpp
@@ -65,7 +65,7 @@ int main() {
   }
 
   const std::vector<std::uint8_t> secondaryHeader{0x77, 0xFA, 0x0B, 0x00, 0x00, 0x0B, 0x05};
-  if (const auto result = templatePacket.setDataFieldHeader(
+  if (const auto result = templatePacket.setSecondaryHeader(
         secondaryHeader, "CustomSecondaryHeader"); !result) {
     return failResult("set custom secondary header", result.error());
   }
@@ -140,11 +140,11 @@ int main() {
   const auto &header = view.getPrimaryHeader();
   if (header.getVersionNumber() != 0U
       || header.getType() != 1U
-      || header.getDataFieldHeaderFlag() != 1U
+      || header.getSecondaryHeaderFlag() != 1U
       || header.getAPID() != 0x123U
       || header.getSequenceFlags() != CCSDS::UNSEGMENTED
       || header.getSequenceCount() != 5U
-      || view.getDataFieldHeaderBytes() != secondaryHeader
+      || view.getSecondaryHeaderBytes() != secondaryHeader
       || view.getApplicationDataBytes() != std::vector<std::uint8_t>({0x01, 0x02, 0x03})
       || view.getCRC() != 0xB745U) {
     return fail("decoded fields", "decoded packet does not match the expected logical fields");
@@ -154,7 +154,7 @@ int main() {
   if (decoded.getPrimaryHeader64bit() == 0U
       || decoded.getFullPacketLength() != expectedPacket.size()
       || decoded.getSerializedSize() != expectedPacket.size()
-      || !decoded.getDataFieldHeaderFlag()
+      || !decoded.getSecondaryHeaderFlag()
       || decoded.getCRCVectorBytes() != std::vector<std::uint8_t>({0xB7, 0x45})) {
     return fail("packet API", "legacy or additive getters returned unexpected values");
   }
@@ -223,7 +223,7 @@ int main() {
       }); !result) {
     return failResult("Idle Packet setup", result.error());
   }
-  if (const auto result = invalidIdle.setDataFieldHeader({0x01}); !result) {
+  if (const auto result = invalidIdle.setSecondaryHeader({0x01}); !result) {
     return failResult("Idle Packet secondary header", result.error());
   }
   if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {

--- a/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+++ b/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
@@ -105,7 +105,7 @@ namespace CCSDSPackMcuTest {
     const std::vector<std::uint8_t> secondaryHeader{
       0x77, 0xFA, 0x0B, 0x00, 0x00, 0x0B, 0x05
     };
-    if (const auto result = templatePacket.setDataFieldHeader(
+    if (const auto result = templatePacket.setSecondaryHeader(
           secondaryHeader, "CustomSecondaryHeader"); !result) {
       return SetSecondaryHeaderFailed;
     }
@@ -154,11 +154,11 @@ namespace CCSDSPackMcuTest {
     const auto &header = decoded.getPrimaryHeader();
     if (header.getVersionNumber() != 0U
         || header.getType() != 1U
-        || header.getDataFieldHeaderFlag() != 1U
+        || header.getSecondaryHeaderFlag() != 1U
         || header.getAPID() != 0x123U
         || header.getSequenceFlags() != CCSDS::UNSEGMENTED
         || header.getSequenceCount() != 5U
-        || decoded.getDataFieldHeaderBytes() != secondaryHeader
+        || decoded.getSecondaryHeaderBytes() != secondaryHeader
         || decoded.getApplicationDataBytes() != applicationData
         || decoded.getCRC() != 0xB745U
         || decoded.getSerializedSize() != expectedPacket.size()) {
@@ -221,7 +221,7 @@ namespace CCSDSPackMcuTest {
         }); !result) {
       return InvalidIdleHeaderFailed;
     }
-    if (const auto result = invalidIdle.setDataFieldHeader({0x01}); !result) {
+    if (const auto result = invalidIdle.setSecondaryHeader({0x01}); !result) {
       return InvalidIdleSecondaryHeaderFailed;
     }
     if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {

--- a/test/src/testGroupConformance.cpp
+++ b/test/src/testGroupConformance.cpp
@@ -10,13 +10,14 @@
 #include "tests.h"
 
 namespace {
-  bool writeConfig(const std::string &path, const int version) {
+  bool writeConfig(const std::string &path, const int version,
+                   const char *secondaryHeaderFlagKey = "ccsds_secondary_header_flag") {
     std::ofstream file(path, std::ios::trunc);
     if (!file) return false;
 
     file << "ccsds_version_number:int=" << version << '\n'
          << "ccsds_type:bool=false\n"
-         << "ccsds_data_field_header_flag:bool=false\n"
+         << secondaryHeaderFlagKey << ":bool=false\n"
          << "ccsds_APID:int=1\n"
          << "ccsds_segmented:bool=false\n"
          << "data_field_size:int=8\n";
@@ -51,12 +52,22 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
     return validResult && !invalidResult;
   });
 
+  tester->unitTest("Configuration requires the v2 secondary-header flag key", []() {
+    const std::string path = "ccsdspack_legacy_secondary_header_flag.cfg";
+    if (!writeConfig(path, 0, "ccsds_data_field_header_flag")) return false;
+
+    CCSDS::Packet packet;
+    const auto result = packet.loadFromConfigFile(path);
+    std::remove(path.c_str());
+    return !result && result.error().code() == CCSDS::CONFIG_FILE_ERROR;
+  });
+
   tester->unitTest("Idle Packet rejects a secondary header", []() {
     CCSDS::Packet packet;
     TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
       0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
     }));
-    TEST_VOID(packet.setDataFieldHeader({0x10}));
+    TEST_VOID(packet.setSecondaryHeader({0x10}));
     TEST_VOID(packet.setApplicationData({0x00}));
     return packet.serialize().empty();
   });
@@ -109,7 +120,7 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
     const auto bytes = packet.serialize();
     return bytes.size() == 9U
            && packet.getPrimaryHeader().getHeaderStatus() == CCSDS::IDLE
-           && packet.getPrimaryHeader().getDataFieldHeaderFlag() == 0U;
+           && packet.getPrimaryHeader().getSecondaryHeaderFlag() == 0U;
   });
 
   tester->unitTest("Maximum serialized size is reported without uint16 overflow", []() {

--- a/test/src/testGroupCore.cpp
+++ b/test/src/testGroupCore.cpp
@@ -75,7 +75,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     const auto &stored = packet.getPrimaryHeader();
     return stored.getVersionNumber() == 0
            && stored.getType() == 1
-           && stored.getDataFieldHeaderFlag() == 1
+           && stored.getSecondaryHeaderFlag() == 1
            && stored.getAPID() == 0x123
            && stored.getSequenceFlags() == CCSDS::FIRST_SEGMENT
            && stored.getSequenceCount() == 7
@@ -88,7 +88,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     if (packet.getCRC() != 0U) return false;
     packet.update();
     return packet.getApplicationDataBytes() == std::vector<std::uint8_t>({1, 2, 3, 4, 5})
-           && packet.getDataFieldHeaderBytes().empty()
+           && packet.getSecondaryHeaderBytes().empty()
            && packet.getCRC() == 0x3B8D;
   });
 
@@ -101,7 +101,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
 
   tester->unitTest("Buffer secondary header inspection preserves current bytes.", [] {
     CCSDS::Packet packet;
-    TEST_VOID(packet.setDataFieldHeader({1, 2}));
+    TEST_VOID(packet.setSecondaryHeader({1, 2}));
     TEST_VOID(packet.setApplicationData({3, 4, 5}));
     const auto dataField = packet.getFullDataFieldBytes();
     if (dataField != std::vector<std::uint8_t>({1, 2, 3, 4, 5})) return false;
@@ -113,8 +113,12 @@ void testGroupCore(TestManager *tester, const std::string &description) {
   tester->unitTest("Custom secondary-header types remain registerable.", [] {
     CCSDS::Packet packet;
     TEST_VOID(packet.RegisterSecondaryHeader<TestSecondaryHeader>());
-    TEST_VOID(packet.setDataFieldHeader({0xAA, 0xBB, 0xCC}, "TestSecondaryHeader"));
-    return packet.getDataFieldHeaderBytes() == std::vector<std::uint8_t>({0xAA, 0xBB, 0xCC});
+    TEST_VOID(packet.setSecondaryHeader({0xAA, 0xBB, 0xCC}, "TestSecondaryHeader"));
+    const CCSDS::Packet &view = packet;
+    const auto header = view.getSecondaryHeader();
+    return header && header->getType() == "TestSecondaryHeader"
+           && view.getSecondaryHeaderBytes()
+              == std::vector<std::uint8_t>({0xAA, 0xBB, 0xCC});
   });
 
   tester->unitTest("Packet getters do not finalize dirty state.", [] {
@@ -122,17 +126,17 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     TEST_VOID(packet.setPrimaryHeader(
       CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 7, 0}));
     TEST_VOID(packet.RegisterSecondaryHeader<UpdatingSecondaryHeader>());
-    TEST_VOID(packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>()));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<UpdatingSecondaryHeader>()));
     TEST_VOID(packet.setApplicationData({0xAA}));
 
     const CCSDS::Packet &view = packet;
     const auto headerBefore = view.getPrimaryHeaderBytes();
-    const auto secondaryBefore = view.getDataFieldHeaderBytes();
+    const auto secondaryBefore = view.getSecondaryHeaderBytes();
     const auto crcBefore = view.getCRC();
 
     (void)view.getPrimaryHeader64bit();
     (void)view.getFullPacketLength();
-    (void)view.getDataFieldHeaderFlag();
+    (void)view.getSecondaryHeaderFlag();
     (void)view.getDataField();
     (void)view.getPrimaryHeader();
     (void)view.getApplicationDataBytes();
@@ -140,7 +144,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     (void)view.getCRCVectorBytes();
 
     return view.getPrimaryHeaderBytes() == headerBefore
-           && view.getDataFieldHeaderBytes() == secondaryBefore
+           && view.getSecondaryHeaderBytes() == secondaryBefore
            && view.getCRC() == crcBefore
            && view.getPrimaryHeader().getSequenceCount() == 7U
            && view.getPrimaryHeader().getDataLength() == 0U
@@ -153,14 +157,14 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     TEST_VOID(packet.setPrimaryHeader(
       CCSDS::PrimaryHeader{0, 0, 0, 1, CCSDS::UNSEGMENTED, 9, 0}));
     TEST_VOID(packet.RegisterSecondaryHeader<UpdatingSecondaryHeader>());
-    TEST_VOID(packet.setDataFieldHeader(std::make_shared<UpdatingSecondaryHeader>()));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<UpdatingSecondaryHeader>()));
     TEST_VOID(packet.setApplicationData({0xAA}));
 
     const auto encoded = packet.serialize();
     return !encoded.empty()
            && packet.getPrimaryHeader().getSequenceCount() == 9U
            && packet.getPrimaryHeader().getDataLength() == 3U
-           && packet.getDataFieldHeaderBytes() == std::vector<std::uint8_t>({0x11})
+           && packet.getSecondaryHeaderBytes() == std::vector<std::uint8_t>({0x11})
            && packet.getCRC() != 0U;
   });
 
@@ -178,7 +182,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     const auto crcBefore = view.getCRC();
     (void)view.getApplicationDataBytes();
     (void)view.getFullDataFieldBytes();
-    (void)view.getDataFieldHeaderBytes();
+    (void)view.getSecondaryHeaderBytes();
 
     return view.getPrimaryHeaderBytes() == headerBefore
            && view.getPrimaryHeader().getSequenceCount() == 123U
@@ -188,7 +192,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
 
   tester->unitTest("Disabling automatic updates preserves a valid parsed packet.", [] {
     CCSDS::Packet source;
-    TEST_VOID(source.setDataFieldHeader({1, 2}));
+    TEST_VOID(source.setSecondaryHeader({1, 2}));
     TEST_VOID(source.setApplicationData({3, 4, 5}));
     const auto encoded = source.serialize();
 

--- a/test/src/testGroupEdgeCases.cpp
+++ b/test/src/testGroupEdgeCases.cpp
@@ -22,7 +22,7 @@ namespace {
     }
     file << "ccsds_version_number:int=0\n"
          << "ccsds_type:bool=false\n"
-         << "ccsds_data_field_header_flag:bool=false\n"
+         << "ccsds_secondary_header_flag:bool=false\n"
          << "ccsds_APID:int=" << apid << "\n"
          << "ccsds_segmented:bool=false\n";
     if (apid == static_cast<int>(CCSDS::IDLE_APID)) {
@@ -226,7 +226,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
 
   tester->unitTest("CRC16 covers primary header, secondary header and application data", []() {
     CCSDS::Packet packet;
-    TEST_VOID(packet.setDataFieldHeader({0x01, 0x02, 0x03}));
+    TEST_VOID(packet.setSecondaryHeader({0x01, 0x02, 0x03}));
     TEST_VOID(packet.setApplicationData({0x04, 0x05}));
 
     const std::vector<std::uint8_t> expected{
@@ -263,7 +263,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     return expected.size() == 8U
            && header.getVersionNumber() == 0U
            && header.getType() == 0U
-           && header.getDataFieldHeaderFlag() == 0U
+           && header.getSecondaryHeaderFlag() == 0U
            && header.getAPID() == 0U
            && header.getSequenceFlags() == CCSDS::UNSEGMENTED
            && header.getSequenceCount() == 0U
@@ -282,7 +282,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected));
-    return decoded.getPrimaryHeader().getDataFieldHeaderFlag() == 0U
+    return decoded.getPrimaryHeader().getSecondaryHeaderFlag() == 0U
            && decoded.getPrimaryHeader().getDataLength() == 3U
            && decoded.getApplicationDataBytes() == std::vector<std::uint8_t>({0xAA, 0x55})
            && decoded.getCRC() == 0x2EBBU;
@@ -293,15 +293,15 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     if (!readHexResource("ccsds_golden_custom_secondary_crc16.hex", expected)) return false;
 
     CCSDS::Packet generated;
-    TEST_VOID(generated.setDataFieldHeader({0x01, 0x02, 0x03}));
+    TEST_VOID(generated.setSecondaryHeader({0x01, 0x02, 0x03}));
     TEST_VOID(generated.setApplicationData({0x04, 0x05}));
     if (generated.serialize() != expected) return false;
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected, 3U));
-    return decoded.getPrimaryHeader().getDataFieldHeaderFlag() == 1U
+    return decoded.getPrimaryHeader().getSecondaryHeaderFlag() == 1U
            && decoded.getPrimaryHeader().getDataLength() == 6U
-           && decoded.getDataFieldHeaderBytes() == std::vector<std::uint8_t>({0x01, 0x02, 0x03})
+           && decoded.getSecondaryHeaderBytes() == std::vector<std::uint8_t>({0x01, 0x02, 0x03})
            && decoded.getApplicationDataBytes() == std::vector<std::uint8_t>({0x04, 0x05})
            && decoded.getCRC() == 0x9903U;
   });
@@ -340,7 +340,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     const auto &header = decoded.getPrimaryHeader();
     return header.getVersionNumber() == 0U
            && header.getType() == 1U
-           && header.getDataFieldHeaderFlag() == 0U
+           && header.getSecondaryHeaderFlag() == 0U
            && header.getAPID() == 0x123U
            && header.getSequenceFlags() == CCSDS::UNSEGMENTED
            && header.getSequenceCount() == 0x123U

--- a/test/src/testGroupManagement.cpp
+++ b/test/src/testGroupManagement.cpp
@@ -18,11 +18,11 @@ namespace {
       const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16,
       const std::uint8_t version = 0U,
       const std::uint8_t type = 0U,
-      const std::uint8_t dataFieldHeaderFlag = 0U) {
+      const std::uint8_t secondaryHeaderFlag = 0U) {
     CCSDS::Packet packet;
     packet.setPacketErrorControlMode(mode);
     const auto result = packet.setPrimaryHeader(
-      CCSDS::PrimaryHeader{version, type, dataFieldHeaderFlag, apid, flags, count, 0});
+      CCSDS::PrimaryHeader{version, type, secondaryHeaderFlag, apid, flags, count, 0});
     if (!result) {
       std::cerr << "[ Error ]: " << result.error().message() << '\n';
     }
@@ -301,7 +301,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
 
   tester->unitTest("Manager preserves secondary headers while segmenting.", [] {
     CCSDS::Packet packet = makePacket(1, CCSDS::FIRST_SEGMENT, 1);
-    TEST_VOID(packet.setDataFieldHeader({0x02, 0x04, 0x05, 0x06, 0x07, 0x0A, 0x00, 0x00}));
+    TEST_VOID(packet.setSecondaryHeader({0x02, 0x04, 0x05, 0x06, 0x07, 0x0A, 0x00, 0x00}));
 
     CCSDS::Manager manager(packet);
     manager.setAutoValidateEnable(false);
@@ -312,9 +312,9 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
            && packets[0].getApplicationDataBytes().size() == 5U
            && packets[1].getApplicationDataBytes().size() == 5U
            && packets[2].getApplicationDataBytes().size() == 2U
-           && packets[0].getDataFieldHeaderFlag()
-           && packets[1].getDataFieldHeaderFlag()
-           && packets[2].getDataFieldHeaderFlag();
+           && packets[0].getSecondaryHeaderFlag()
+           && packets[1].getSecondaryHeaderFlag()
+           && packets[2].getSecondaryHeaderFlag();
   });
 
   tester->unitTest("Manager supports CRC-disabled templates.", [] {

--- a/test/src/testGroupParsing.cpp
+++ b/test/src/testGroupParsing.cpp
@@ -126,7 +126,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
 
     const auto versionResult = version.setVersionNumber(8);
     const auto typeResult = type.setType(2);
-    const auto dataFieldResult = dataFieldFlag.setDataFieldHeaderFlag(2);
+    const auto dataFieldResult = dataFieldFlag.setSecondaryHeaderFlag(2);
     const auto apidResult = apid.setAPID(2048);
     const auto flagsResult = sequenceFlags.setSequenceFlags(4);
     const auto countResult = sequenceCount.setSequenceCount(16384);

--- a/test/src/testGroupPus.cpp
+++ b/test/src/testGroupPus.cpp
@@ -164,7 +164,7 @@ void testGroupPus(TestManager *tester, const std::string &description) {
     CCSDS::Packet source;
     TEST_VOID(source.setPrimaryHeader(primary(CCSDS::PacketDirection::Telecommand)));
     TEST_VOID(source.setMissionProfile(profile));
-    TEST_VOID(source.setDataFieldHeader(
+    TEST_VOID(source.setSecondaryHeader(
       std::make_shared<CCSDS::PusCTcHeader>(profile, 17U, 1U, 0x1234U, 0x09U)));
     TEST_VOID(source.setApplicationData({0x60U, 0x70U}));
     const auto packetBytes = source.serialize();
@@ -176,7 +176,7 @@ void testGroupPus(TestManager *tester, const std::string &description) {
     std::size_t consumed{};
     TEST_RET(consumed, decoded.deserializeBounded(stream, "PUS:revC:TC"));
     const auto header = std::dynamic_pointer_cast<CCSDS::PusCTcHeader>(
-      decoded.getDataField().getSecondaryHeader());
+      decoded.getSecondaryHeader());
     return consumed == packetBytes.size() && header && header->getSourceId() == 0x1234U
            && decoded.getApplicationDataBytes() == std::vector<std::uint8_t>({0x60U, 0x70U});
   });
@@ -188,18 +188,18 @@ void testGroupPus(TestManager *tester, const std::string &description) {
                                                  CCSDS::PacketDirection::Telemetry);
     CCSDS::Packet wrongDirection;
     TEST_VOID(wrongDirection.setMissionProfile(tcProfile));
-    TEST_VOID(wrongDirection.setDataFieldHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
+    TEST_VOID(wrongDirection.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
     TEST_VOID(wrongDirection.setApplicationData({1U}));
     if (!wrongDirection.serialize().empty()) return false;
 
     CCSDS::Packet wrongProfile;
     TEST_VOID(wrongProfile.setMissionProfile(tmProfile));
-    if (wrongProfile.setDataFieldHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile))) return false;
+    if (wrongProfile.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile))) return false;
 
     CCSDS::Packet wrongPec;
     TEST_VOID(wrongPec.setPrimaryHeader(primary(CCSDS::PacketDirection::Telecommand)));
     TEST_VOID(wrongPec.setMissionProfile(tcProfile));
-    TEST_VOID(wrongPec.setDataFieldHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
+    TEST_VOID(wrongPec.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
     TEST_VOID(wrongPec.setApplicationData({1U}));
     wrongPec.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
     return wrongPec.serialize().empty();

--- a/test/src/testGroupValidator.cpp
+++ b/test/src/testGroupValidator.cpp
@@ -15,11 +15,11 @@ namespace {
       const CCSDS::PacketErrorControlMode mode = CCSDS::PacketErrorControlMode::CRC16,
       const std::uint8_t version = 0U,
       const std::uint8_t type = 0U,
-      const std::uint8_t dataFieldHeaderFlag = 0U) {
+      const std::uint8_t secondaryHeaderFlag = 0U) {
     CCSDS::Packet packet;
     packet.setPacketErrorControlMode(mode);
     const auto headerResult = packet.setPrimaryHeader(
-      CCSDS::PrimaryHeader{version, type, dataFieldHeaderFlag, apid, flags, count, 0});
+      CCSDS::PrimaryHeader{version, type, secondaryHeaderFlag, apid, flags, count, 0});
     if (!headerResult) {
       return {};
     }

--- a/test/test_resources/config.cfg
+++ b/test/test_resources/config.cfg
@@ -40,7 +40,7 @@ ccsds_APID:int=125
 # header within the data field
 # NOTE: This field shall remain false, until Secondary header parsing is
 # implemented in the encoder
-ccsds_data_field_header_flag:bool=false
+ccsds_secondary_header_flag:bool=false
 
 
 # true the packet is segmented


### PR DESCRIPTION
## Summary

- rename the v2 public secondary-header API from the legacy `DataFieldHeader` terminology to CCSDS `SecondaryHeader` terminology across `Packet`, `DataField`, `Header`, tools, tests, and configuration
- add nullable `Packet::getSecondaryHeader()` const/non-const accessors and remove the unsafe unchecked reference getter
- rename the v2 configuration key to `ccsds_secondary_header_flag` and reject the former key
- add four standalone `find_package(CCSDSPack 2.0 CONFIG REQUIRED)` examples: generic packet, custom secondary header, PUS-C TC, and timestamped PUS-C TM
- add aggregate and targeted builds through `example/build_examples.sh all|<name>`
- run the installed-package examples in Linux and Windows CI
- update README, configuration, examples, migration guidance, roadmap, and acceptance records

## Impact

This is an intentional v2 breaking API/configuration rename. No compatibility aliases are retained.

## Validation

- 98/98 native tests
- 98/98 AddressSanitizer and UndefinedBehaviorSanitizer tests
- MCU syntax build with `-fno-exceptions -fno-rtti`
- CLI integration suite
- installed shared-library consumer probe
- all four example applications compile and round-trip
- `bash -n example/build_examples.sh`
- `git diff --check`

The PR workflows validate the actual installed CMake package and `find_package` example path on Linux and Windows.

Tracks #84, #85, #87, and #109.