### PR TITLE
feat(CCSDSPack): return serialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ int main() {
   }
 
   const auto wire = manager.getPacketsBuffer();
-  return wire.empty() ? 1 : 0;
+  return wire && !wire.value().empty() ? 0 : 1;
 }
 ```
 
@@ -299,9 +299,10 @@ packet.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(
   profile, 17, 1, 0x1234, 0x09));
 packet.setApplicationData({0x10, 0x20});
 const auto wire = packet.serialize();
+if (!wire) return wire.error().code();
 ```
 
-All checked results should be inspected in production code; they are omitted above only to keep the example compact.
+All checked setter results should also be inspected in production code; they are omitted above only to keep the example compact.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following diagram shows the main v1.x relationships between the user applica
 ## Documentation
 
 - [Generated API reference](https://exospacelabs.github.io/CCSDSPack/html/)
+- [CCSDS compliance matrix](CCSDS_COMPLIANCE.md)
 - [CCSDS 133.0-B-2 EC2 PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md)
 - [PUS and mission tailoring](docs/MISSION_TAILORING.md)
 - [v1 to v2 migration](docs/MIGRATION_V1_TO_V2.md)

--- a/V2_TRANSITION_ACCEPTANCE_LIST.md
+++ b/V2_TRANSITION_ACCEPTANCE_LIST.md
@@ -54,6 +54,10 @@
 - [x] PUS parsing requires the explicit canonical selector.
 - [x] Failed PUS parsing does not commit partial packet state.
 - [x] Generic CCSDS regression vectors remain passing.
+- [x] Packet finalization returns specific validation errors.
+- [x] Packet serialization returns `ResultBuffer` rather than using an empty vector as an error sentinel.
+- [x] DataField and Manager serialization propagate errors without collapsing them.
+- [x] Packet Data Length and CRC16 are updated only after successful checked finalization.
 
 ## Legacy removal and migration
 
@@ -68,7 +72,7 @@
 
 ## Local validation
 
-- [x] 98 native tests pass.
+- [x] 101 native tests pass.
 - [x] AddressSanitizer and UndefinedBehaviorSanitizer pass.
 - [x] MCU sources compile with `-fno-exceptions -fno-rtti`.
 - [x] `git diff --check` passes.

--- a/V2_TRANSITION_ROADMAP.md
+++ b/V2_TRANSITION_ROADMAP.md
@@ -48,7 +48,9 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 
 Completed and integrated:
 
-- 98 native tests, including the four-selector PUS factory matrix and v2 configuration naming;
+- checked `Packet::update()`, `Packet::serialize()`, `DataField::serialize()`, and Manager stream serialization results;
+- native tests covering exact finalization, profile, header, data-length, and Manager propagation errors;
+- 101 native tests, including the four-selector PUS factory matrix and v2 configuration naming;
 - PUS-A/PUS-C fixed byte vectors and negative vectors;
 - ASan/UBSan validation;
 - MCU compile with `-fno-exceptions -fno-rtti`;

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -63,11 +63,12 @@ int main() {
     return dataResult.error().code();
   }
 
-  const std::vector<std::uint8_t> wire = packet.serialize();
-  if (wire.empty()) {
-    std::cerr << "Packet finalization failed\n";
-    return 1;
+  const auto wireResult = packet.serialize();
+  if (!wireResult) {
+    std::cerr << wireResult.error().message() << '\n';
+    return wireResult.error().code();
   }
+  const auto &wire = wireResult.value();
 
   CCSDS::Packet decoded; // CRC16 is also the receiving default
   const auto consumedResult = decoded.deserializeBounded(wire);
@@ -84,7 +85,7 @@ int main() {
 }
 ```
 
-`serialize()` finalizes Packet Data Length and the optional CRC16 trailer. Getters inspect the stored state and do not perform hidden finalization.
+`serialize()` returns `ResultBuffer` and reports the exact finalization error. `update()` returns `ResultBool` when finalization without bytes is required. Getters inspect the stored state and do not perform hidden finalization.
 
 ## Segment a payload with Manager
 
@@ -119,7 +120,9 @@ int main() {
     return dataResult.error().code();
   }
 
-  const auto stream = manager.getPacketsBuffer();
+  const auto streamResult = manager.getPacketsBuffer();
+  if (!streamResult) return streamResult.error().code();
+  const auto &stream = streamResult.value();
   std::cout << "Generated " << manager.getTotalPackets()
             << " packets in " << stream.size() << " bytes\n";
 
@@ -197,7 +200,7 @@ CCSDS::ResultBool parseStream(const std::vector<std::uint8_t>& stream) {
 }
 ```
 
-For large or zero-copy streams, wrap this policy around the application's own buffering layer. The current v1 API accepts vectors.
+For large or zero-copy streams, wrap this policy around the application's own buffering layer. The current v2 parsing API accepts vectors.
 
 ## Create CRC-free packets
 
@@ -209,7 +212,9 @@ sender.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
 sender.setDataFieldSize(1024);
 sender.setPrimaryHeader({0, 0, 0, 0x123, CCSDS::UNSEGMENTED, 0, 0});
 sender.setApplicationData({0x01, 0x02});
-const auto wire = sender.serialize();
+const auto wireResult = sender.serialize();
+if (!wireResult) return wireResult.error().code();
+const auto &wire = wireResult.value();
 
 CCSDS::Packet receiver;
 receiver.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
@@ -235,7 +240,9 @@ if (!secondaryResult) return secondaryResult.error().code();
 const auto dataResult = packet.setApplicationData({0x10, 0x20});
 if (!dataResult) return dataResult.error().code();
 
-const auto wire = packet.serialize();
+const auto wireResult = packet.serialize();
+if (!wireResult) return wireResult.error().code();
+const auto &wire = wireResult.value();
 ```
 
 When parsing an opaque secondary header, provide its byte count:

--- a/docs/FLOW.md
+++ b/docs/FLOW.md
@@ -18,9 +18,9 @@ CCSDSPack exposes two main levels:
 2. Assign a version-0 `PrimaryHeader`.
 3. Configure the Packet Data Field capacity and packet-error-control mode.
 4. Add an optional secondary header and application data.
-5. Call `serialize()`.
+5. Call `serialize()` and check the returned `ResultBuffer`.
 
-`serialize()` finalizes Packet Data Length, the stored sequence count, and the optional CCSDSPack CRC16 trailer. Inspection getters do not perform hidden finalization.
+`serialize()` finalizes Packet Data Length, the stored sequence count, and the optional CCSDSPack CRC16 trailer. It returns the exact validation/finalization error instead of an empty byte vector. `update()` provides the same checked finalization without producing bytes. Inspection getters do not perform hidden finalization.
 
 ## Generate a packet stream
 
@@ -28,7 +28,7 @@ CCSDSPack exposes two main levels:
 2. Construct a `Manager` from the template or call `setPacketTemplate()`.
 3. Set the per-packet data capacity with `setDataFieldSize()`.
 4. Call `setApplicationData()` with the complete payload.
-5. Retrieve adjacent packet bytes with `getPacketsBuffer()` or persist them with `write()`.
+5. Retrieve adjacent packet bytes with `getPacketsBuffer()` and check its `ResultBuffer`, or persist them with `write()`.
 
 The Manager assigns `UNSEGMENTED` for one generated packet or `FIRST_SEGMENT`, `CONTINUING_SEGMENT`, and `LAST_SEGMENT` for a segmented sequence. Automatic Packet Sequence Count advances once per generated packet and wraps modulo 16384.
 

--- a/docs/MIGRATION_V1_TO_V2.md
+++ b/docs/MIGRATION_V1_TO_V2.md
@@ -34,6 +34,42 @@ The packet-template key is likewise renamed from `ccsds_data_field_header_flag` 
 `getSecondaryHeader()` returns a nullable shared pointer; the former unchecked
 reference getter is removed.
 
+## Serialization and finalization results
+
+v1.2 returned packet bytes directly and used an empty vector for every finalization
+failure. v2 makes the error channel explicit:
+
+| v1.2 API | v2 API |
+|---|---|
+| `std::vector<std::uint8_t> Packet::serialize()` | `ResultBuffer Packet::serialize()` |
+| `void Packet::update()` | `ResultBool Packet::update()` |
+| `std::vector<std::uint8_t> DataField::serialize()` | `ResultBuffer DataField::serialize()` |
+| `std::vector<std::uint8_t> Manager::getPacketsBuffer()` | `ResultBuffer Manager::getPacketsBuffer()` |
+
+Before:
+
+```cpp
+const auto wire = packet.serialize();
+if (wire.empty()) {
+  // The failure reason is unavailable.
+}
+```
+
+After:
+
+```cpp
+const auto wire = packet.serialize();
+if (!wire) {
+  log(wire.error().code(), wire.error().message());
+  return wire.error().code();
+}
+send(wire.value());
+```
+
+`serialize()` invokes checked finalization. `update()` exposes the same validation
+and dependent-field update without allocating the complete packet output. Manager
+stream serialization propagates the first packet error unchanged.
+
 ## Construction
 
 Before:

--- a/example/basic_packet/main.cpp
+++ b/example/basic_packet/main.cpp
@@ -24,11 +24,9 @@ int main() {
     return fail("setApplicationData", result.error());
   }
 
-  const auto wire = packet.serialize();
-  if (wire.empty()) {
-    std::cerr << "serialize: packet finalization failed\n";
-    return 1;
-  }
+  const auto wireResult = packet.serialize();
+  if (!wireResult) return fail("serialize", wireResult.error());
+  const auto &wire = wireResult.value();
 
   CCSDS::Packet decoded;
   decoded.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);

--- a/example/custom_secondary_header/main.cpp
+++ b/example/custom_secondary_header/main.cpp
@@ -55,7 +55,9 @@ int main() {
     return fail("setApplicationData", result.error());
   }
 
-  const auto wire = packet.serialize();
+  const auto wireResult = packet.serialize();
+  if (!wireResult) return fail("serialize", wireResult.error());
+  const auto &wire = wireResult.value();
   CCSDS::Packet decoded;
   if (const auto result = decoded.RegisterSecondaryHeader<MissionSecondaryHeader>(); !result) {
     return fail("RegisterSecondaryHeader decoder", result.error());

--- a/example/pus_c_telecommand/main.cpp
+++ b/example/pus_c_telecommand/main.cpp
@@ -34,7 +34,9 @@ int main() {
     return fail("setApplicationData", result.error());
   }
 
-  const auto wire = packet.serialize();
+  const auto wireResult = packet.serialize();
+  if (!wireResult) return fail("serialize", wireResult.error());
+  const auto &wire = wireResult.value();
   CCSDS::Packet decoded;
   if (const auto result = decoded.setMissionProfile(profile); !result) {
     return fail("setMissionProfile decoder", result.error());

--- a/example/pus_c_telemetry/main.cpp
+++ b/example/pus_c_telemetry/main.cpp
@@ -39,7 +39,9 @@ int main() {
     return fail("setApplicationData", result.error());
   }
 
-  const auto wire = packet.serialize();
+  const auto wireResult = packet.serialize();
+  if (!wireResult) return fail("serialize", wireResult.error());
+  const auto &wire = wireResult.value();
   CCSDS::Packet decoded;
   if (const auto result = decoded.setMissionProfile(profile); !result) {
     return fail("setMissionProfile decoder", result.error());

--- a/inc/CCSDSDataField.h
+++ b/inc/CCSDSDataField.h
@@ -176,9 +176,9 @@ namespace CCSDS {
 
     /**
      * @brief Finalizes the secondary header and serializes the complete data-field content.
-     * @return Secondary-header bytes followed by application-data bytes.
+     * @return Secondary-header bytes followed by application data, or a header/capacity error.
      */
-    std::vector<std::uint8_t> serialize();
+    [[nodiscard]] ResultBuffer serialize();
 
     /** @brief Returns a copy of application data without finalizing. */
     std::vector<std::uint8_t> getApplicationData();

--- a/inc/CCSDSManager.h
+++ b/inc/CCSDSManager.h
@@ -41,6 +41,7 @@ namespace CCSDS {
    * manager.setDataFieldSize(1024);
    * manager.setApplicationData(payload);
    * const auto stream = manager.getPacketsBuffer();
+   * if (!stream) return stream.error().code();
    * @endcode
    */
   class Manager {
@@ -50,14 +51,13 @@ namespace CCSDS {
 
     /**
      * @brief Constructs and binds a Manager to a packet template.
-     * @param packet Template copied into the Manager after finalization.
+     * @param packet Template copied into the Manager.
      *
      * The template's complete Packet Identification becomes immutable for packets
      * accepted by this Manager until clear() is called. Its sequence count becomes
      * the initial stream count.
      */
     explicit Manager(Packet packet) {
-      packet.update();
       m_templatePacket = std::move(packet);
       m_templateIsSet = true;
       m_sequenceCount = m_templatePacket.getPrimaryHeader().getSequenceCount() & SEQUENCE_COUNT_MASK;
@@ -86,7 +86,7 @@ namespace CCSDS {
     [[nodiscard]] bool getSyncPatternEnable() const;
 
     /**
-     * @brief Finalizes and installs a packet template, binding the Manager identifier.
+     * @brief Validates and installs a packet template, binding the Manager identifier.
      * @param packet Template packet to copy.
      * @return Success, TEMPLATE_SET_FAILURE when a template already exists, or a header error.
      * @note Call clear() before replacing an existing template.
@@ -170,21 +170,21 @@ namespace CCSDS {
      * @return Serialized template, or NO_DATA when serialization produces no bytes.
      * @note The stored template is not mutated by this inspection path.
      */
-    ResultBuffer getPacketTemplate();
+    [[nodiscard]] ResultBuffer getPacketTemplate();
 
     /**
      * @brief Finalizes a copy of one stored packet and returns its serialized bytes.
      * @param index Zero-based packet index.
      * @return Packet bytes, or an index, validation, or serialization error.
      */
-    ResultBuffer getPacketBufferAtIndex(std::uint16_t index);
+    [[nodiscard]] ResultBuffer getPacketBufferAtIndex(std::uint16_t index);
 
     /**
      * @brief Serializes all stored packets into one sequential byte buffer.
-     * @return Concatenated packet bytes, optionally prefixed by sync patterns.
+     * @return Concatenated packet bytes, or the first packet serialization error.
      * @note Stored packets are copied before finalization; this getter does not mutate them.
      */
-    [[nodiscard]] std::vector<std::uint8_t> getPacketsBuffer() const;
+    [[nodiscard]] ResultBuffer getPacketsBuffer() const;
 
     /**
      * @brief Reassembles application data from all stored packets in order.

--- a/inc/CCSDSPack.h
+++ b/inc/CCSDSPack.h
@@ -24,6 +24,7 @@
  * packet.setPrimaryHeader({0, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0});
  * packet.setApplicationData({0x01, 0x02});
  * const auto bytes = packet.serialize();
+ * if (!bytes) return bytes.error().code();
  * @endcode
  */
 #ifndef CCSDSPACK_H

--- a/inc/CCSDSPacket.h
+++ b/inc/CCSDSPacket.h
@@ -59,9 +59,10 @@ namespace CCSDS {
    *
    * @par Finalization
    * Setters mark the packet dirty. Getters only inspect the currently stored
-   * state and never call update(). update() recalculates dependent fields without
-   * producing bytes. serialize() calls update() and returns the finalized wire
-   * representation. Packet finalization accepts only encoded Packet Version
+   * state and never call update(). update() recalculates dependent fields and returns
+   * any validation error without producing bytes. serialize() calls update() and
+   * returns either the finalized wire representation or the same explicit error.
+   * Packet finalization accepts only encoded Packet Version
    * Number 000, as required by CCSDS 133.0-B-2.
    *
    * @par Idle packets
@@ -81,9 +82,10 @@ namespace CCSDS {
    *                          CCSDS::UNSEGMENTED, 0, 0});
    * packet.setApplicationData({0x10, 0x20});
    * const auto wire = packet.serialize();
+   * if (!wire) return;
    *
    * CCSDS::Packet decoded;
-   * const auto consumed = decoded.deserializeBounded(wire);
+   * const auto consumed = decoded.deserializeBounded(wire.value());
    * @endcode
    */
   class Packet {
@@ -339,10 +341,9 @@ namespace CCSDS {
 
     /**
      * @brief Finalizes and serializes the packet under the v2 mission profile.
-     * @return Complete wire bytes, or an empty vector when the header, version,
-     * Idle Packet structure, size, or update state is invalid.
+     * @return Complete wire bytes, or a specific header, profile, data, or finalization error.
      */
-    std::vector<std::uint8_t> serialize();
+    [[nodiscard]] ResultBuffer serialize();
 
     /** @brief Returns the currently stored six primary-header bytes without finalizing. */
     std::vector<std::uint8_t> getPrimaryHeaderBytes();
@@ -432,12 +433,12 @@ namespace CCSDS {
     /**
      * @brief Finalizes dependent packet state without returning serialized bytes.
      *
-     * When updates are enabled and the packet satisfies the active mission profile, this
-     * refreshes the secondary header, encodes Packet Data Length as Packet Data
-     * Field octets minus one, writes the cached sequence count, and recalculates
-     * the optional CRC16 trailer over the finalized header and preceding data.
+     * When updates are enabled, this validates the active mission profile, refreshes
+     * the secondary header, encodes Packet Data Length as Packet Data Field octets
+     * minus one, writes the cached sequence count, and recalculates the optional CRC16.
+     * @return Success, or a specific header, profile, data, or secondary-header error.
      */
-    void update();
+    [[nodiscard]] ResultBool update();
 
     /**
      * @brief Loads packet construction settings from a configuration file.

--- a/src/CCSDSDataField.cpp
+++ b/src/CCSDSDataField.cpp
@@ -5,9 +5,15 @@
 #include <CCSDSSecondaryHeaderFactory.h>
 #include <utility>
 
-std::vector<std::uint8_t> CCSDS::DataField::serialize() {
+CCSDS::ResultBuffer CCSDS::DataField::serialize() {
   update();
   const auto secondaryHeader = static_cast<const DataField &>(*this).getSecondaryHeaderBytes();
+  RET_IF_ERR_MSG(m_secondaryHeader && secondaryHeader.size() != m_secondaryHeader->getSize(),
+                 ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                 "Secondary header serialization failed or returned an unexpected size.");
+  RET_IF_ERR_MSG(secondaryHeader.size() + m_applicationData.size() > m_dataPacketSize,
+                 ErrorCode::INVALID_DATA,
+                 "Serialized packet data field exceeds its configured capacity.");
   std::vector<std::uint8_t> fullData{};
   fullData.reserve(secondaryHeader.size() + m_applicationData.size());
   fullData.insert(fullData.end(), secondaryHeader.begin(), secondaryHeader.end());

--- a/src/CCSDSManager.cpp
+++ b/src/CCSDSManager.cpp
@@ -73,10 +73,6 @@ CCSDS::ResultBool CCSDS::Manager::setPacketTemplate(Packet packet) {
   RET_IF_ERR_MSG(packet.getPrimaryHeader().getHeaderStatus() == INVALID,
                  ErrorCode::INVALID_HEADER_DATA, "Cannot set an invalid packet template");
 
-  packet.update();
-  RET_IF_ERR_MSG(packet.getPrimaryHeader().getHeaderStatus() == INVALID,
-                 ErrorCode::INVALID_HEADER_DATA, "Cannot finalize an invalid packet template");
-
   m_templatePacket = std::move(packet);
   m_sequenceCount = (m_sequenceCount & AUTO_SEQUENCE_DISABLED_MASK)
                     | (m_templatePacket.getPrimaryHeader().getSequenceCount()
@@ -197,10 +193,8 @@ void CCSDS::Manager::setAutoValidateEnable(const bool enable) {
 
 CCSDS::ResultBuffer CCSDS::Manager::getPacketTemplate() {
   auto packet = m_templatePacket;
-  const auto data = packet.serialize();
-  RET_IF_ERR_MSG(data.empty(), ErrorCode::NO_DATA,
-                 "Cannot get Packet template data, data is empty");
-  return data;
+  packet.setUpdatePacketEnable(true);
+  return packet.serialize();
 }
 
 CCSDS::ResultBuffer CCSDS::Manager::getPacketBufferAtIndex(const std::uint16_t index) {
@@ -209,20 +203,18 @@ CCSDS::ResultBuffer CCSDS::Manager::getPacketBufferAtIndex(const std::uint16_t i
 
   auto packet = m_packets[index];
   if (m_validateEnable) {
-    packet.update();
+    const auto updateResult = packet.update();
+    if (!updateResult) return updateResult.error();
     const std::string errorMessage =
       "Validation failure for packet at index " + std::to_string(index);
     RET_IF_ERR_MSG(!m_validator.validate(packet), ErrorCode::VALIDATION_FAILURE,
                    errorMessage);
   }
 
-  const auto packetBuffer = packet.serialize();
-  RET_IF_ERR_MSG(packetBuffer.empty(), ErrorCode::INVALID_HEADER_DATA,
-                 "Cannot serialize packet with an invalid header");
-  return packetBuffer;
+  return packet.serialize();
 }
 
-std::vector<std::uint8_t> CCSDS::Manager::getPacketsBuffer() const {
+CCSDS::ResultBuffer CCSDS::Manager::getPacketsBuffer() const {
   std::vector<std::uint8_t> buffer;
   for (auto packet : m_packets) {
     if (m_syncPattEnable) {
@@ -232,8 +224,8 @@ std::vector<std::uint8_t> CCSDS::Manager::getPacketsBuffer() const {
       buffer.push_back(static_cast<std::uint8_t>(m_syncPattern & 0xFFU));
     }
 
-    const auto packetBuffer = packet.serialize();
-    if (packetBuffer.empty()) return {};
+    std::vector<std::uint8_t> packetBuffer;
+    ASSIGN_MV(packetBuffer, packet.serialize());
     buffer.insert(buffer.end(), packetBuffer.begin(), packetBuffer.end());
   }
   return buffer;
@@ -365,10 +357,8 @@ CCSDS::ResultBool CCSDS::Manager::read(const std::string &binaryFile) {
 }
 
 CCSDS::ResultBool CCSDS::Manager::write(const std::string &binaryFile) const {
-  const auto buffer = getPacketsBuffer();
-  RET_IF_ERR_MSG(!m_packets.empty() && buffer.empty(),
-                 ErrorCode::INVALID_HEADER_DATA,
-                 "Cannot write packet stream containing an invalid header");
+  std::vector<std::uint8_t> buffer;
+  ASSIGN_MV(buffer, getPacketsBuffer());
   FORWARD_RESULT(writeBinaryFile(buffer, binaryFile));
   return true;
 }

--- a/src/CCSDSPacket.cpp
+++ b/src/CCSDSPacket.cpp
@@ -19,27 +19,57 @@ namespace {
     std::uint16_t receivedCRC{};
   };
 
-  bool packetProfileAllowsSerialization(const CCSDS::Header &header,
-                                        const CCSDS::DataField &dataField,
-                                        const CCSDS::MissionProfile &profile,
-                                        const CCSDS::PacketErrorControlMode errorControl) {
-    if (header.getVersionNumber() != 0U) return false;
+  CCSDS::ResultBool validatePacketForSerialization(
+      const CCSDS::Header &header,
+      const CCSDS::DataField &dataField,
+      const CCSDS::MissionProfile &profile,
+      const CCSDS::PacketErrorControlMode errorControl) {
+    RET_IF_ERR_MSG(header.getHeaderStatus() == CCSDS::INVALID,
+                   CCSDS::ErrorCode::INVALID_HEADER_DATA,
+                   "Cannot serialize packet: primary header is invalid.");
+    RET_IF_ERR_MSG(header.getVersionNumber() != 0U,
+                   CCSDS::ErrorCode::INVALID_HEADER_DATA,
+                   "Cannot serialize packet: unsupported CCSDS packet version.");
+    FORWARD_RESULT(CCSDS::validateMissionProfile(profile));
     if (header.getAPID() == CCSDS::IDLE_APID) {
-      return !profile.pusEnabled && header.getSecondaryHeaderFlag() == 0U
-             && !dataField.getSecondaryHeaderFlag()
-             && dataField.getApplicationDataBytesSize() > 0U;
+      RET_IF_ERR_MSG(profile.pusEnabled, CCSDS::ErrorCode::INVALID_DATA,
+                     "Cannot serialize Idle Packet with a PUS mission profile.");
+      RET_IF_ERR_MSG(header.getSecondaryHeaderFlag() != 0U,
+                     CCSDS::ErrorCode::INVALID_HEADER_DATA,
+                     "Cannot serialize Idle Packet: secondary-header flag must be zero.");
+      RET_IF_ERR_MSG(dataField.getSecondaryHeaderFlag(),
+                     CCSDS::ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                     "Cannot serialize Idle Packet with a secondary header.");
+      RET_IF_ERR_MSG(dataField.getApplicationDataBytesSize() == 0U,
+                     CCSDS::ErrorCode::INVALID_DATA,
+                     "Cannot serialize Idle Packet without mission-defined idle user data.");
+      return true;
     }
 
-    const auto profileResult = CCSDS::validateMissionProfile(profile);
-    if (!profileResult) return false;
     const auto secondary = dataField.getSecondaryHeader();
-    if (!profile.pusEnabled) return !secondary || !secondary->isPusHeader();
-    if (!secondary || !secondary->isPusHeader()
-        || !secondary->matchesMissionProfile(profile)
-        || errorControl != profile.packetErrorControl
-        || header.getSecondaryHeaderFlag() == 0U) return false;
+    RET_IF_ERR_MSG((header.getSecondaryHeaderFlag() != 0U) != static_cast<bool>(secondary),
+                   CCSDS::ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                   "Cannot serialize packet: primary-header flag and secondary-header state differ.");
+    if (!profile.pusEnabled) {
+      RET_IF_ERR_MSG(secondary && secondary->isPusHeader(),
+                     CCSDS::ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                     "Cannot serialize a PUS secondary header with a generic mission profile.");
+      return true;
+    }
+    RET_IF_ERR_MSG(!secondary || !secondary->isPusHeader(),
+                   CCSDS::ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                   "Cannot serialize a PUS packet without a standards-defined PUS secondary header.");
+    RET_IF_ERR_MSG(!secondary->matchesMissionProfile(profile),
+                   CCSDS::ErrorCode::INVALID_SECONDARY_HEADER_DATA,
+                   "Cannot serialize packet: PUS secondary header does not match the mission profile.");
+    RET_IF_ERR_MSG(errorControl != profile.packetErrorControl,
+                   CCSDS::ErrorCode::INVALID_DATA,
+                   "Cannot serialize packet: packet error control differs from the mission profile.");
     const auto expectedType = profile.direction == CCSDS::PacketDirection::Telecommand ? 1U : 0U;
-    return header.getType() == expectedType;
+    RET_IF_ERR_MSG(header.getType() != expectedType,
+                   CCSDS::ErrorCode::INVALID_HEADER_DATA,
+                   "Cannot serialize packet: primary-header type differs from the PUS direction.");
+    return true;
   }
 
   CCSDS::Result<std::size_t> declaredPacketSize(const std::vector<std::uint8_t> &data) {
@@ -128,25 +158,29 @@ namespace {
   }
 }
 
-void CCSDS::Packet::update() {
-  if (m_updateStatus || !m_enableUpdatePacket) return;
-  if (m_primaryHeader.getHeaderStatus() == INVALID) return;
-  if (!packetProfileAllowsSerialization(m_primaryHeader, m_dataField, m_missionProfile,
-                                        getPacketErrorControlMode())) return;
+CCSDS::ResultBool CCSDS::Packet::update() {
+  FORWARD_RESULT(validatePacketForSerialization(m_primaryHeader, m_dataField, m_missionProfile,
+                                                getPacketErrorControlMode()));
+  if (m_updateStatus || !m_enableUpdatePacket) return true;
 
-  const auto dataField = m_dataField.serialize();
+  std::vector<std::uint8_t> dataField;
+  ASSIGN_MV(dataField, m_dataField.serialize());
   const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
   constexpr auto maximumPacketDataFieldSize =
     static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1U;
 
-  if (packetDataFieldSize == 0U || packetDataFieldSize > maximumPacketDataFieldSize) return;
+  RET_IF_ERR_MSG(packetDataFieldSize == 0U, ErrorCode::INVALID_DATA,
+                 "Cannot finalize packet: Packet Data Field is empty.");
+  RET_IF_ERR_MSG(packetDataFieldSize > maximumPacketDataFieldSize, ErrorCode::INVALID_DATA,
+                 "Cannot finalize packet: Packet Data Field exceeds the CCSDS length field.");
 
   m_primaryHeader.setDataLength(static_cast<std::uint16_t>(packetDataFieldSize - 1U));
-  if (!m_primaryHeader.setSequenceCount(m_sequenceCounter & SEQUENCE_COUNT_MASK)) return;
+  FORWARD_RESULT(m_primaryHeader.setSequenceCount(m_sequenceCounter & SEQUENCE_COUNT_MASK));
 
   if (getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
     auto crcInput = static_cast<const Header &>(m_primaryHeader).serialize();
-    if (crcInput.size() != 6U) return;
+    RET_IF_ERR_MSG(crcInput.size() != 6U, ErrorCode::INVALID_HEADER_DATA,
+                   "Cannot finalize packet: primary-header serialization failed.");
     crcInput.insert(crcInput.end(), dataField.begin(), dataField.end());
     m_CRC16 = ::crc16(crcInput, m_CRC16Config.polynomial, m_CRC16Config.initialValue,
                       m_CRC16Config.finalXorValue);
@@ -154,6 +188,7 @@ void CCSDS::Packet::update() {
     m_CRC16 = 0U;
   }
   m_updateStatus = true;
+  return true;
 }
 
 #ifndef CCSDS_MCU
@@ -250,12 +285,14 @@ CCSDS::ResultBool CCSDS::Packet::loadFromConfig(const Config &cfg) {
     FORWARD_RESULT(m_dataField.setApplicationData(applicationData));
   }
 
-  RET_IF_ERR_MSG(m_primaryHeader.getAPID() == IDLE_APID
-                 && !packetProfileAllowsSerialization(m_primaryHeader, m_dataField,
-                                                      m_missionProfile,
-                                                      getPacketErrorControlMode()),
-                 ErrorCode::CONFIG_FILE_ERROR,
-                 "Config: Idle Packets require no secondary header and non-empty idle user data");
+  if (m_primaryHeader.getAPID() == IDLE_APID) {
+    const auto idleResult = validatePacketForSerialization(
+      m_primaryHeader, m_dataField, m_missionProfile, getPacketErrorControlMode());
+    if (!idleResult) {
+      return Error{ErrorCode::CONFIG_FILE_ERROR,
+                   "Config: invalid Idle Packet: " + idleResult.error().message()};
+    }
+  }
 
   return true;
 }
@@ -350,24 +387,26 @@ std::vector<std::uint8_t> CCSDS::Packet::getFullDataFieldBytes() const {
   return data;
 }
 
-std::vector<std::uint8_t> CCSDS::Packet::serialize() {
-  if (m_primaryHeader.getHeaderStatus() == INVALID) return {};
-  if (!packetProfileAllowsSerialization(m_primaryHeader, m_dataField, m_missionProfile,
-                                        getPacketErrorControlMode())) return {};
+CCSDS::ResultBuffer CCSDS::Packet::serialize() {
+  const auto updateResult = update();
+  if (!updateResult) return updateResult.error();
+  const auto header = static_cast<const Header &>(m_primaryHeader).serialize();
+  RET_IF_ERR_MSG(header.size() != 6U, ErrorCode::INVALID_HEADER_DATA,
+                 "Cannot serialize packet: primary-header serialization failed.");
+  std::vector<std::uint8_t> dataField;
+  ASSIGN_MV(dataField, m_dataField.serialize());
 
-  const auto currentDataField = getFullDataFieldBytes();
-  const auto currentPacketDataFieldSize = currentDataField.size() + getPacketErrorControlSize();
+  const auto packetDataFieldSize = dataField.size() + getPacketErrorControlSize();
   constexpr auto maximumPacketDataFieldSize =
     static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1U;
-  if (currentPacketDataFieldSize == 0U || currentPacketDataFieldSize > maximumPacketDataFieldSize) {
-    return {};
-  }
-
-  update();
-  if (!m_updateStatus && m_enableUpdatePacket) return {};
-  const auto header = static_cast<const Header &>(m_primaryHeader).serialize();
-  if (header.size() != 6U) return {};
-  const auto dataField = getFullDataFieldBytes();
+  RET_IF_ERR_MSG(packetDataFieldSize == 0U, ErrorCode::INVALID_DATA,
+                 "Cannot serialize packet: Packet Data Field is empty.");
+  RET_IF_ERR_MSG(packetDataFieldSize > maximumPacketDataFieldSize, ErrorCode::INVALID_DATA,
+                 "Cannot serialize packet: Packet Data Field exceeds the CCSDS length field.");
+  RET_IF_ERR_MSG(static_cast<std::size_t>(m_primaryHeader.getDataLength()) + 1U
+                   != packetDataFieldSize,
+                 ErrorCode::INVALID_DATA,
+                 "Cannot serialize packet: Packet Data Length does not match the finalized data field.");
 
   std::vector<std::uint8_t> packet;
   packet.reserve(header.size() + dataField.size() + getPacketErrorControlSize());

--- a/src/CCSDSUtils.cpp
+++ b/src/CCSDSUtils.cpp
@@ -199,7 +199,12 @@ void printPackets(CCSDS::Manager& manager) {
     std::cout << "[ CCSDS Manager ] Printing Packet [ " << idx << " ]:" << std::endl;
     std::cout << "[ CCSDS Manager ] Packet Length : " << packet.getFullPacketLength() << " bytes" << std::endl;
     std::cout << "[ CCSDS Manager ] Data ";
-    printBufferData(packet.serialize(), 20);
+    const auto serialized = packet.serialize();
+    if (serialized) {
+      printBufferData(serialized.value(), 20);
+    } else {
+      std::cout << "[ Error ]: " << serialized.error().message() << std::endl;
+    }
     printPacket(packet);
     idx++;
   }

--- a/src/exec_encoder.cpp
+++ b/src/exec_encoder.cpp
@@ -162,13 +162,10 @@ int main(const int argc, char *argv[]) {
   if (args["verbose"] == "true") printPackets(manager);
 
   const auto packets = manager.getPacketsBuffer();
-  if (!manager.getPackets().empty() && packets.empty()) {
-    return printError(CCSDS::Error{CCSDS::ErrorCode::INVALID_HEADER_DATA,
-                                   "Unable to serialize generated packet stream"});
-  }
+  if (!packets) return printError(packets.error());
 
   customConsole(appName, "writing data to " + output);
-  if (const auto result = writeBinaryFile(packets, output); !result) {
+  if (const auto result = writeBinaryFile(packets.value(), output); !result) {
     return printError(result.error());
   }
 

--- a/test/inc/tests.h
+++ b/test/inc/tests.h
@@ -4,7 +4,30 @@
 #ifndef TESTS_H
 #define TESTS_H
 
+#include <CCSDSManager.h>
+#include <iostream>
+#include <vector>
 #include "TestManager.h"
+
+inline std::vector<std::uint8_t> serializedPacket(CCSDS::Packet &packet) {
+  const auto result = packet.serialize();
+  if (!result) {
+    std::cerr << "[ Error ]: Code [" << result.error().code()
+              << "]: " << result.error().message() << '\n';
+    return {};
+  }
+  return result.value();
+}
+
+inline std::vector<std::uint8_t> serializedPackets(const CCSDS::Manager &manager) {
+  const auto result = manager.getPacketsBuffer();
+  if (!result) {
+    std::cerr << "[ Error ]: Code [" << result.error().code()
+              << "]: " << result.error().message() << '\n';
+    return {};
+  }
+  return result.value();
+}
 
 void testGroupCore(TestManager *tester, const std::string &description);
 void testGroupValidator(TestManager *tester, const std::string &description);

--- a/test/package_tester/shared_lib/src/main.cpp
+++ b/test/package_tester/shared_lib/src/main.cpp
@@ -92,7 +92,9 @@ int main() {
     0xB7, 0x45
   };
 
-  const auto packetsData = manager.getPacketsBuffer();
+  const auto packetsResult = manager.getPacketsBuffer();
+  if (!packetsResult) return failResult("serialize Manager packets", packetsResult.error());
+  const auto &packetsData = packetsResult.value();
   if (packetsData != expectedPacket) {
     return fail("wire vector", "generated generic packet bytes differ from the expected vector");
   }
@@ -185,7 +187,11 @@ int main() {
   if (const auto result = crcDisabled.setApplicationData({0xAA, 0x55}); !result) {
     return failResult("CRC-disabled application data", result.error());
   }
-  const auto crcDisabledBytes = crcDisabled.serialize();
+  const auto crcDisabledResult = crcDisabled.serialize();
+  if (!crcDisabledResult) {
+    return failResult("serialize CRC-disabled packet", crcDisabledResult.error());
+  }
+  const auto &crcDisabledBytes = crcDisabledResult.value();
   const std::vector<std::uint8_t> expectedCrcDisabled{
     0x01, 0x23, 0xC0, 0x07, 0x00, 0x01, 0xAA, 0x55
   };
@@ -213,7 +219,7 @@ int main() {
   if (const auto result = invalidVersion.setApplicationData({0x01}); !result) {
     return failResult("non-zero PVN data", result.error());
   }
-  if (!invalidVersion.serialize().empty()) {
+  if (invalidVersion.serialize()) {
     return fail("Packet Version Number", "non-zero PVN was serialized as a Space Packet");
   }
 
@@ -229,7 +235,7 @@ int main() {
   if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {
     return failResult("Idle Packet data", result.error());
   }
-  if (!invalidIdle.serialize().empty()) {
+  if (invalidIdle.serialize()) {
     return fail("Idle Packet", "Idle Packet with a secondary header was serialized");
   }
 
@@ -242,8 +248,10 @@ int main() {
   if (const auto result = validIdle.setApplicationData({0x00}); !result) {
     return failResult("valid Idle Packet data", result.error());
   }
-  const auto validIdleBytes = validIdle.serialize();
-  if (validIdleBytes.empty() || validIdle.getSerializedSize() != validIdleBytes.size()) {
+  const auto validIdleResult = validIdle.serialize();
+  if (!validIdleResult) return failResult("serialize valid Idle Packet", validIdleResult.error());
+  const auto &validIdleBytes = validIdleResult.value();
+  if (validIdle.getSerializedSize() != validIdleBytes.size()) {
     return fail("valid Idle Packet", "conformant Idle Packet did not serialize");
   }
 

--- a/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+++ b/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
@@ -133,7 +133,9 @@ namespace CCSDSPackMcuTest {
       0xB7, 0x45
     };
 
-    const auto packetsData = manager.getPacketsBuffer();
+    const auto packetsResult = manager.getPacketsBuffer();
+    if (!packetsResult) return WireVectorMismatch;
+    const auto &packetsData = packetsResult.value();
     if (packetsData != expectedPacket) {
       return WireVectorMismatch;
     }
@@ -185,7 +187,9 @@ namespace CCSDSPackMcuTest {
     const std::vector<std::uint8_t> expectedCrcDisabled{
       0x01, 0x23, 0xC0, 0x07, 0x00, 0x01, 0xAA, 0x55
     };
-    const auto crcDisabledBytes = crcDisabled.serialize();
+    const auto crcDisabledResult = crcDisabled.serialize();
+    if (!crcDisabledResult) return CrcFreeVectorMismatch;
+    const auto &crcDisabledBytes = crcDisabledResult.value();
     if (crcDisabledBytes != expectedCrcDisabled) {
       return CrcFreeVectorMismatch;
     }
@@ -211,7 +215,7 @@ namespace CCSDSPackMcuTest {
     if (const auto result = invalidVersion.setApplicationData({0x01}); !result) {
       return InvalidVersionDataFailed;
     }
-    if (!invalidVersion.serialize().empty()) {
+    if (invalidVersion.serialize()) {
       return InvalidVersionSerialized;
     }
 
@@ -227,7 +231,7 @@ namespace CCSDSPackMcuTest {
     if (const auto result = invalidIdle.setApplicationData({0x00}); !result) {
       return InvalidIdleDataFailed;
     }
-    if (!invalidIdle.serialize().empty()) {
+    if (invalidIdle.serialize()) {
       return InvalidIdleSerialized;
     }
 
@@ -240,8 +244,10 @@ namespace CCSDSPackMcuTest {
     if (const auto result = validIdle.setApplicationData({0x00}); !result) {
       return ValidIdleDataFailed;
     }
-    const auto validIdleBytes = validIdle.serialize();
-    if (validIdleBytes.empty() || validIdle.getSerializedSize() != validIdleBytes.size()) {
+    const auto validIdleResult = validIdle.serialize();
+    if (!validIdleResult) return ValidIdleSerializationFailed;
+    const auto &validIdleBytes = validIdleResult.value();
+    if (validIdle.getSerializedSize() != validIdleBytes.size()) {
       return ValidIdleSerializationFailed;
     }
 

--- a/test/src/testGroupConformance.cpp
+++ b/test/src/testGroupConformance.cpp
@@ -34,7 +34,8 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
       1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0
     }));
     TEST_VOID(packet.setApplicationData({0x01}));
-    return packet.serialize().empty();
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_HEADER_DATA;
   });
 
   tester->unitTest("Configuration accepts only Packet Version Number zero", []() {
@@ -69,7 +70,8 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
     }));
     TEST_VOID(packet.setSecondaryHeader({0x10}));
     TEST_VOID(packet.setApplicationData({0x00}));
-    return packet.serialize().empty();
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_HEADER_DATA;
   });
 
   tester->unitTest("Idle Packet rejects an asserted secondary-header flag", []() {
@@ -78,7 +80,8 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
       0, 0, 1, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
     }));
     TEST_VOID(packet.setApplicationData({0x00}));
-    return packet.serialize().empty();
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_HEADER_DATA;
   });
 
   tester->unitTest("Idle Packet requires mission-defined idle user data", []() {
@@ -86,7 +89,8 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
     TEST_VOID(packet.setPrimaryHeader(CCSDS::PrimaryHeader{
       0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
     }));
-    return packet.serialize().empty();
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_DATA;
   });
 
   tester->unitTest("Received Idle Packet rejects secondary-header flag", []() {
@@ -117,7 +121,7 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
       0, 0, 0, CCSDS::IDLE_APID, CCSDS::UNSEGMENTED, 0, 0
     }));
     TEST_VOID(packet.setApplicationData({0x00}));
-    const auto bytes = packet.serialize();
+    const auto bytes = serializedPacket(packet);
     return bytes.size() == 9U
            && packet.getPrimaryHeader().getHeaderStatus() == CCSDS::IDLE
            && packet.getPrimaryHeader().getSecondaryHeaderFlag() == 0U;
@@ -127,7 +131,7 @@ void testGroupConformance(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     packet.setDataFieldSize(0xFFFEU);
     TEST_VOID(packet.setApplicationData(std::vector<std::uint8_t>(0xFFFEU, 0x00)));
-    const auto bytes = packet.serialize();
+    const auto bytes = serializedPacket(packet);
     return bytes.size() == 65542U
            && packet.getSerializedSize() == 65542U
            && packet.getFullPacketLength() == 0xFFFFU;

--- a/test/src/testGroupCore.cpp
+++ b/test/src/testGroupCore.cpp
@@ -57,6 +57,17 @@ namespace {
   private:
     std::vector<std::uint8_t> m_data{};
   };
+
+  class FailingSecondaryHeader final : public CCSDS::SecondaryHeaderAbstract {
+  public:
+    [[nodiscard]] CCSDS::ResultBool deserialize(
+        const std::vector<std::uint8_t> &) override { return true; }
+    [[nodiscard]] std::uint16_t getSize() const override { return 1U; }
+    [[nodiscard]] std::string getType() const override { return "FailingSecondaryHeader"; }
+    [[nodiscard]] std::vector<std::uint8_t> serialize() const override { return {}; }
+    void update(CCSDS::DataField *) override {}
+    CCSDS::ResultBool loadFromConfig(const Config &) override { return true; }
+  };
 }
 
 void testGroupCore(TestManager *tester, const std::string &description) {
@@ -86,7 +97,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     TEST_VOID(packet.setApplicationData({1, 2, 3, 4, 5}));
     if (packet.getCRC() != 0U) return false;
-    packet.update();
+    TEST_VOID(packet.update());
     return packet.getApplicationDataBytes() == std::vector<std::uint8_t>({1, 2, 3, 4, 5})
            && packet.getSecondaryHeaderBytes().empty()
            && packet.getCRC() == 0x3B8D;
@@ -106,7 +117,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     const auto dataField = packet.getFullDataFieldBytes();
     if (dataField != std::vector<std::uint8_t>({1, 2, 3, 4, 5})) return false;
     if (packet.getCRC() != 0U) return false;
-    packet.update();
+    TEST_VOID(packet.update());
     return packet.getCRC() == 0x9903;
   });
 
@@ -160,7 +171,7 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     TEST_VOID(packet.setSecondaryHeader(std::make_shared<UpdatingSecondaryHeader>()));
     TEST_VOID(packet.setApplicationData({0xAA}));
 
-    const auto encoded = packet.serialize();
+    const auto encoded = serializedPacket(packet);
     return !encoded.empty()
            && packet.getPrimaryHeader().getSequenceCount() == 9U
            && packet.getPrimaryHeader().getDataLength() == 3U
@@ -168,12 +179,38 @@ void testGroupCore(TestManager *tester, const std::string &description) {
            && packet.getCRC() != 0U;
   });
 
+  tester->unitTest("Finalization and serialization return secondary-header errors.", [] {
+    CCSDS::Packet packet;
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<FailingSecondaryHeader>()));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+
+    const auto updateResult = packet.update();
+    const auto serializeResult = packet.serialize();
+    return !updateResult
+           && updateResult.error().code() == CCSDS::INVALID_SECONDARY_HEADER_DATA
+           && !serializeResult
+           && serializeResult.error().code() == CCSDS::INVALID_SECONDARY_HEADER_DATA;
+  });
+
+  tester->unitTest("Serialization reports a stale manual Packet Data Length.", [] {
+    CCSDS::Packet packet;
+    packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
+    TEST_VOID(packet.setPrimaryHeader(
+      CCSDS::PrimaryHeader{0U, 0U, 0U, 1U, CCSDS::UNSEGMENTED, 0U, 7U}));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+    packet.setUpdatePacketEnable(false);
+
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_DATA
+           && result.error().message().find("Packet Data Length") != std::string::npos;
+  });
+
   tester->unitTest("Parsed packet inspection preserves received sequence and CRC.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setPrimaryHeader(
       CCSDS::PrimaryHeader{0, 0, 0, 0x123, CCSDS::UNSEGMENTED, 123, 0}));
     TEST_VOID(source.setApplicationData({0xDE, 0xAD}));
-    const auto encoded = source.serialize();
+    const auto encoded = serializedPacket(source);
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(encoded));
@@ -194,18 +231,18 @@ void testGroupCore(TestManager *tester, const std::string &description) {
     CCSDS::Packet source;
     TEST_VOID(source.setSecondaryHeader({1, 2}));
     TEST_VOID(source.setApplicationData({3, 4, 5}));
-    const auto encoded = source.serialize();
+    const auto encoded = serializedPacket(source);
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(encoded, 2));
     decoded.setUpdatePacketEnable(false);
-    return decoded.serialize() == encoded;
+    return serializedPacket(decoded) == encoded;
   });
 
   tester->unitTest("Binary file helpers round-trip packet bytes.", [] {
     CCSDS::Packet packet;
     TEST_VOID(packet.setApplicationData({0xDE, 0xAD, 0xBE, 0xEF}));
-    const auto encoded = packet.serialize();
+    const auto encoded = serializedPacket(packet);
     const std::string path = "test_resources/core_packet.bin";
     TEST_VOID(writeBinaryFile(encoded, path));
     std::vector<std::uint8_t> decoded;

--- a/test/src/testGroupEdgeCases.cpp
+++ b/test/src/testGroupEdgeCases.cpp
@@ -70,7 +70,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     std::vector<uint8_t> largeData(1024, 0x5A);
     TEST_VOID(pkt.setApplicationData(largeData));
 
-    auto buffer = pkt.serialize();
+    auto buffer = serializedPacket(pkt);
     if (buffer.size() < 1024 + 6 + 2) return false;
 
     CCSDS::Packet pktDec;
@@ -124,7 +124,10 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0, 0, 0, static_cast<std::uint16_t>(CCSDS::IDLE_APID + 1U),
       CCSDS::UNSEGMENTED, 0, 0
     });
-    return !result && packet.serialize().empty() && packet.getPrimaryHeaderBytes().empty();
+    const auto serialized = packet.serialize();
+    return !result && !serialized
+           && serialized.error().code() == CCSDS::INVALID_HEADER_DATA
+           && packet.getPrimaryHeaderBytes().empty();
   });
 
   tester->unitTest("Configuration supports the complete APID range and rejects overflow", []() {
@@ -167,7 +170,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     if (packet.getPacketErrorControlSize() != 2) return false;
 
     TEST_VOID(packet.setApplicationData({0xAA, 0x55}));
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
     return serialized.size() == 10 && packet.getFullPacketLength() == 10;
   });
 
@@ -176,7 +179,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     packet.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
     TEST_VOID(packet.setApplicationData({0xAA, 0x55}));
 
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
     if (serialized.size() != 8) return false;
     if (packet.getFullPacketLength() != 8) return false;
     if (!packet.getCRCVectorBytes().empty()) return false;
@@ -191,7 +194,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
   tester->unitTest("CRC16 mode still strips the received error control field", []() {
     CCSDS::Packet packet;
     TEST_VOID(packet.setApplicationData({0x10, 0x20, 0x30}));
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(serialized));
@@ -207,7 +210,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0x00, 0x00, 0xC0, 0x00, 0x00, 0x03, 0xAA, 0x55, 0x2E, 0xBB
     };
 
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
     return serialized == expected && packet.getPrimaryHeader().getDataLength() == 3U;
   });
 
@@ -220,7 +223,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0x00, 0x00, 0xC0, 0x00, 0x00, 0x01, 0xAA, 0x55
     };
 
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
     return serialized == expected && packet.getPrimaryHeader().getDataLength() == 1U;
   });
 
@@ -235,7 +238,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0x99, 0x03
     };
 
-    return packet.serialize() == expected;
+    return serializedPacket(packet) == expected;
   });
 
   tester->unitTest("Configured CRC16 parameters remain effective", []() {
@@ -247,7 +250,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0x00, 0x00, 0xC0, 0x00, 0x00, 0x03, 0xAA, 0x55, 0x1F, 0x85
     };
 
-    return packet.serialize() == expected;
+    return serializedPacket(packet) == expected;
   });
 
   tester->unitTest("Independent minimum packet vector encodes and decodes", []() {
@@ -255,7 +258,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     if (!readHexResource("ccsds_golden_minimum_crc16.hex", expected)) return false;
 
     CCSDS::Packet generated;
-    if (generated.serialize() != expected) return false;
+    if (serializedPacket(generated) != expected) return false;
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected));
@@ -278,7 +281,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
 
     CCSDS::Packet generated;
     TEST_VOID(generated.setApplicationData({0xAA, 0x55}));
-    if (generated.serialize() != expected) return false;
+    if (serializedPacket(generated) != expected) return false;
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected));
@@ -295,7 +298,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     CCSDS::Packet generated;
     TEST_VOID(generated.setSecondaryHeader({0x01, 0x02, 0x03}));
     TEST_VOID(generated.setApplicationData({0x04, 0x05}));
-    if (generated.serialize() != expected) return false;
+    if (serializedPacket(generated) != expected) return false;
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected, 3U));
@@ -313,7 +316,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     CCSDS::Packet generated;
     generated.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
     TEST_VOID(generated.setApplicationData({0xAA, 0x55}));
-    if (generated.serialize() != expected) return false;
+    if (serializedPacket(generated) != expected) return false;
 
     CCSDS::Packet decoded;
     decoded.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
@@ -333,7 +336,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
       0, 1, 0, 0x123, CCSDS::UNSEGMENTED, 0x123, 0
     }));
     TEST_VOID(generated.setApplicationData({0xDE, 0xAD}));
-    if (generated.serialize() != expected) return false;
+    if (serializedPacket(generated) != expected) return false;
 
     CCSDS::Packet decoded;
     TEST_VOID(decoded.deserialize(expected));
@@ -365,8 +368,8 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     }));
     TEST_VOID(generatedSecond.setApplicationData({0xBB}));
 
-    auto generated = generatedFirst.serialize();
-    const auto generatedSecondBytes = generatedSecond.serialize();
+    auto generated = serializedPacket(generatedFirst);
+    const auto generatedSecondBytes = serializedPacket(generatedSecond);
     generated.insert(generated.end(), generatedSecondBytes.begin(), generatedSecondBytes.end());
     if (generated != expected) return false;
 
@@ -401,7 +404,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     packet.setDataFieldSize(0xFFFEU);
     TEST_VOID(packet.setApplicationData(std::vector<std::uint8_t>(0xFFFEU, 0x00)));
 
-    const auto serialized = packet.serialize();
+    const auto serialized = serializedPacket(packet);
     return serialized.size() == 0x10006U
            && serialized[4] == 0xFF
            && serialized[5] == 0xFF
@@ -412,6 +415,7 @@ void testGroupEdgeCases(TestManager *tester, const std::string &description) {
     CCSDS::Packet packet;
     packet.setDataFieldSize(0xFFFFU);
     TEST_VOID(packet.setApplicationData(std::vector<std::uint8_t>(0xFFFFU, 0x00)));
-    return packet.serialize().empty();
+    const auto result = packet.serialize();
+    return !result && result.error().code() == CCSDS::INVALID_DATA;
   });
 }

--- a/test/src/testGroupManagement.cpp
+++ b/test/src/testGroupManagement.cpp
@@ -36,7 +36,7 @@ namespace {
     auto packet = makePacket(apid, flags, count, CCSDS::PacketErrorControlMode::CRC16,
                              0U, type, 0U);
     const auto result = packet.setApplicationData({1, 2});
-    if (!result || packet.serialize().empty()) {
+    if (!result || !packet.serialize()) {
       return {};
     }
     packet.setUpdatePacketEnable(false);
@@ -81,7 +81,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     packet.setSequenceFlags(CCSDS::UNSEGMENTED);
     TEST_VOID(packet.setSequenceCount(123));
     TEST_VOID(packet.setApplicationData({0xAA}));
-    const auto encoded = packet.serialize();
+    const auto encoded = serializedPacket(packet);
     return !encoded.empty()
            && packet.getPrimaryHeader().getSequenceCount() == 123U
            && (static_cast<std::uint16_t>(encoded[2] & 0x3FU) << 8U | encoded[3]) == 123U;
@@ -211,8 +211,8 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
   tester->unitTest("Concatenated buffer loads reject mixed identifiers transactionally.", [] {
     auto packet1 = finalizedPacket(1, CCSDS::FIRST_SEGMENT, 1, 0);
     auto packet2 = finalizedPacket(1, CCSDS::LAST_SEGMENT, 2, 1);
-    auto buffer = packet1.serialize();
-    const auto bytes2 = packet2.serialize();
+    auto buffer = serializedPacket(packet1);
+    const auto bytes2 = serializedPacket(packet2);
     buffer.insert(buffer.end(), bytes2.begin(), bytes2.end());
 
     CCSDS::Manager manager;
@@ -243,7 +243,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     producer.setDataFieldSize(5);
     const std::vector<std::uint8_t> input{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7};
     TEST_VOID(producer.setApplicationData(input));
-    const auto buffer = producer.getPacketsBuffer();
+    const auto buffer = serializedPackets(producer);
 
     CCSDS::Manager consumer;
     consumer.setAutoValidateEnable(false);
@@ -251,7 +251,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     std::vector<std::uint8_t> reassembled;
     TEST_RET(reassembled, consumer.getApplicationDataBuffer());
     if (consumer.getTotalPackets() != 3U || reassembled != input
-        || consumer.getPacketsBuffer() != buffer) {
+        || serializedPackets(consumer) != buffer) {
       return false;
     }
 
@@ -268,7 +268,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     producer.setDataFieldSize(3);
     producer.setSyncPatternEnable(true);
     TEST_VOID(producer.setApplicationData({1, 2, 3, 4, 5}));
-    const auto framed = producer.getPacketsBuffer();
+    const auto framed = serializedPackets(producer);
     if (framed.size() < 4U || framed[0] != 0x1A || framed[1] != 0xCF
         || framed[2] != 0xFC || framed[3] != 0x1D) {
       return false;
@@ -288,7 +288,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     producer.setAutoValidateEnable(false);
     producer.setDataFieldSize(4);
     TEST_VOID(producer.setApplicationData({1, 2, 3, 4, 5, 6}));
-    const auto expected = producer.getPacketsBuffer();
+    const auto expected = serializedPackets(producer);
     const std::string path = "test_resources/myPackets.bin";
     TEST_VOID(producer.write(path));
 
@@ -296,7 +296,7 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     consumer.setAutoValidateEnable(false);
     TEST_VOID(consumer.read(path));
     std::remove(path.c_str());
-    return consumer.getPacketsBuffer() == expected;
+    return serializedPackets(consumer) == expected;
   });
 
   tester->unitTest("Manager preserves secondary headers while segmenting.", [] {
@@ -327,6 +327,17 @@ void testGroupManagement(TestManager *tester, const std::string &description) {
     TEST_RET(serialized, manager.getPacketBufferAtIndex(0));
     return serialized == std::vector<std::uint8_t>({0x00, 0x01, 0xC0, 0x00,
                                                      0x00, 0x01, 0xAA, 0x55});
+  });
+
+  tester->unitTest("Manager propagates packet serialization errors.", [] {
+    CCSDS::Manager manager;
+    manager.setAutoValidateEnable(false);
+    TEST_VOID(manager.addPacket(makePacket(1U, CCSDS::UNSEGMENTED, 0U,
+                                           CCSDS::PacketErrorControlMode::CRC16,
+                                           1U)));
+
+    const auto result = manager.getPacketsBuffer();
+    return !result && result.error().code() == CCSDS::INVALID_HEADER_DATA;
   });
 
   tester->unitTest("Manager rejects data without a template or with an empty payload.", [] {

--- a/test/src/testGroupParsing.cpp
+++ b/test/src/testGroupParsing.cpp
@@ -22,8 +22,8 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
     CCSDS::Packet second;
     TEST_VOID(first.setApplicationData({0x10, 0x20}));
     TEST_VOID(second.setApplicationData({0x30, 0x40, 0x50}));
-    const auto firstBytes = first.serialize();
-    const auto secondBytes = second.serialize();
+    const auto firstBytes = serializedPacket(first);
+    const auto secondBytes = serializedPacket(second);
 
     auto stream = firstBytes;
     stream.insert(stream.end(), secondBytes.begin(), secondBytes.end());
@@ -45,7 +45,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   tester->unitTest("Existing deserialize parses the first declared packet and ignores trailing bytes.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setApplicationData({0xAA, 0x55}));
-    auto input = source.serialize();
+    auto input = serializedPacket(source);
     input.insert(input.end(), {0xDE, 0xAD, 0xBE, 0xEF});
 
     CCSDS::Packet decoded;
@@ -56,7 +56,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   tester->unitTest("Truncated packet body returns a deterministic parsing error.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setApplicationData({1, 2, 3, 4}));
-    auto input = source.serialize();
+    auto input = serializedPacket(source);
     input.pop_back();
 
     CCSDS::Packet decoded;
@@ -67,7 +67,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   tester->unitTest("A declared Packet Data Length larger than the buffer is rejected.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setApplicationData({1, 2}));
-    auto input = source.serialize();
+    auto input = serializedPacket(source);
     input[4] = 0x00;
     input[5] = 0x20;
 
@@ -79,7 +79,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   tester->unitTest("CRC corruption returns INVALID_CHECKSUM without mutating the target packet.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setApplicationData({0x10, 0x20, 0x30}));
-    auto input = source.serialize();
+    auto input = serializedPacket(source);
     input[6] ^= 0x01U;
 
     CCSDS::Packet target;
@@ -94,7 +94,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
     CCSDS::Packet source;
     source.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
     TEST_VOID(source.setApplicationData({0x10, 0x20, 0x30}));
-    auto input = source.serialize();
+    auto input = serializedPacket(source);
     input[6] ^= 0x01U;
 
     CCSDS::Packet decoded;
@@ -106,10 +106,9 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   });
 
   tester->unitTest("Unsupported packet versions are rejected during packet parsing.", [] {
-    CCSDS::Packet source;
-    TEST_VOID(source.setPrimaryHeader(CCSDS::PrimaryHeader{1, 0, 0, 1, CCSDS::UNSEGMENTED, 0, 0}));
-    TEST_VOID(source.setApplicationData({0x01}));
-    const auto input = source.serialize();
+    const std::vector<std::uint8_t> input{
+      0x20U, 0x01U, 0xC0U, 0x00U, 0x00U, 0x00U, 0x01U
+    };
 
     CCSDS::Packet decoded;
     const auto result = decoded.deserializeBounded(input);
@@ -160,7 +159,7 @@ void testGroupParsing(TestManager *tester, const std::string &description) {
   tester->unitTest("Separated header and body input must match the declared packet length.", [] {
     CCSDS::Packet source;
     TEST_VOID(source.setApplicationData({1, 2}));
-    const auto encoded = source.serialize();
+    const auto encoded = serializedPacket(source);
     const std::vector<std::uint8_t> header(encoded.begin(), encoded.begin() + 6);
     std::vector<std::uint8_t> body(encoded.begin() + 6, encoded.end());
     body.pop_back();

--- a/test/src/testGroupPus.cpp
+++ b/test/src/testGroupPus.cpp
@@ -167,7 +167,7 @@ void testGroupPus(TestManager *tester, const std::string &description) {
     TEST_VOID(source.setSecondaryHeader(
       std::make_shared<CCSDS::PusCTcHeader>(profile, 17U, 1U, 0x1234U, 0x09U)));
     TEST_VOID(source.setApplicationData({0x60U, 0x70U}));
-    const auto packetBytes = source.serialize();
+    const auto packetBytes = serializedPacket(source);
     auto stream = packetBytes;
     stream.insert(stream.end(), {0x99U, 0x88U});
 
@@ -190,7 +190,9 @@ void testGroupPus(TestManager *tester, const std::string &description) {
     TEST_VOID(wrongDirection.setMissionProfile(tcProfile));
     TEST_VOID(wrongDirection.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
     TEST_VOID(wrongDirection.setApplicationData({1U}));
-    if (!wrongDirection.serialize().empty()) return false;
+    const auto directionResult = wrongDirection.serialize();
+    if (directionResult
+        || directionResult.error().code() != CCSDS::INVALID_HEADER_DATA) return false;
 
     CCSDS::Packet wrongProfile;
     TEST_VOID(wrongProfile.setMissionProfile(tmProfile));
@@ -202,7 +204,8 @@ void testGroupPus(TestManager *tester, const std::string &description) {
     TEST_VOID(wrongPec.setSecondaryHeader(std::make_shared<CCSDS::PusCTcHeader>(tcProfile)));
     TEST_VOID(wrongPec.setApplicationData({1U}));
     wrongPec.setPacketErrorControlMode(CCSDS::PacketErrorControlMode::None);
-    return wrongPec.serialize().empty();
+    const auto pecResult = wrongPec.serialize();
+    return !pecResult && pecResult.error().code() == CCSDS::INVALID_DATA;
   });
 
   tester->unitTest("Invalid profiles, versions, reserved bits, timestamp sizes, and spare bytes fail.", [] {

--- a/test/src/testGroupValidator.cpp
+++ b/test/src/testGroupValidator.cpp
@@ -24,7 +24,7 @@ namespace {
       return {};
     }
     const auto dataResult = packet.setApplicationData(data);
-    if (!dataResult || packet.serialize().empty()) {
+    if (!dataResult || !packet.serialize()) {
       return {};
     }
     packet.setUpdatePacketEnable(false);


### PR DESCRIPTION
## Summary

- change `Packet::serialize()` and `DataField::serialize()` to return `ResultBuffer`
- change `Packet::update()` to return `ResultBool` with specific finalization errors
- propagate packet serialization failures through Manager, CLI, examples, and installed-package consumers
- validate Packet Version, mission profile, Idle Packet rules, PUS direction/profile, Packet Error Control, data-field size, and Packet Data Length
- update the v2 migration and transition documentation
- link the README directly to the compliance matrix

## Validation

- native tests: 101/101
- ASan/UBSan: 101/101 (`detect_leaks=0` because this runtime runs under ptrace)
- MCU syntax compile with `-fno-exceptions -fno-rtti`
- CLI integration
- all four standalone examples
- installed-package consumer probe
- `git diff --check`

Closes #69
Closes #86