### PR TITLE
feat(CCSDSPack): #72 add structured packet validation

### DIFF
--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -1,15 +1,14 @@
 name: Generate UML Diagrams
 
+# UML generation is intentionally manual for v2.0.0 development. The diagrams
+# are useful documentation aids, but regenerating them on every push/PR consumes
+# substantial CI time without contributing to the current release gates.
+# Re-enable push/pull_request triggers when diagram maintenance becomes useful.
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   generate-uml:
@@ -33,8 +32,7 @@ jobs:
             libyaml-cpp-dev \
             wget \
             openjdk-17-jre-headless
-            wget https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar -O plantuml.jar
-
+          wget https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar -O plantuml.jar
 
       - name: Build and install clang-uml
         run: |
@@ -53,18 +51,12 @@ jobs:
           cp compile_commands.json ../
 
       - name: Generate UML diagrams
-        run: |
-          clang-uml -c clang-uml.yaml
-          
-      - name: Convert .puml to .png
+        run: clang-uml -c clang-uml.yaml
+
+      - name: Convert .puml to .svg
         run: |
           cd docs
           find . -name "*.puml" -exec java -jar ../plantuml.jar -tsvg {} \;
-          
-      - name: Commit UML diagrams
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add docs/
-          git commit -m "Update UML diagrams [skip ci]" || echo "No changes to commit"
-          git push origin develop
+
+      - name: Show generated changes
+        run: git status --short docs/

--- a/CCSDS_COMPLIANCE.md
+++ b/CCSDS_COMPLIANCE.md
@@ -14,7 +14,8 @@ CCSDSPack v2.0.0 Space Packet implementation. It shall be read together with:
 - [`docs/CCSDS_133_0_B_2_PROFILE.md`](docs/CCSDS_133_0_B_2_PROFILE.md), the
   supported packet profile and wire behaviour;
 - [`docs/MISSION_TAILORING.md`](docs/MISSION_TAILORING.md), the PUS and CUC
-  mission-profile contract.
+  mission-profile contract;
+- [`docs/VALIDATION.md`](docs/VALIDATION.md), the structured Validator contract.
 
 The detailed rows cover the CCSDS Space Packet layer. The additional v2 profile
 section records the narrower PUS secondary-header and CUC codec scope. The
@@ -28,7 +29,7 @@ named class is not, by itself, conformance evidence.
 
 | Area | Selected baseline | v2.0.0 decision |
 |---|---|---|
-| CCSDS Space Packet Protocol | CCSDS 133.0-B-2, Recommended Standard Issue 2, June 2020, including Editorial Change 2 of September 2024 | Space Packet PDU construction, serialization, bounded parsing, validation, supported assembly/extraction behaviour, and packet-format parameters |
+| CCSDS Space Packet Protocol | CCSDS 133.0-B-2, Recommended Standard Issue 2, June 2020, including Editorial Change 2 of September 2024 | Space Packet PDU construction, serialization, bounded parsing, structured validation, supported assembly/extraction behaviour, and packet-format parameters |
 | Packet Utilisation Standard | ECSS-E-70-41A and ECSS-E-ST-70-41C | Direction-specific supported secondary-header layouts only; complete PUS services are outside scope |
 | CCSDS time code | CCSDS 301.0-B-4 | Basic CUC numeric counter with selected epoch, implicit/explicit P-field, 1–4 coarse octets, and 0–3 fine octets |
 
@@ -82,9 +83,9 @@ covering every applicable mandatory item in annex A.
 
 Test references name the focused repository test source or the fixed independent
 evidence used by the release. The complete native suite currently contains
-106 passing regression and conformance tests.
+108 passing regression and conformance tests.
 
-## PUS secondary-header and CUC profile
+## PUS secondary-header, CUC, and validation profile
 
 | Area | Classification | Status | Evidence |
 |---|---|---|---|
@@ -94,6 +95,7 @@ evidence used by the release. The complete native suite currently contains
 | Identifier widths and spare octets | Mission-tailored | Implemented | width boundaries, profile validation, zero-spare rejection |
 | Basic CUC counter encoding | Direct supported subset | Implemented | independent explicit/implicit P-field vectors and negative vectors |
 | Epoch and P-field policy | Mission-tailored | Implemented | configuration, P-field verification, invalid-policy rejection |
+| Structured generic/PUS validation | Library invariant supporting the claimed profile | Implemented | named `ValidationCode` checks, fixed-capacity `ValidationReport`, generic/PUS positive and negative tests, CLI delegation |
 | Complete PUS services and time correlation | Outside codec scope | Unsupported | documented claim boundary |
 
 ## Annex A PICS scope summary
@@ -119,7 +121,7 @@ system-level PICS.
 | SPP-18 | 4.1.4.3 | User Data Field | Conditional packet content | Implemented |
 | SPP-19 | 4.2.2 | Packet Assembly Function | Implemented by the supported `Packet` and `Manager` construction paths | Implemented in profile |
 | SPP-20 | 4.2.3 | Packet Transfer Function | Lower-layer transport responsibility | Not applicable |
-| SPP-21 | 4.3.2 | Packet Extraction Function | Implemented by bounded parsing and validation for the supported profile | Implemented in profile |
+| SPP-21 | 4.3.2 | Packet Extraction Function | Implemented by bounded parsing and structured validation for the supported profile | Implemented in profile |
 | SPP-22 | 4.3.3 | Packet Reception Function | Subnetwork reception and routing are outside scope | Unsupported |
 | SPP-23 | table 5-1 | Maximum Packet Length | Full representable PDU size is supported and boundary-tested | Implemented |
 | SPP-24 | table 5-1 | Packet Type of outgoing packets | Telemetry and telecommand values are supported | Implemented |
@@ -150,7 +152,7 @@ system-level PICS.
 | SPP-PARSE-002 | 4.1.2; 4.1.3.5; 4.3.2.2 | SPP-14, SPP-21 | Derived | Input shorter than the declared packet boundary is rejected without committing partial state. | Implemented | bounded transactional parser | truncated body and oversized declared-length tests |
 | SPP-PARSE-003 | 2.1.1; 4.1.3.5; 4.3.2.2 | SPP-14, SPP-21 | Derived | Parsing reports consumed octets and does not absorb following packets or trailing bytes. | Implemented | `deserializeBounded` result value | concatenated parsing and legacy first-packet behaviour tests |
 | SPP-PROC-001 | 4.2.2.2 to 4.2.2.4 | SPP-19 | Direct | Supported packet assembly creates the primary header, applies secondary-header indication, and applies maintained sequence count. | Implemented in profile | `Packet::serialize`; `Manager::setApplicationData` | Manager creation, segmentation, sequence, identifier, CRC, and STM32 packet-generation tests |
-| SPP-PROC-002 | 4.3.2.1, 4.3.2.2 | SPP-21 | Direct | Supported extraction exposes packet components, secondary-header presence, exact boundaries, and sequence continuity information. | Implemented in profile | bounded parser and `Validator` | parsing, decoded-field, CRC, template identity, and sequence-continuity tests |
+| SPP-PROC-002 | 4.3.2.1, 4.3.2.2 | SPP-21 | Direct | Supported extraction exposes packet components, secondary-header presence, exact boundaries, and sequence continuity information. | Implemented in profile | bounded parser and `Validator` | parsing, structured named length/CRC/template/PUS checks, decoded-field, and sequence-continuity tests |
 | SPP-PROC-003 | 4.3.3.1 to 4.3.3.3 | SPP-22 | Direct | Subnetwork reception and APID demultiplexing are performed outside this library. | Unsupported | caller/higher-layer responsibility | explicit claim boundary |
 | SPP-MGMT-001 | 5.1; 5.2 table 5-1 | SPP-23, SPP-24, SPP-26 | Direct | Maximum length and outgoing packet type used by the profile are explicit configuration; complete service management remains outside scope. | Implemented in profile | packet template and configuration parser | configuration, field-range, maximum-size, and packet-type tests |
 | SPP-API-001 | No direct CCSDS clause | N/A | Library invariant | Inspecting a parsed packet does not mutate received header, sequence, data, or CRC state. | Implemented | const packet getters and explicit finalization | getter non-finalization and parsed inspection preservation tests |
@@ -176,24 +178,29 @@ For CCSDSPack v2.0.0:
 | Error-control presence | External selection; encoded bytes remain within the CCSDS Packet Data Field | External / mission-tailored | Implemented | CRC16 and CRC-disabled vectors and parser tests |
 | CRC coverage | Not defined by CCSDS 133.0-B-2 | External / mission-tailored | Implemented | independent CRC vector, coverage test, and STM32 exact-vector test |
 | CRC encoding | Not defined by CCSDS 133.0-B-2 | External / mission-tailored | Implemented | fixed golden vectors and big-endian comparisons |
-| CRC verification | Not defined by CCSDS 133.0-B-2 | External / mission-tailored | Implemented | corruption rejection and non-mutating failure tests |
+| CRC verification | Not defined by CCSDS 133.0-B-2 | External / mission-tailored | Implemented | corruption rejection, structured `Crc16` validation check, and non-mutating failure tests |
 
 ## Evidence baseline
 
 The v2 claim is supported by:
 
-- 106 native regression and conformance tests;
+- 108 native regression and conformance tests;
 - independent Python-generated fixed byte vectors under `test/test_resources`;
 - negative tests for invalid version, field ranges, length, CRC, identifier,
-  segmentation, sequence continuity, and Idle Packet structure;
-- Linux and Windows CI;
-- installed-package and exact-version external-consumer tests;
-- historical v1.2 Raspberry Pi 5 and NUCLEO-H755ZI-Q execution evidence for the
-  inherited packet core.
+  segmentation, sequence continuity, mission profiles, and supported PUS fields;
+- structured generic/PUS `ValidationCode` and `ValidationReport` tests;
+- Linux and Windows CI plus Doxygen;
+- installed-package and exact-version external-consumer tests and standalone examples;
+- Ubuntu 22.04 package/cross-build generation with the ARM compile/link probe exercising the structured Validator and a representative PUS-C TC packet;
+- historical v1.2 Raspberry Pi 5 and NUCLEO-H755ZI-Q execution evidence for the inherited packet core.
 
 The historical hardware runs do not establish the new v2 namespace, PUS, CUC,
-or configuration APIs on those targets. v2 hardware revalidation remains a
-release gate.
+Validator, or configuration APIs on those targets. v2 hardware revalidation
+remains a release gate.
+
+Automatic UML generation is disabled for the v2.0.0 release path. The manual
+workflow remains available as a documentation utility, but diagrams are not
+conformance or release evidence.
 
 ## Matrix maintenance policy
 
@@ -208,5 +215,5 @@ A row remains **Implemented** only while:
 6. no contradictory supported configuration path exists.
 
 Changes to packet wire behaviour, the claim boundary, or the selected normative
-baseline require this matrix, `COMPLIANCE.md`, and the detailed PDU profile to
-be updated together.
+baseline require this matrix, `COMPLIANCE.md`, the structured validation
+contract, and the detailed PDU profile to be updated together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ All notable changes to CCSDSPack are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses semantic versioning for its public package versions.
 
+## [Unreleased] - v2.0.0
+
+### Added
+
+- Standards-oriented PUS-A and PUS-C TC/TM secondary-header codecs under `ccsds::pus::rev_a` and `ccsds::pus::rev_c`.
+- Explicit `ccsds::MissionProfile` selection and validation for generic CCSDS and PUS revision/direction profiles.
+- Numeric basic CCSDS CUC time with explicit epoch, P-field, coarse-width, and fine-width policy.
+- Fixed-capacity `ccsds::ValidationReport` and named `ccsds::ValidationCode` checks for generic CCSDS, templates, mission profiles, and supported PUS fields.
+- Standalone installed-package examples and complete generic/PUS configuration profiles.
+
+### Changed
+
+- Public C++ namespace changes from `CCSDS` to `ccsds`.
+- Packet finalization and serialization APIs return checked Result types rather than hiding failure behind empty buffers.
+- Public secondary-header API uses `SecondaryHeader` terminology instead of the previous `DataFieldHeader` naming.
+- `ccsds::Validator::validate()` returns a structured named report instead of a positional six-element boolean report.
+- `ccsds_validator` delegates protocol/profile checks to the library Validator.
+- PUS packet configuration requires explicit revision, TC/TM direction, canonical selector, identifier widths, packet error control, and applicable CUC policy.
+- The bare-metal package path forwards `-m` flags through `CCSDSPACK_MCU_FLAGS` to the library and consumer probe.
+
+### Removed
+
+- Legacy project-specific `PusA`, `PusB`, and `PusC` classes.
+- `PusServices` and automatic registration of legacy pseudo-PUS formats.
+- Automatic UML generation as a v2.0.0 CI/release gate. The workflow remains available manually through `workflow_dispatch`.
+
+### Compatibility
+
+v2.0.0 is a breaking source/API and PUS-layout release. The corrected generic Space Packet wire behavior delivered in v1.2.0 is retained and is not reclassified as a new v2 wire break.
+
+The project remains C++17. The protocol-facing Validator, MissionProfile, PUS, CUC, Packet, Manager, and Result APIs remain available in the `CCSDS_MCU` static-library build and are compatible with builds that disable exceptions and RTTI.
+
+### Validation status
+
+Current development evidence includes 108 passing hosted native tests, Linux/Windows hosted builds, Doxygen, representative generic/PUS CLI integration, local ASan/UBSan runs, and an ARM compile/link consumer probe that exercises the structured Validator and a PUS-C telecommand path. Final v2 release gates remain tracked by the v2 milestone.
+
 ## [1.2.0] - 2026-08-02
 
 ### Added

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,18 +1,7 @@
-# CCSDSPack v1.0.0
-***Date: 18/08/2025*** 
-- The first stable release of the library see RELEASE_NOTES.md ON TAG v1.0.0
+# Legacy change-log pointer
 
-# CCSDSPack v1.1.1 (Includes previous 1.1.0 changes)
-***Date: 25/10/2025*** 
-- Baremetal static lib build support.
-- includes toolchain for arm and instructions for build.
-- include scripts to install cross-build dependencies.
+`CHANGE_LOG.md` is retained only so old repository links do not break.
 
-# CCSDSPack v1.1.1
-***Date: 23/04/2026***
-- Fixed #42: Primary header now correctly deserialized when using secondary header types.
-- Fixed off-by-one errors in deserialization length checks.
-- Fixed PusB eventId truncation (uint8_t -> uint16_t).
-- Standardized CMake package configuration using template file.
-- Added latest tag support for Docker images.
-- Expanded test suite for edge cases.
+The maintained project history is [`CHANGELOG.md`](CHANGELOG.md). Draft v2.0.0 release notes are in [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
+
+Do not add new release entries to this file.

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -22,13 +22,15 @@ complete PUS application.
 - Packet Version Number `000`, TM/TC Packet Types, the 11-bit APID range, Idle
   Packet structure, Sequence Flags, and modulo-16384 sequence count;
 - checked construction, serialization, bounded parsing, stream management, and
-  validation;
+  structured validation;
 - explicit PUS-A/PUS-C revision and TC/TM selection;
 - service, subtype, acknowledgement, source/destination, counter,
-  time-reference-status, optional PUS-A subcounter, and spare fields applicable
-  to the selected layout;
+  four-bit time-reference-status, optional PUS-A subcounter, and spare fields
+  applicable to the selected layout;
 - numeric basic CCSDS CUC time with explicit epoch, P-field policy, and
   coarse/fine widths;
+- fixed-capacity named `ValidationReport` checks for generic CCSDS, templates,
+  mission profiles, and the supported PUS fields;
 - independent vectors, negative tests, CLI round trips, and installed-package
   consumer tests.
 
@@ -44,6 +46,17 @@ inside the Packet Data Field. CCSDS 133.0-B-2 does not define it as a separate
 top-level field. The optional Manager synchronization marker is external stream
 framing, not part of a Space Packet.
 
+## Validation and bare-metal profile
+
+`ccsds::Validator` reports named `ValidationCode` checks and does not mutate the
+Packet, MissionProfile, or secondary header being inspected. Its
+`ValidationReport` stores checks in fixed `std::array` storage and performs no
+dynamic allocation itself.
+
+The protocol library remains C++17 and the Validator is part of the
+`CCSDS_MCU` static-library build. MCU builds can disable exceptions and RTTI;
+host-only Config and command-line components are excluded.
+
 ## Evidence
 
 Technical scope and traceability are documented in:
@@ -51,6 +64,7 @@ Technical scope and traceability are documented in:
 - [CCSDS compliance matrix](CCSDS_COMPLIANCE.md);
 - [Space Packet PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md);
 - [PUS and mission tailoring](docs/MISSION_TAILORING.md);
+- [structured validation](docs/VALIDATION.md);
 - [configuration reference](docs/CONFIG.md);
 - independent vectors and regression tests under `test/`;
 - Linux and Windows CI, CLI integration, examples, sanitizers, and package
@@ -58,4 +72,8 @@ Technical scope and traceability are documented in:
 
 Historical v1.2 execution on Raspberry Pi 5 and NUCLEO-H755ZI-Q supports the
 inherited packet core only. It does not replace v2 hardware revalidation for the
-new namespace, PUS, time, or configuration APIs.
+new namespace, PUS, time, Validator, or configuration APIs.
+
+Automatic UML generation is currently disabled and is not part of the v2.0.0
+compliance or release gate. The workflow remains available manually for later
+documentation maintenance.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,10 @@ SPDX-License-Identifier: Apache-2.0
 The v2 packet layer targets **CCSDS 133.0-B-2, Issue 2, including Editorial Change 2 (September 2024)** and provides standards-facing secondary headers for **ECSS-E-70-41A (PUS-A)** and **ECSS-E-ST-70-41C (PUS-C)**.
 
 > [!IMPORTANT]
-> The implementation scope is limited to the documented **Space Packet PDU profile** and PUS secondary-header layouts. CCSDSPack does not implement every PUS service, the complete abstract Packet Service, transfer frames, or a Protocol Implementation Conformance Statement.
+> The implementation scope is the documented Space Packet PDU profile and supported PUS secondary-header layouts. CCSDSPack does not implement every PUS service, the complete abstract Packet Service, transfer frames, or a complete protocol entity.
 
 > [!IMPORTANT]
-> v2 removed the project-specific `PusA`, `PusB`, and `PusC` model. The public
-> PUS types are `ccsds::pus::rev_a::TcHeader`, `ccsds::pus::rev_a::TmHeader`,
-> `ccsds::pus::rev_c::TcHeader`, and `ccsds::pus::rev_c::TmHeader`. There is no
-> standards-facing PUS-B revision.
+> v2 removed the project-specific `PusA`, `PusB`, and `PusC` model. The public PUS types are `ccsds::pus::rev_a::TcHeader`, `ccsds::pus::rev_a::TmHeader`, `ccsds::pus::rev_c::TcHeader`, and `ccsds::pus::rev_c::TmHeader`. There is no standards-facing PUS-B revision.
 
 ## Status
 
@@ -28,49 +25,24 @@ The v2 packet layer targets **CCSDS 133.0-B-2, Issue 2, including Editorial Chan
 |---|---|
 | ![Linux build status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/linux.yml?branch=develop) | ![Windows build status](https://img.shields.io/github/actions/workflow/status/ExoSpaceLabs/CCSDSPack/windows.yml?branch=develop) |
 
-| Platform | CI |
-|---|---|
-| Ubuntu 22.04 | ![Ubuntu 22.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-22-04) |
-| Ubuntu 24.04 | ![Ubuntu 24.04](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-24-04) |
-| Ubuntu latest | ![Ubuntu latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/linux.yml/badge.svg?job=ubuntu-latest) |
-| Windows latest | ![Windows latest](https://github.com/ExoSpaceLabs/CCSDSPack/actions/workflows/windows.yml/badge.svg?job=windows-latest) |
+UML generation is currently **manual-only** and is not a v2.0.0 CI/release gate. The workflow remains available through `workflow_dispatch` for later documentation maintenance.
 
 ## v2 Space Packet PDU profile
 
-The v2 implementation inherits the validated v1.2 six-octet CCSDS primary header and Packet Data Field behaviour.
+The v2 implementation retains the validated v1.2 six-octet CCSDS primary-header and Packet Data Field behaviour and adds explicit mission profiles, standards-oriented PUS-A/PUS-C secondary headers, CUC time support, checked finalization, and structured validation.
 
-The Packet Data Field contains optional secondary-header bytes, mission application data, and, when enabled, the optional CCSDSPack CRC16 trailer.
+CCSDSPack v2 enforces:
 
-### CCSDSPack packet layout
-
-The following diagram represents the generic Space Packet wire layout.
-
-![CCSDSPack v1.2 Space Packet layout](docs/imgs/ccsdsPacket.drawio.png)
-
-When the optional CCSDSPack CRC16 profile is enabled, the final two Packet Data Field octets are reserved for the CRC trailer. CCSDS 133.0-B-2 does not define this trailer as a third top-level Space Packet structural field.
-
-Detailed scope, limitations, and migration behavior are documented in the [CCSDS 133.0-B-2 EC2 Space Packet PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md).
-
-### Primary-header rules
-
-CCSDSPack v2 enforces the following packet-level rules:
-
-- Packet Version Number is `000`;
-- telemetry and telecommand Packet Types are supported;
-- the complete 11-bit APID range is supported;
-- APID `0x7FF` is reserved for Idle Packets;
-- within the CCSDSPack profile, Idle Packets omit the secondary header and carry mission-defined idle data;
-- Packet Data Length is the number of octets after the primary header minus one;
-- Sequence Flags use the CCSDS first, continuation, last, and unsegmented values;
-- Packet Sequence Count advances modulo 16384 in automatic `ccsds::Manager` mode.
-
-CCSDSPack uses Packet Sequence Count semantics for both telemetry and telecommand packets. The optional telecommand Packet Name interpretation is not implemented.
-
-### Packet size
+- Packet Version Number `000`;
+- telemetry and telecommand Packet Types;
+- the complete 11-bit APID range;
+- Idle Packet structural rules for APID `0x7FF`;
+- Packet Data Length as the number of octets after the primary header minus one;
+- CCSDS sequence flags and modulo-16384 Packet Sequence Count handling;
+- explicit packet-error-control selection;
+- explicit PUS revision/direction/profile consistency.
 
 The Packet Data Field can contain 1 through 65,536 octets, giving a total serialized packet size of 7 through 65,542 octets.
-
-Profiles requiring a two-octet CRC trailer have a practical minimum serialized packet size of 8 octets.
 
 Use:
 
@@ -78,26 +50,7 @@ Use:
 std::size_t packetSize = packet.getSerializedSize();
 ```
 
-for the complete range.
-
-The legacy `getFullPacketLength()` API returns `std::uint16_t` and saturates at `UINT16_MAX` rather than wrapping.
-
-### Packet error control
-
-`PacketErrorControlMode` supports:
-
-- `PacketErrorControlMode::CRC16`, the existing v1 default;
-- `PacketErrorControlMode::None`.
-
-In CRC16 mode, CCSDSPack reserves the final two Packet Data Field octets for CRC-16/CCITT-FALSE and includes those octets in Packet Data Length.
-
-The receiver must configure the expected mode before parsing.
-
-### Library architecture
-
-The following diagram shows the main v1.x relationships between the user application, `ccsds::Manager`, `ccsds::Packet`, primary-header handling, Packet Data Field handling, secondary-header creation, serialization, validation, CRC16, and utility functions.
-
-![CCSDSPack v1 library architecture](docs/imgs/CCSDSPack_architecture.drawio.png)
+for the complete size range.
 
 ## Features
 
@@ -113,186 +66,44 @@ The following diagram shows the main v1.x relationships between the user applica
 - separate fixed PUS and extensible custom secondary-header factories;
 - explicit mission-profile validation for revision, direction, identifiers, time, spare fields, and packet error control;
 - numeric basic CUC time with explicit epoch, P-field, and coarse/fine-width policy;
+- fixed-capacity structured `ccsds::ValidationReport` with named generic/PUS checks;
 - exception-free `Result` and `Error` handling;
-- Linux and Windows builds;
-- optional bare-metal and cross-build targets;
-- encoder, decoder, validator, and regression-test executables;
-- installed CMake package and shared-library consumer test.
+- C++17 hosted and bare-metal builds;
+- MCU builds compatible with `-fno-exceptions -fno-rtti`;
+- encoder, decoder, validator, and regression-test executables on hosted platforms;
+- installed CMake package and shared-library consumer tests.
 
-## Documentation
+## Structured validation
 
-- [Generated API reference](https://exospacelabs.github.io/CCSDSPack/html/)
-- [CCSDS compliance matrix](CCSDS_COMPLIANCE.md)
-- [CCSDS 133.0-B-2 EC2 PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md)
-- [PUS and mission tailoring](docs/MISSION_TAILORING.md)
-- [v1 to v2 migration](docs/MIGRATION_V1_TO_V2.md)
-- [v1.2 current behavior](docs/V1_2_CURRENT_BEHAVIOUR.md)
-- [CLI reference](docs/CLI.md)
-- [Configuration reference](docs/CONFIG.md)
-- [Error handling](docs/ERROR.md)
-- [Packages](docs/PACKAGES.md)
-- [Cross-build guide](docs/CROSSBUILD.md)
-- [Examples](docs/EXAMPLES.md)
-
-## Build from source
-
-### Requirements
-
-- CMake 3.16 or newer;
-- a C++17 compiler;
-- GCC 8.5 or newer on supported Linux configurations.
-
-```bash
-git clone https://github.com/ExoSpaceLabs/CCSDSPack.git
-cd CCSDSPack
-cmake -S . -B build
-cmake --build build
-```
-
-Run the regression tester from the configured binary directory:
-
-```bash
-./bin/CCSDSPack_tester
-```
-
-Install the library and exported CMake package:
-
-```bash
-cmake --install build
-```
-
-### Build options
-
-| CMake option | Default | Description |
-|---|---:|---|
-| `CCSDSPACK_BUILD_MCU` | `OFF` | Build the MCU static-library profile |
-| `ENABLE_TESTER` | `ON` | Build `CCSDSPack_tester` |
-| `ENABLE_ENCODER` | `ON` | Build `ccsds_encoder` |
-| `ENABLE_DECODER` | `ON` | Build `ccsds_decoder` |
-| `ENABLE_VALIDATOR` | `ON` | Build `ccsds_validator` |
-
-### Windows with MinGW
-
-```powershell
-cmake -S . -B build -G "MinGW Makefiles"
-cmake --build build
-```
-
-The Windows workflow copies the shared-library DLL beside the test and external-consumer executables before running them.
-
-## CMake integration
-
-After installing CCSDSPack:
-
-```cmake
-find_package(CCSDSPack CONFIG REQUIRED)
-
-add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE ccsdspack::CCSDSPack)
-```
-
-For a non-standard install prefix:
-
-```bash
-cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/install/prefix
-```
-
-The [`example/`](example/README.md) directory contains independent installed-package
-consumers and complete generic/PUS configuration profiles.
-Build all of them, or select one by directory name:
-
-```bash
-./example/build_examples.sh all /path/to/install/prefix
-./example/build_examples.sh pus_c_telecommand /path/to/install/prefix
-```
-
-## C++ example
+`ccsds::Validator` validates an existing packet without mutating it. Reports use named `ValidationCode` values instead of positional boolean indices:
 
 ```cpp
-#include <CCSDSPack.h>
+ccsds::Validator validator;
+const auto report = validator.validate(packet);
 
-#include <cstdint>
-#include <vector>
+if (report.failed(ccsds::ValidationCode::PacketDataLength)) {
+  handleLengthFailure();
+}
 
-int main() {
-  ccsds::Packet packetTemplate;
-
-  const auto headerResult = packetTemplate.setPrimaryHeader(ccsds::PrimaryHeader{
-    0,                       // Packet Version Number 000
-    0,                       // telemetry packet
-    0,                       // no secondary header
-    0x123,                   // APID
-    ccsds::UNSEGMENTED,
-    0,
-    0                        // calculated during serialization
-  });
-
-  if (!headerResult) {
-    return headerResult.error().code();
-  }
-
-  packetTemplate.setDataFieldSize(1024);
-
-  ccsds::Manager manager;
-
-  const auto templateResult = manager.setPacketTemplate(packetTemplate);
-  if (!templateResult) {
-    return templateResult.error().code();
-  }
-
-  const std::vector<std::uint8_t> inputBytes{0x10, 0x20, 0x30};
-
-  const auto dataResult = manager.setApplicationData(inputBytes);
-  if (!dataResult) {
-    return dataResult.error().code();
-  }
-
-  const auto wire = manager.getPacketsBuffer();
-  return wire && !wire.value().empty() ? 0 : 1;
+if (report.failed(ccsds::ValidationCode::PusDirection)) {
+  handlePusDirectionFailure();
 }
 ```
 
-## Command-line tools
+`ValidationReport` stores up to 32 performed checks in `std::array` and performs no dynamic allocation itself. The API is available in `CCSDS_MCU`, requires C++17, and does not require RTTI or exceptions.
 
-The build can provide:
+The host-side `ccsds_validator` executable delegates protocol/profile checks to this library implementation rather than maintaining separate validation logic.
 
-- `ccsds_encoder`;
-- `ccsds_decoder`;
-- `ccsds_validator`;
-- `CCSDSPack_tester`.
-
-The encoder, decoder, and validator support `crc16` and `none` packet-error-control profiles.
-
-See the [CLI reference](docs/CLI.md) for exact options, concatenated decoding, trailing-byte handling, validation categories, and exit codes.
-
-## Packages and container
-
-Release packages are published under [GitHub Releases](https://github.com/ExoSpaceLabs/CCSDSPack/releases).
-
-Container images are published at:
-
-```bash
-docker pull ghcr.io/exospacelabs/ccsdspack:<version>
-```
-
-The image contains the library and command-line executables.
-
-Run the installed tester with:
-
-```bash
-docker run --rm ghcr.io/exospacelabs/ccsdspack:<version> /usr/bin/CCSDSPack_tester
-```
+See [Structured validation](docs/VALIDATION.md).
 
 ## PUS secondary headers
 
-PUS selection is explicit and direction-safe. Canonical diagnostic/factory selectors are:
+PUS selection is explicit and direction-safe. Canonical selectors are:
 
 - `PUS:revA:TC` and `PUS:revA:TM`;
 - `PUS:revC:TC` and `PUS:revC:TM`.
 
-Custom headers remain string-keyed in `ccsds::SecondaryHeaderFactory`; the
-reserved PUS selectors are owned by the non-extensible
-`ccsds::pus::SecondaryHeaderFactory`. Both return fresh header objects.
+Custom headers remain string-keyed in `ccsds::SecondaryHeaderFactory`; the reserved PUS selectors are owned by the non-extensible `ccsds::pus::SecondaryHeaderFactory`.
 
 ```cpp
 auto profile = ccsds::pus::makeProfile(
@@ -300,37 +111,135 @@ auto profile = ccsds::pus::makeProfile(
   ccsds::pus::Direction::Telecommand);
 
 ccsds::Packet packet;
-packet.setPrimaryHeader({0, 1, 0, 0x123, ccsds::UNSEGMENTED, 0, 0});
-packet.setMissionProfile(profile);
-packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TcHeader>(
-  profile, 17, 1, 0x1234, 0x09));
-packet.setApplicationData({0x10, 0x20});
+const auto primary = packet.setPrimaryHeader(
+  {0, 1, 0, 0x123, ccsds::UNSEGMENTED, 0, 0});
+if (!primary) return primary.error().code();
+
+const auto profileResult = packet.setMissionProfile(profile);
+if (!profileResult) return profileResult.error().code();
+
+const auto secondary = packet.setSecondaryHeader(
+  std::make_shared<ccsds::pus::rev_c::TcHeader>(
+    profile, 17, 1, 0x1234, 0x09));
+if (!secondary) return secondary.error().code();
+
+const auto data = packet.setApplicationData({0x10, 0x20});
+if (!data) return data.error().code();
+
 const auto wire = packet.serialize();
 if (!wire) return wire.error().code();
 ```
 
-All checked setter results should also be inspected in production code; they are omitted above only to keep the example compact.
+## Build from source
+
+### Requirements
+
+- CMake 3.16 or newer;
+- a C++17 compiler.
+
+```bash
+git clone https://github.com/ExoSpaceLabs/CCSDSPack.git
+cd CCSDSPack
+cmake -S . -B build
+cmake --build build
+./build/bin/CCSDSPack_tester
+```
+
+Install the library and exported package:
+
+```bash
+cmake --install build
+```
+
+### Main CMake options
+
+| CMake option | Default | Description |
+|---|---:|---|
+| `CCSDSPACK_BUILD_MCU` | `OFF` | Build the bare-metal static-library profile |
+| `CCSDSPACK_MCU_FLAGS` | empty | Additional flags for the MCU library target |
+| `ENABLE_TESTER` | `ON` | Build `CCSDSPack_tester` |
+| `ENABLE_ENCODER` | `ON` | Build `ccsds_encoder` |
+| `ENABLE_DECODER` | `ON` | Build `ccsds_decoder` |
+| `ENABLE_VALIDATOR` | `ON` | Build `ccsds_validator` |
+
+Bare-metal Cortex-M example:
+
+```bash
+cmake -S . -B build-mcu \
+  -DCCSDSPACK_BUILD_MCU=ON \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/arm-none-eabi.cmake \
+  -DCCSDSPACK_MCU_FLAGS="-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb"
+cmake --build build-mcu -j
+```
+
+Host-only `ccsds::Config` and CLI executables are excluded from the MCU target. Packet, Manager, PUS, CUC, Result, and Validator APIs remain part of the static library.
+
+## CMake integration
+
+After installing CCSDSPack:
+
+```cmake
+find_package(CCSDSPack 2.0 CONFIG REQUIRED)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE ccsdspack::CCSDSPack)
+target_compile_features(my_app PRIVATE cxx_std_17)
+```
+
+The [`example/`](example/README.md) directory contains independent installed-package consumers and complete generic/PUS configuration profiles.
+
+## Command-line tools
+
+Hosted builds can provide:
+
+- `ccsds_encoder`;
+- `ccsds_decoder`;
+- `ccsds_validator`;
+- `CCSDSPack_tester`.
+
+See [CLI reference](docs/CLI.md).
+
+## Documentation
+
+- [Documentation index](docs/README.md)
+- [Structured validation](docs/VALIDATION.md)
+- [CCSDS compliance baseline](docs/CCSDS_COMPLIANCE.md)
+- [CCSDS 133.0-B-2 EC2 PDU profile](docs/CCSDS_133_0_B_2_PROFILE.md)
+- [PUS and mission tailoring](docs/MISSION_TAILORING.md)
+- [v1 to v2 migration](docs/MIGRATION_V1_TO_V2.md)
+- [CLI reference](docs/CLI.md)
+- [Configuration reference](docs/CONFIG.md)
+- [Error handling](docs/ERROR.md)
+- [Packages](docs/PACKAGES.md)
+- [Cross-build guide](docs/CROSSBUILD.md)
+- [Examples](docs/EXAMPLES.md)
+- [Generated API reference](https://exospacelabs.github.io/CCSDSPack/html/)
 
 ## Compatibility
 
-v2 is a breaking release. The generic CCSDS packet corrections introduced by v1.2 are retained, while the non-standard secondary-header classes and their wire formats are removed without aliases.
+v2 is a breaking **source/API and PUS-layout** release. The generic Space Packet wire corrections introduced by v1.2.0 are retained rather than being reintroduced as v2 changes.
 
-Changes include:
+The principal v1.2-to-v2 changes include:
 
-- Packet Data Length;
-- CRC coverage;
-- parsing boundaries;
-- sequence behavior;
-- Packet Identification enforcement;
-- Packet Version Number validation;
-- Idle Packet validation.
+- namespace `CCSDS` to `ccsds`;
+- removal of project-specific `PusA`, `PusB`, and `PusC`;
+- explicit PUS-A/PUS-C revision and direction types;
+- explicit mission profiles and numeric CUC time;
+- secondary-header API renaming;
+- checked serialization/finalization results;
+- structured named Validator reports;
+- v2 configuration schema and canonical PUS selectors.
 
-Stored or transmitted packets generated by older releases should be regenerated or migrated explicitly before adopting v2.
+See [v1 to v2 migration](docs/MIGRATION_V1_TO_V2.md).
 
-See the [v1 to v2 migration guide](docs/MIGRATION_V1_TO_V2.md) for API and selector replacements.
+## Packages and container
+
+Release packages are published under GitHub Releases. Container images use:
+
+```bash
+docker pull ghcr.io/exospacelabs/ccsdspack:<version>
+```
 
 ## License
 
-CCSDSPack is licensed under the Apache License 2.0.
-
-See [LICENSE](LICENSE) and [Notice.md](Notice.md).
+CCSDSPack is licensed under the Apache License 2.0. See [LICENSE](LICENSE) and [Notice.md](Notice.md).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,30 +1,150 @@
-# CCSDSPack v1.1.1
+# CCSDSPack v2.0.0 release notes — draft
 
-Maintenance release focusing on critical bug fixes and CMake integration improvements.
+> [!IMPORTANT]
+> These are **draft** release notes for the v2.0.0 release candidate. v2.0.0 is not approved for tagging until the remaining conformance, fuzz/sanitizer, arm64, STM32, migration-guide, and publication gates are complete.
 
-## Highlights
-- Fixed a critical deserialization bug where primary headers were not correctly populated when using secondary headers.
-- Modernized CMake package configuration for easier integration in downstream projects.
-- Docker images now include a `:latest` tag for the most recent stable release.
+## Summary
 
-## Bug Fixes
-- **#42 (Deserialize issue):** Fixed `CCSDS::Packet::deserialize(data, headerType, headerSize)` skipping primary header processing.
-- Fixed off-by-one errors in packet length validation during deserialization.
-- Corrected `PusB` `eventId` type from `uint8_t` to `uint16_t` to prevent data truncation.
-- Fixed `setApplicationData` return value handling in tests to resolve compiler warnings.
+CCSDSPack v2 is a breaking C++17 release that keeps the corrected v1.2 generic CCSDS Space Packet wire behavior and replaces the legacy project-specific PUS model with standards-oriented PUS-A and PUS-C revision/direction codecs.
 
-## Enhancements
-- Added `CCSDSPackConfig.cmake.in` template for robust `find_package(CCSDSPack CONFIG)` support.
-- Improved `build_terminal.sh` for reliable test execution regardless of current working directory.
-- Expanded test suite with `testGroupEdgeCases.cpp` covering PUS B/C edge cases and large payloads.
+The release also adds explicit mission profiles, numeric CUC time, checked packet finalization, structured packet validation, a lowercase public namespace, installed-package examples, and updated hosted/bare-metal integration.
 
-## Distribution
-- Docker image published to GHCR:
-```bash
-docker pull ghcr.io/exospacelabs/ccsdspack:latest
-docker run --rm ghcr.io/exospacelabs/ccsdspack:latest /usr/bin/CCSDSPack_tester
+## Standards scope
+
+Implemented and documented baselines:
+
+- CCSDS 133.0-B-2 Issue 2, including Editorial Change 2, for the supported Space Packet PDU profile;
+- ECSS-E-70-41A for supported PUS-A TC/TM secondary-header layouts;
+- ECSS-E-ST-70-41C for supported PUS-C TC/TM secondary-header layouts;
+- CCSDS 301.0-B-4 basic CUC numeric time for the documented supported subset.
+
+This is not a claim to implement every PUS service, transfer frames, COP-1, CFDP, a complete CCSDS protocol entity, UTC/leap-second conversion, or mission time correlation.
+
+## Breaking API changes
+
+- public namespace changes from `CCSDS` to `ccsds`;
+- legacy project-specific `PusA`, `PusB`, and `PusC` classes are removed;
+- `PusServices` is removed;
+- there is no standards-facing PUS-B revision;
+- PUS-A and PUS-C TC/TM use distinct public types under `ccsds::pus::rev_a` and `ccsds::pus::rev_c`;
+- secondary-header APIs use `setSecondaryHeader`, `getSecondaryHeader`, and related CCSDS terminology rather than `DataFieldHeader` naming;
+- packet finalization and serialization paths return checked `Result` types;
+- the Validator no longer exposes a positional six-boolean report;
+- hosted configuration uses the explicit v2 mission-profile schema and rejects legacy PUS selectors/keys.
+
+## Structured validation
+
+`ccsds::Validator::validate()` returns a `ccsds::ValidationReport` containing named `ValidationCode` checks.
+
+The report covers the applicable subset of:
+
+- primary-header/version validity;
+- Packet Data Length;
+- CRC16 when enabled;
+- secondary-header presence;
+- segmentation state and sequence-count continuity;
+- Packet Identification, segmentation class, and mission-profile template matching;
+- PUS revision, direction, and Packet Type consistency;
+- PUS profile and encoded header size;
+- PUS version/reserved bits and spare fields;
+- telecommand acknowledgement flags and source ID;
+- telemetry destination ID;
+- PUS-A TM packet-subcounter policy;
+- PUS-C TM four-bit time-reference status;
+- configured CUC timestamp fit.
+
+`ValidationReport` stores its checks in a fixed `std::array`, performs no dynamic allocation itself, requires only C++17, and remains available in `CCSDS_MCU` builds with exceptions and RTTI disabled.
+
+The hosted `ccsds_validator` command delegates packet/profile checks to the library Validator rather than maintaining a parallel validation implementation.
+
+## Mission profiles and PUS
+
+A default `ccsds::MissionProfile` represents generic CCSDS without implicit PUS.
+
+PUS profiles explicitly select:
+
+- PUS-A or PUS-C;
+- telecommand or telemetry direction;
+- packet error control;
+- applicable source/destination identifier widths;
+- optional PUS-A TM packet subcounter;
+- zero spare-octet count;
+- optional CUC telemetry time and its epoch/P-field/coarse/fine layout.
+
+Canonical selectors are:
+
+- `PUS:revA:TC`;
+- `PUS:revA:TM`;
+- `PUS:revC:TC`;
+- `PUS:revC:TM`.
+
+## CUC time
+
+The v2 CUC codec stores numeric coarse/fine counters with an explicit wire profile. The supported subset includes:
+
+- CCSDS 1958 TAI or agency-defined epoch metadata;
+- implicit or explicit basic one-octet P-field;
+- 1–4 coarse octets;
+- 0–3 fine octets;
+- counter-width and P-field validation.
+
+Calendar conversion, leap-second handling, and time correlation remain outside scope.
+
+## Generic Space Packet behavior retained from v1.2
+
+The following are **not new v2 wire changes**. They were corrected in v1.2 and remain the v2 foundation:
+
+- correct Packet Data Length calculation;
+- optional CRC16 coverage over primary header plus packet data excluding the CRC bytes themselves;
+- bounded parsing and exact packet consumption;
+- complete 11-bit APID support and Idle Packet handling;
+- modulo-16384 Packet Sequence Count behavior;
+- complete Packet Identification binding in Manager;
+- non-mutating inspection getters.
+
+## Hosted integration
+
+v2 provides:
+
+- encoder, decoder, and validator CLIs using the same mission-profile model;
+- generic and PUS configuration examples;
+- installed-package CMake consumers using `find_package(CCSDSPack 2.0 CONFIG REQUIRED)`;
+- Linux and Windows CI;
+- Doxygen API documentation.
+
+Automatic UML generation is intentionally disabled for v2.0.0 development. The workflow remains available manually through `workflow_dispatch`; diagrams are not a release gate.
+
+## Bare-metal integration
+
+The project remains C++17. `CCSDSPACK_BUILD_MCU=ON` builds the protocol library as a static archive and excludes hosted Config/CLI components.
+
+The MCU public library includes Packet, Manager, MissionProfile, PUS-A/PUS-C codecs, CUC time, Result/Error, and the structured Validator.
+
+The ARM compile/link consumer probe uses the same `CCSDSPACK_MCU_FLAGS` as the library and exercises both the structured Validator API and a representative PUS-C telecommand packet.
+
+## Validation status
+
+Current development evidence includes:
+
+- 108 passing hosted native tests after the structured Validator work;
+- Linux/Windows hosted builds and Doxygen;
+- representative generic/PUS CLI integration;
+- local ASan and UBSan runs;
+- independent generic and representative PUS byte vectors;
+- MCU compile/link probe coverage designed for `-fno-exceptions -fno-rtti`.
+
+The final release still requires the remaining gates tracked by the v2 milestone, including dedicated fuzz/sanitizer CI, final PUS-C/negative traceability, fresh arm64 execution, fresh NUCLEO-H755ZI-Q/Cortex-M7 execution, final migration-guide approval, and release publication checks.
+
+## Migration
+
+See [`docs/MIGRATION_V1_TO_V2.md`](docs/MIGRATION_V1_TO_V2.md) for the source, configuration, Validator, and wire-layout migration guidance.
+
+## Release control
+
+The intended promotion path is:
+
+```text
+feature/* -> v2.0.0-dev -> develop -> main -> tag v2.0.0
 ```
 
-___
-
-For detailed changes, see `CHANGE_LOG.md`.
+The `v2.0.0` tag is created only after the final `main` commit passes the approved release gates.

--- a/V2_TRANSITION_ACCEPTANCE_LIST.md
+++ b/V2_TRANSITION_ACCEPTANCE_LIST.md
@@ -95,6 +95,7 @@
 - [x] MCU sources are designed for `-fno-exceptions -fno-rtti` and the ARM compile/link probe exercises the structured Validator and representative PUS-C TC path.
 - [x] Linux and Windows hosted builds compile the structured Validator and CLI.
 - [x] Doxygen builds the updated public API documentation.
+- [x] Ubuntu 22.04 package/cross-build generation passes with the updated MCU structured-Validator/PUS probe.
 - [x] Automatic UML generation is disabled; the workflow remains manual-only through `workflow_dispatch`.
 
 ## Integration and release gates
@@ -104,7 +105,7 @@
 - [x] Standalone generic, custom-header, PUS-C TC, and PUS-C TM examples consume the installed package in Linux and Windows CI.
 - [x] Encoder, decoder, and validator accept/report complete PUS profiles.
 - [x] Manager higher-level PUS profile workflows are covered.
-- [ ] Final Linux package/cross-build gate passes with the updated MCU structured-Validator probe.
+- [x] Linux package/cross-build gate passes with the updated MCU structured-Validator probe.
 - [ ] Dedicated sanitizer/fuzz smoke jobs pass.
 - [ ] Final PUS-C acknowledgement-vector matrix and traceability are approved.
 - [ ] Final structured negative-vector coverage is approved.

--- a/V2_TRANSITION_ACCEPTANCE_LIST.md
+++ b/V2_TRANSITION_ACCEPTANCE_LIST.md
@@ -7,6 +7,7 @@
 - [x] ECSS-E-70-41A selected for PUS-A secondary headers.
 - [x] ECSS-E-ST-70-41C selected for PUS-C secondary headers.
 - [x] PUS-B rejected as a standards revision.
+- [x] Public implementation remains C++17.
 
 ## Mission profile
 
@@ -45,7 +46,7 @@
 
 - [x] TC version and acknowledgement fields are correct.
 - [x] TC service, subtype, two-octet source ID, and spare fields are encoded and parsed.
-- [x] TM version and time-reference status are correct.
+- [x] TM version and four-bit time-reference status are correct.
 - [x] TM service, subtype, message counter, destination, timestamp, and spare fields are encoded and parsed.
 - [x] Fixed vectors with and without timestamp pass.
 
@@ -62,34 +63,54 @@
 - [x] DataField and Manager serialization propagate errors without collapsing them.
 - [x] Packet Data Length and CRC16 are updated only after successful checked finalization.
 
+## Structured validation
+
+- [x] `ccsds::Validator::validate()` returns a structured `ValidationReport`.
+- [x] Validation failures are named by `ValidationCode` instead of positional boolean indices.
+- [x] Generic length, CRC, sequence, Packet Identification, segmentation, and mission-profile checks are represented.
+- [x] PUS revision, direction, Packet Type, profile, identifier, reserved/spare, optional-field, and CUC checks are represented.
+- [x] Validation does not mutate Packet, MissionProfile, or secondary-header state.
+- [x] Sequence validation remains stateful and rolls over modulo 16384.
+- [x] `ValidationReport` uses fixed `std::array` storage and performs no dynamic allocation itself.
+- [x] The Validator requires neither RTTI nor exceptions and remains part of `CCSDS_MCU`.
+- [x] `ccsds_validator` delegates protocol/profile checks to the library Validator.
+- [x] Native structured-validator tests cover generic and PUS positive/negative cases.
+
 ## Legacy removal and migration
 
 - [x] Legacy project-specific `PusA`, `PusB`, and `PusC` classes removed.
 - [x] `PusServices.h/.cpp` removed.
 - [x] Automatic legacy registration removed.
 - [x] Legacy configuration selectors rejected with migration guidance.
-- [x] Current tests and diagrams no longer present legacy codecs as supported.
-- [x] `docs/MIGRATION_V1_TO_V2.md` documents API, selector, and wire changes.
+- [x] Current tests no longer present legacy codecs as supported.
+- [x] UML diagrams are not treated as current v2 release evidence while generation is deferred.
+- [x] `docs/MIGRATION_V1_TO_V2.md` documents API, selector, wire, and structured Validator changes.
 - [x] Public secondary-header APIs and configuration use CCSDS secondary-header terminology.
 - [x] Project version and SOVERSION set to 2.0.0/2.
 
-## Local validation
+## Current validation
 
-- [x] 106 native tests pass.
-- [x] AddressSanitizer and UndefinedBehaviorSanitizer pass.
-- [x] MCU sources compile with `-fno-exceptions -fno-rtti`.
-- [x] `git diff --check` passes.
+- [x] 108 native tests pass in the current Linux build.
+- [x] AddressSanitizer and UndefinedBehaviorSanitizer have passed locally.
+- [x] MCU sources are designed for `-fno-exceptions -fno-rtti` and the ARM compile/link probe exercises the structured Validator and representative PUS-C TC path.
+- [x] Linux and Windows hosted builds compile the structured Validator and CLI.
+- [x] Doxygen builds the updated public API documentation.
+- [x] Automatic UML generation is disabled; the workflow remains manual-only through `workflow_dispatch`.
 
 ## Integration and release gates
 
-- [x] `v2.0.0-dev` merged into `develop` through PR #111.
-- [x] Linux, Windows, and Doxygen CI pass on `develop`.
+- [x] Linux, Windows, and Doxygen CI are retained as active hosted gates.
 - [x] Installed-consumer/package gates use v2 version expectations.
 - [x] Standalone generic, custom-header, PUS-C TC, and PUS-C TM examples consume the installed package in Linux and Windows CI.
 - [x] Encoder, decoder, and validator accept/report complete PUS profiles.
 - [x] Manager higher-level PUS profile workflows are covered.
-- [ ] Fuzz smoke jobs pass.
-- [ ] arm64 and STM32 representative PUS validation is recorded.
+- [ ] Final Linux package/cross-build gate passes with the updated MCU structured-Validator probe.
+- [ ] Dedicated sanitizer/fuzz smoke jobs pass.
+- [ ] Final PUS-C acknowledgement-vector matrix and traceability are approved.
+- [ ] Final structured negative-vector coverage is approved.
+- [ ] arm64 and STM32 representative v2 PUS/Validator execution is recorded.
+- [ ] Complete v1.2-to-v2 migration guide is approved.
 - [ ] Release notes and final compliance traceability are approved.
-- [ ] Approved `develop` merged into `main`.
-- [ ] `v2.0.0` tag created from approved `main` only.
+- [ ] Approved `v2.0.0-dev` is merged into `develop`.
+- [ ] Approved `develop` is merged into `main`.
+- [ ] `v2.0.0` tag is created from approved `main` only.

--- a/V2_TRANSITION_ROADMAP.md
+++ b/V2_TRANSITION_ROADMAP.md
@@ -2,7 +2,9 @@
 
 ## Objective
 
-Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 133.0-B-2 Space Packet foundation, with proper PUS-A and PUS-C TC/TM secondary headers and no legacy pseudo-PUS formats.
+Deliver a breaking, standards-oriented C++17 v2 release on the validated v1.2 CCSDS 133.0-B-2 Space Packet foundation, with proper PUS-A and PUS-C TC/TM secondary headers, structured validation, explicit mission tailoring, and no legacy pseudo-PUS formats.
+
+The public protocol library must remain usable in hosted and bare-metal builds. The MCU profile therefore remains compatible with `-fno-exceptions -fno-rtti`; host-only configuration and CLI code stay outside `CCSDS_MCU`.
 
 ## Completed foundation
 
@@ -10,29 +12,31 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 - CCSDS 133.0-B-2 Issue 2 plus Editorial Change 2 remains the generic packet baseline.
 - ECSS-E-70-41A and ECSS-E-ST-70-41C are the selected PUS-A and PUS-C secondary-header baselines.
 - PUS-B is rejected because ECSS-E-70-41B was never issued.
+- the project language standard remains C++17.
 
 ## Stage 1: Typed PUS architecture — implemented
 
-- `ccsds::pus::Revision` and `ccsds::pus::Direction` are independent strong types.
-- TC and TM use distinct concrete classes for each revision.
-- `ccsds::SecondaryHeaderFactory` handles custom, direction-neutral extensions.
-- fixed `ccsds::pus::SecondaryHeaderFactory` owns the reserved canonical selectors.
-- both factory paths create fresh mutable instances.
+- `ccsds::pus::Revision` and `ccsds::pus::Direction` are independent strong types;
+- TC and TM use distinct concrete classes for each revision;
+- `ccsds::SecondaryHeaderFactory` handles custom, direction-neutral extensions;
+- fixed `ccsds::pus::SecondaryHeaderFactory` owns the reserved canonical selectors;
+- both factory paths create fresh mutable instances;
 - all four canonical selector paths are covered directly by the PUS factory tests.
 
-## Stage 2: Mission profiles — implemented for the codec boundary
+## Stage 2: Mission profiles — implemented
 
 - a default profile is generic CCSDS;
 - PUS requires explicit revision and direction;
 - identifier, error-control, timestamp, PUS-A subcounter, and spare choices are validated;
 - header size is derived from the validated profile;
-- packet attachment and parsing validate profile, direction, and error-control consistency.
+- packet attachment and parsing validate profile, direction, and error-control consistency;
+- numeric basic CUC uses explicit epoch, P-field, coarse-width, and fine-width policy.
 
 ## Stage 3: PUS-A/PUS-C secondary headers — implemented
 
 - PUS-A TC/TM version, reserved, acknowledgement, service, subtype, optional identifier, subcounter, timestamp, and spare fields;
-- PUS-C TC acknowledgement/service/subtype/source fields;
-- PUS-C TM time-reference/service/subtype/counter/destination/timestamp fields;
+- PUS-C TC acknowledgement/service/subtype/two-octet source fields;
+- PUS-C TM four-bit time-reference/service/subtype/counter/two-octet destination/timestamp fields;
 - canonical selectors `PUS:revA:TC`, `PUS:revA:TM`, `PUS:revC:TC`, and `PUS:revC:TM`.
 
 ## Stage 4: Remove legacy model — implemented
@@ -44,44 +48,63 @@ Deliver a breaking, standards-oriented v2 release on the validated v1.2 CCSDS 13
 - legacy configuration selectors fail with migration guidance;
 - documented the breaking API/wire migration.
 
-## Stage 5: Evidence — codec evidence implemented, release evidence ongoing
+## Stage 5: Structured validation — implementation complete, integration under review
 
-Completed and integrated:
+The inherited positional six-boolean Validator model has been replaced by named checks:
+
+- `ccsds::ValidationCode` identifies generic CCSDS, mission-profile, template, and PUS failures;
+- `ccsds::ValidationReport` uses fixed `std::array` storage with bounded capacity;
+- `ccsds::Validator::validate()` does not mutate the packet, profile, or secondary header;
+- sequence validation retains one stateful modulo-16384 stream per Validator instance;
+- PUS validation covers revision, direction, Packet Type, profile, header size, reserved/spare fields, TC acknowledgement/source ID, TM destination ID, PUS-A subcounter policy, PUS-C time-reference status, and CUC timestamp fit;
+- `ccsds_validator` delegates protocol/profile checks to the library instead of maintaining parallel validation rules;
+- the API remains C++17 and is compiled into `CCSDS_MCU` without requiring RTTI or exceptions;
+- the ARM compile/link consumer probe exercises the structured report and a representative PUS-C TC packet.
+
+The current hosted native suite contains 108 passing tests after the Validator additions.
+
+## Stage 6: Evidence and hardening — ongoing
+
+Completed or present:
 
 - checked `Packet::update()`, `Packet::serialize()`, `DataField::serialize()`, and Manager stream serialization results;
-- native tests covering exact finalization, profile, header, data-length, and Manager propagation errors;
-- 106 native tests, including the four-selector PUS factory/configuration matrices
-  and numeric CUC vectors;
-- PUS-A/PUS-C fixed byte vectors and negative vectors;
-- ASan/UBSan validation;
-- MCU compile with `-fno-exceptions -fno-rtti`;
-- diff hygiene;
-- Linux, Windows, and Doxygen workflows on `develop`;
-- installed-package consumer validation with v2 version expectations.
-- standalone generic, custom, PUS-C TC, and PUS-C TM `find_package` examples, built and executed as installed-package consumers on Linux and Windows.
+- native tests covering finalization, profile, header, data-length, Manager, and structured Validator behavior;
+- PUS-A/PUS-C fixed byte vectors and malformed vectors;
+- local ASan/UBSan validation;
+- MCU build design for `-fno-exceptions -fno-rtti`;
+- Linux, Windows, and Doxygen hosted workflows;
+- installed-package consumer validation with v2 version expectations;
+- standalone generic, custom, PUS-C TC, and PUS-C TM `find_package` examples.
 
 Remaining release-level evidence:
 
-- bounded fuzz smoke jobs;
-- arm64 and STM32 hardware repetition with representative PUS vectors.
+- final Linux package/cross-build validation with the new MCU Validator/PUS probe;
+- committed sanitizer jobs and bounded parser fuzz smoke jobs;
+- completion of the PUS-C acknowledgement-vector matrix and final traceability;
+- final negative-vector coverage through the structured Validator;
+- arm64 and STM32 v2 execution with representative PUS/Validator paths.
 
-## Stage 6: Higher-level integration — implemented
+UML diagrams are deliberately **not** a v2.0.0 release gate. Automatic UML generation is disabled because its processing cost currently exceeds its release value. The workflow remains available manually through `workflow_dispatch` and can be re-enabled later.
 
-- the public namespace is `ccsds`, with revision-specific PUS codecs under
-  `ccsds::pus::rev_a` and `ccsds::pus::rev_c`;
-- the configuration schema constructs generic and complete PUS-A/PUS-C TC/TM
-  mission profiles and rejects legacy mappings;
-- encoder, decoder, and validator use and report the configured PUS profile;
+## Stage 7: User-facing integration — substantially implemented
+
+- the public namespace is `ccsds`, with revision-specific PUS codecs under `ccsds::pus::rev_a` and `ccsds::pus::rev_c`;
+- configuration constructs generic and complete PUS-A/PUS-C TC/TM mission profiles and rejects legacy mappings;
+- encoder, decoder, and validator use the configured PUS profile;
 - Manager applies the template profile during automatic PUS parsing;
-- numeric basic CUC supports CCSDS/agency epoch metadata, implicit/explicit
-  P-field, and validated coarse/fine widths;
-- CLI integration round-trips every committed generic/PUS profile and rejects a
-  corrupted PUS secondary header.
+- numeric basic CUC supports CCSDS/agency epoch metadata, implicit/explicit P-field, and validated coarse/fine widths;
+- CLI integration round-trips committed generic/PUS profiles and rejects malformed PUS input;
+- the public documentation describes structured validation and hosted versus bare-metal ownership.
 
-## Stage 7: Release preparation
+Remaining documentation work is concentrated in the complete before/after v1.2-to-v2 migration guide and final release notes/traceability.
 
-1. Continue reviewed v2 changes through pull requests from `v2.0.0-dev` to `develop`.
-2. Resolve integration failures without weakening fixed vectors or profile checks.
-3. Complete remaining fuzz/hardware gates.
-4. Synchronize release notes and final compliance traceability.
-5. Merge approved `develop` into `main` and tag `v2.0.0` from `main` only.
+## Stage 8: Release preparation
+
+1. Complete reviewed feature branches into `v2.0.0-dev`.
+2. Finish #74, #76, #77, #85, and the remaining #87 release gates without weakening fixed vectors or profile checks.
+3. Record fresh arm64 and STM32 v2 evidence.
+4. Approve release notes and final compliance traceability.
+5. Merge approved `v2.0.0-dev` into `develop`.
+6. Run the integrated `develop` gates.
+7. Merge approved `develop` into `main`.
+8. Run final `main` CI and tag `v2.0.0` from the approved `main` commit only.

--- a/docs/CCSDS_133_0_B_2_PROFILE.md
+++ b/docs/CCSDS_133_0_B_2_PROFILE.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # CCSDS 133.0-B-2 EC2 Space Packet PDU profile
 
-[Main README](../README.md) | [Compliance statement](../COMPLIANCE.md) | [Clause-level matrix](../CCSDS_COMPLIANCE.md)
+[Main README](../README.md) | [v2 compliance baseline](CCSDS_COMPLIANCE.md) | [Structured validation](VALIDATION.md)
 
 ## Normative baseline
 
@@ -22,20 +22,18 @@ The supported claim is:
 
 > CCSDSPack v2 implements a CCSDS 133.0-B-2 EC2 Space Packet PDU profile.
 
-This claim covers construction, serialization, bounded parsing, validation, sequence-count handling, and stream management for CCSDS Space Packet PDUs.
+This claim covers construction, serialization, bounded parsing, structured
+validation, sequence-count handling, and stream management for the implemented
+Space Packet PDU profile.
 
-It does **not** claim implementation of the complete CCSDS Space Packet Protocol entity, including:
+It does **not** claim implementation of the complete Space Packet Protocol entity,
+including all abstract service interfaces, sending/receiving procedures, managed
+parameters, or a completed PICS. Transfer frames, COP-1, CFDP, and other protocol
+layers are outside this library.
 
-- the abstract Packet Service interface;
-- the abstract Octet String Service interface;
-- all sending and receiving procedures;
-- all managed parameters;
-- a completed Protocol Implementation Conformance Statement (PICS);
-- transfer frames, Attached Synchronization Markers, CFDP, or other CCSDS protocol layers.
-
-This boundary is intentional and appropriate for a packet PDU library. Complete abstract services, lower-layer transfer, routing, and system-wide managed behavior belong to a larger flight or ground protocol entity when that system requires them.
-
-`ccsds::Manager` may prepend a configurable synchronization pattern around packet streams. That pattern is a CCSDSPack container convenience and is not part of a CCSDS Space Packet.
+`ccsds::Manager` may prepend a configurable synchronization pattern around packet
+streams. That pattern is a CCSDSPack framing convenience and is not part of a
+CCSDS Space Packet.
 
 ## Primary header profile
 
@@ -52,28 +50,25 @@ CCSDSPack uses the fixed six-octet primary header with:
 ### Packet Version Number
 
 A serialized or parsed Space Packet must encode Packet Version Number `000`.
-
-`ccsds::Header` remains a low-level three-bit field container for source compatibility and future protocol work. `ccsds::Packet` is the Space Packet profile gate and refuses to serialize non-zero versions. Configuration files also require:
-
-```ini
-ccsds_version_number:int=0
-```
+`ccsds::Header` remains a low-level field container; `ccsds::Packet` is the v2
+Space Packet profile gate.
 
 ### Packet Type
 
-Both telemetry (`0`) and telecommand (`1`) packet types are supported.
+Both telemetry (`0`) and telecommand (`1`) packet types are supported. For a PUS
+profile, Packet Type must agree with the explicit `ccsds::pus::Direction`.
 
 ### APID and Idle Packets
 
-The complete 11-bit APID range is supported. APID `0x7FF` is reserved for Idle Packets.
-
-A serializable or accepted Idle Packet must:
+The complete 11-bit APID range is supported. APID `0x7FF` is reserved for Idle
+Packets. A serializable or accepted Idle Packet must:
 
 - encode Secondary Header Flag `0`;
 - contain no secondary-header object;
+- use a generic mission profile;
 - carry at least one octet of mission-defined idle user data.
 
-CCSDSPack validates these structural rules but does not validate the mission-specific idle fill pattern.
+CCSDSPack validates these structural rules but not the mission-specific fill pattern.
 
 ### Sequence control
 
@@ -86,11 +81,16 @@ Sequence Flags use the CCSDS values:
 | `10` | last segment |
 | `11` | unsegmented packet |
 
-The Manager uses one modulo-16384 Packet Sequence Count stream per bound Packet Identification value. Automatic mode advances once for every generated packet, including unsegmented packets.
+The Manager uses one modulo-16384 Packet Sequence Count stream per bound Packet
+Identification value. Automatic mode advances once per generated packet,
+including unsegmented packets.
 
-CCSDSPack uses **Packet Sequence Count semantics for both telemetry and telecommand packets**. The optional telecommand Packet Name interpretation is not implemented.
+`ccsds::Validator` can independently validate legal segmentation transitions and
+sequence-count continuity. It retains its own sequence-stream state and advances
+that state only after the enabled checks for the packet pass.
 
-Manual sequence mode is an expert override. Applications using manual counts are responsible for continuity.
+CCSDSPack uses Packet Sequence Count semantics for both telemetry and telecommand
+packets. The optional telecommand Packet Name interpretation is not implemented.
 
 ## Packet Data Length and size
 
@@ -106,15 +106,11 @@ Therefore:
 total packet size = 6 + Packet Data Length + 1
 ```
 
-The representable Packet Data Field range is 1 through 65,536 octets, giving a total packet-size range of 7 through 65,542 octets.
+The representable Packet Data Field range is 1 through 65,536 octets, giving a
+total packet-size range of 7 through 65,542 octets.
 
-Use:
-
-```cpp
-std::size_t ccsds::Packet::getSerializedSize() const;
-```
-
-for the complete range. The legacy `getFullPacketLength()` returns `std::uint16_t` and saturates at `UINT16_MAX` rather than wrapping when the exact packet size is larger.
+Use `ccsds::Packet::getSerializedSize()` for the complete range. The legacy
+`getFullPacketLength()` returns `std::uint16_t` and saturates at `UINT16_MAX`.
 
 ## Secondary headers
 
@@ -122,19 +118,19 @@ CCSDS 133.0-B-2 permits optional secondary-header information. CCSDSPack support
 
 - opaque `BufferHeader` bytes;
 - user-registered secondary-header classes;
-- standards-oriented `ccsds::pus::rev_a::TcHeader`,
-  `ccsds::pus::rev_a::TmHeader`, `ccsds::pus::rev_c::TcHeader`, and
-  `ccsds::pus::rev_c::TmHeader` classes selected by an explicit
-  `ccsds::MissionProfile`.
+- standards-oriented `ccsds::pus::rev_a::TcHeader`;
+- `ccsds::pus::rev_a::TmHeader`;
+- `ccsds::pus::rev_c::TcHeader`;
+- `ccsds::pus::rev_c::TmHeader`.
 
 The v1 project-specific `PusA`, `PusB`, and `PusC` classes are removed. There is
-no PUS-B revision. PUS-A and PUS-C parsing uses the canonical revision/direction
-selectors documented in the [examples](EXAMPLES.md).
+no PUS-B revision. PUS-A and PUS-C use explicit revision/direction mission
+profiles and canonical selectors.
 
 PUS telemetry time is numeric and profile-driven. The supported basic CUC codec
-records the CCSDS-1958 or agency-defined epoch, implicit or explicit P-field,
-and 1–4 coarse plus 0–3 fine octets. Calendar conversion, leap-second handling,
-and agency-epoch definition remain outside the packet codec.
+records the CCSDS-1958 or agency-defined epoch, implicit or explicit one-octet
+P-field, and 1-4 coarse plus 0-3 fine octets. Calendar conversion, leap-second
+handling, and agency-epoch definition are outside the packet codec.
 
 ## CCSDSPack CRC16 mission profile
 
@@ -146,84 +142,96 @@ Packet Primary Header + Packet Data Field
 
 It does not define a third standardized packet error-control field.
 
-When `PacketErrorControlMode::CRC16` is selected, CCSDSPack reserves the **final two octets of the Packet Data Field** for a mission-profile CRC-16/CCITT-FALSE trailer. Those two octets:
+When `PacketErrorControlMode::CRC16` is selected, CCSDSPack reserves the final
+two octets of the Packet Data Field for a mission-profile CRC-16/CCITT-FALSE
+trailer. Those two octets:
 
 - are included in Packet Data Length;
 - are serialized most-significant byte first;
 - are excluded from their own CRC calculation;
-- are validated during parsing.
+- are validated during parsing and can be reported by the structured Validator.
 
-The CRC input is:
+The CRC input is the six-octet primary header followed by secondary-header and
+application-data bytes.
 
-```text
-six-octet Packet Primary Header
-+ optional secondary-header bytes
-+ application-data bytes
-```
-
-`PacketErrorControlMode::None` reserves no trailer octets. Configuration selects
-the mode explicitly.
+`PacketErrorControlMode::None` reserves no trailer octets. The receiving side
+must select the expected mode explicitly.
 
 ## Parsing profile
 
 `deserializeBounded()`:
 
-- validates the six-octet primary header before copying the body;
+- validates the six-octet primary header;
 - rejects non-zero Packet Version Numbers;
 - derives the exact boundary from Packet Data Length;
 - rejects truncated packet bodies;
 - validates the configured CRC trailer when enabled;
+- parses the selected PUS secondary header when a PUS profile is active;
 - returns the number of consumed octets;
-- leaves later concatenated packets or unrelated trailing bytes unconsumed;
-- commits parsed state only after validation succeeds.
+- leaves later packets or unrelated trailing bytes unconsumed;
+- commits parsed state only after parsing succeeds.
 
-The receiving application must configure whether the stream uses the CRC16 profile. The mode is not inferred from packet bytes.
+Malformed wire bytes can therefore fail before a `Packet` exists for structured
+object validation.
+
+## Structured Validator profile
+
+`ccsds::Validator` returns a fixed-capacity `ccsds::ValidationReport` containing
+named `ValidationCode` checks rather than positional boolean indices.
+
+Generic checks cover primary-header/version, Packet Data Length, CRC16 when
+applicable, secondary-header presence, sequence state, and optional template
+Packet Identification/profile checks.
+
+PUS profiles additionally validate revision, direction, Packet Type,
+mission-profile equality, secondary-header size, version/reserved bits, spare
+fields, acknowledgement/source ID, destination ID, PUS-A TM packet-subcounter
+policy, PUS-C TM time-reference status, and configured CUC timestamp fit.
+
+The report itself uses `std::array`, performs no dynamic allocation, and remains
+available in C++17 `CCSDS_MCU` builds with exceptions and RTTI disabled. See
+[VALIDATION.md](VALIDATION.md).
 
 ## Manager profile
 
-One `ccsds::Manager` represents one complete Packet Identification value and one sequence-count stream.
-
-The bound identifier contains:
+One `ccsds::Manager` represents one complete Packet Identification value and one
+sequence-count stream. The bound identifier contains:
 
 - Packet Version Number;
 - Packet Type;
 - Secondary Header Flag;
 - APID.
 
-Sequence Flags, Packet Sequence Count, and Packet Data Length are excluded because they vary within the stream.
-
-Applications managing multiple identifiers use multiple Manager instances or independent Packet objects. Within one managed data path, one APID should have one sequence-count authority.
+Sequence Flags, Packet Sequence Count, and Packet Data Length vary within the stream.
+Applications managing multiple identifiers use multiple Manager instances or
+independent Packet objects.
 
 ## Compatibility
 
 v2 does not retain the v1 namespace or legacy PUS source API. It preserves the
-corrected v1.2 packet-wire behavior, including:
+corrected v1.2 generic packet-wire behaviour, including Packet Data Length,
+optional CRC coverage, exact packet-boundary parsing, sequence rollover, complete
+Packet Identification enforcement, Packet Version Number validation, and Idle
+Packet validation.
 
-- Packet Data Length to use `N - 1`;
-- inclusion of the optional CRC trailer in Packet Data Length;
-- CRC coverage from the first primary-header octet;
-- exact packet-boundary parsing;
-- sequence-count advancement and rollover;
-- full Packet Identification enforcement;
-- Packet Version Number and Idle Packet profile validation.
-
-Stored or transmitted packets using the removed project-specific secondary
-headers must be regenerated with an explicit v2 mission profile. See the
-[migration guide](MIGRATION_V1_TO_V2.md).
+Those generic corrections are historical v1.2 behaviour, not new v1.2-to-v2
+wire breaks. Stored packets using the removed project-specific secondary headers
+must be regenerated with an explicit v2 mission profile.
 
 ## Conformance evidence
 
-The profile is exercised by:
+The v2 profile is exercised by:
 
-- independent Python-generated byte vectors committed under `test/test_resources`;
-- packet encode/decode and maximum-size tests;
-- malformed length, CRC, version, identifier, and sequence tests;
-- dedicated Idle Packet and PDU-profile tests;
-- the installed shared-library consumer under `test/package_tester/shared_lib`;
-- Linux and Windows CI builds and execution;
-- native Raspberry Pi 5 arm64 execution with `CCSDSPACK_AARCH64_TEST:PASS`;
-- STM32 Cortex-M7 build, link, flash, startup, and execution with `CCSDSPACK_MCU_TEST:PASS` reported twice.
+- inherited independent generic Space Packet vectors and regression tests from v1.2;
+- revision-specific PUS-A/PUS-C fixed and independent vectors;
+- positive and negative mission-profile and CUC tests;
+- structured Validator tests for generic and PUS checks;
+- installed-package consumer and CLI integration tests;
+- Linux and Windows CI.
 
-The clause-to-code-to-test mapping is recorded in [CCSDS_COMPLIANCE.md](../CCSDS_COMPLIANCE.md). Hardware details and reproduction procedures are recorded in [V1_2_HARDWARE_VALIDATION.md](V1_2_HARDWARE_VALIDATION.md) and [V1_2_STM32_VALIDATION_STEPS.md](V1_2_STM32_VALIDATION_STEPS.md).
+Historical Raspberry Pi 5 and STM32H755 results from v1.2 remain regression
+references. v2 arm64 and Cortex-M7 execution are repeated and recorded as
+separate v2 release gates before tagging v2.0.0.
 
-All supported Space Packet PDU implementation and hardware-validation gates are complete. This evidence does not expand the claim to a complete protocol entity or qualify every platform, compiler, memory layout, mission profile, or operating condition.
+UML diagram generation is a manual documentation utility and is not part of the
+v2.0.0 conformance or release gate.

--- a/docs/CCSDS_COMPLIANCE.md
+++ b/docs/CCSDS_COMPLIANCE.md
@@ -6,7 +6,7 @@ CCSDSPack v2 inherits the validated generic Space Packet PDU behaviour from v1.2
 
 | Area | Baseline | Implemented scope |
 |---|---|---|
-| Space Packet | CCSDS 133.0-B-2 Issue 2, including Editorial Change 2 | Construction, serialization, bounded parsing, inspection, validation, segmentation, and packet-error-control profile |
+| Space Packet | CCSDS 133.0-B-2 Issue 2, including Editorial Change 2 | Construction, serialization, bounded parsing, inspection, structured validation, segmentation, and packet-error-control profile |
 | PUS-A | ECSS-E-70-41A, 30 January 2003 | TC and TM secondary-header layouts |
 | PUS-C | ECSS-E-ST-70-41C, 15 April 2016 | TC and TM secondary-header layouts |
 | CUC time | CCSDS 301.0-B-4 | Basic numeric CUC with selected epoch, P-field, and coarse/fine widths |
@@ -110,16 +110,47 @@ synchronizes packet-error-control mode. PUS attachment and parsing reject:
 - identifier and timestamp sizes inconsistent with the profile;
 - invalid CUC epoch, P-field, coarse/fine widths, or overflowing counters.
 
+## Structured validation
+
+`ccsds::Validator` exposes named checks through `ccsds::ValidationReport` rather
+than a positional boolean vector. The report has fixed capacity and stores its
+checks in `std::array`, so the report itself performs no dynamic allocation.
+
+The validator covers the inherited generic checks and the selected v2 profile,
+including:
+
+- primary-header/version and Packet Data Length coherence;
+- CRC16 when enabled;
+- secondary-header presence;
+- sequence-flag state and modulo-16384 count continuity;
+- Packet Identification, segmentation class, and profile matching against a template;
+- PUS revision, direction, Packet Type, and header-profile consistency;
+- PUS header size, version/reserved bits, and zero spare fields;
+- telecommand acknowledgement/source-ID constraints;
+- telemetry destination-ID constraints;
+- PUS-A TM packet-subcounter policy;
+- PUS-C TM time-reference status;
+- numeric CUC timestamp fit under the mission profile.
+
+Validation does not modify the packet, mission profile, or secondary header. The
+Validator maintains only its own sequence-stream state. `ccsds_validator`
+delegates protocol/profile validation to this library implementation. See
+[VALIDATION.md](VALIDATION.md).
+
 ## Evidence
 
-The current native suite contains 106 passing tests. Evidence includes fixed
-TC/TM byte vectors for both revisions, explicit and implicit P-field CUC vectors,
-fresh-instance factory checks, all four configuration selectors, Manager PUS
-parsing, wrong-direction/profile/error-control failures, version and
-reserved-bit rejection, timestamp overflow, and spare-byte validation. CLI
-integration round-trips generic, PUS-A TC/TM, and PUS-C TC/TM configurations and
-rejects a corrupted PUS version.
+The native test suite covers fixed TC/TM byte vectors for both revisions,
+explicit and implicit P-field CUC vectors, fresh-instance factory checks, all
+four configuration selectors, Manager PUS parsing, structured Validator checks,
+wrong-direction/profile/error-control failures, version and reserved-bit
+rejection, timestamp overflow, spare-byte validation, and generic v1.2
+regressions. CLI integration round-trips generic, PUS-A TC/TM, and PUS-C TC/TM
+configurations and rejects a corrupted PUS version.
 
-The library also compiles in MCU mode with `-fno-exceptions -fno-rtti`. Generic v1.2 independent CCSDS vectors and regression tests remain passing.
+The library also compiles in MCU mode with C++17 and supports builds with
+`-fno-exceptions -fno-rtti`. Host-only configuration and CLI components are not
+part of the MCU build; the structured Validator is.
 
-CI, installed-package, Doxygen, cross-platform, sanitizer, fuzz, arm64, and hardware release gates remain authoritative at integration/release time and are not implied by a local compile.
+Linux, Windows, Doxygen, installed-package, sanitizer, fuzz, arm64, and hardware
+release gates remain authoritative at integration/release time. UML generation
+is currently a manual documentation tool and is not a v2.0.0 release gate.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -4,7 +4,7 @@ CCSDSPack installs three host-side command-line programs:
 
 - `ccsds_encoder` converts application bytes into one or more CCSDS Space Packets;
 - `ccsds_decoder` consumes complete adjacent packets and reassembles application bytes;
-- `ccsds_validator` reports packet-wire, identifier, and sequence-stream failures.
+- `ccsds_validator` reports parser, packet, profile, and sequence-stream failures.
 
 All tools load the same explicit v2 mission profile used by `ccsds::Packet` and
 `ccsds::Manager`.
@@ -71,18 +71,35 @@ Without external framing, an arbitrary suffix that happens to form a syntactical
 ccsds_validator --input packets.bin --config template.cfg --verbose
 ```
 
-The validator reports these checks separately:
+The executable does not maintain a second protocol-validator implementation.
+It uses `ccsds::Packet` for bounded parsing and `ccsds::Validator` for the
+structured object/profile checks described in [VALIDATION.md](VALIDATION.md).
 
-- Packet Data Length and packet boundary;
-- CRC16, or `NOT CHECKED` in `none` mode;
-- CCSDS packet version;
-- APID when a template config is supplied;
-- packet type and secondary-header flag when a template config is supplied;
-- PUS secondary-header structure and profile consistency for PUS templates;
-- sequence-flag state;
-- sequence-count continuity, including rollover from 16383 to 0.
+The library report can include named checks for:
 
-`--print-packets` prints packets which pass the parse-time length, CRC, and version checks. The process returns exit code `18` when any packet or trailing stream bytes fail validation.
+- primary-header validity and Packet Version Number;
+- Packet Data Length;
+- CRC16 when the configured profile enables it;
+- secondary-header presence;
+- sequence-flag state and modulo-16384 sequence-count continuity;
+- Packet Identification, segmentation class, and mission-profile equality when a template is supplied;
+- PUS revision, direction, and CCSDS Packet Type consistency;
+- PUS profile and secondary-header size;
+- version/reserved and spare fields;
+- telecommand acknowledgement flags and source ID;
+- telemetry destination ID;
+- PUS-A TM packet subcounter policy;
+- PUS-C TM time-reference status;
+- configured CUC timestamp validity.
+
+Only checks that are actually performed are emitted by the structured report. In
+`none` mode there is no `Crc16` report entry.
+
+Malformed wire input can fail during bounded parsing before a structured
+`ValidationReport` exists. PUS parse failures are reported as `PUS secondary
+header : FAILED`; generic parse failures are reported as packet-parse failures.
+
+`--print-packets` prints packets that parse successfully. The process returns exit code `18` when any packet or trailing stream bytes fail parsing or validation.
 
 ## Configuration
 
@@ -99,3 +116,7 @@ values are case-insensitive. PUS profiles additionally declare their canonical
 selector, revision, direction, identifiers, and time policy. See
 [CONFIG.md](CONFIG.md) and the runnable profiles in
 [`example/config`](../example/config).
+
+The command-line programs and `ccsds::Config` are hosted-only components. The
+underlying Packet, MissionProfile, PUS, time, and Validator APIs remain available
+in the C++17 `CCSDS_MCU` static-library build.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -14,7 +14,9 @@ CCSDSPack configuration files use one typed entry per line:
 ```
 
 Lines beginning with `#` are comments. The host-only parser is
-`ccsds::Config`.
+`ccsds::Config`. Configuration parsing is intentionally excluded from
+`CCSDS_MCU`; bare-metal applications construct `ccsds::MissionProfile` and
+packet objects directly in C++17.
 
 ## Value types
 
@@ -95,7 +97,7 @@ canonical selector:
 | Key | Type | Constraint |
 |---|---|---|
 | `pus_source_id_octets` | int | `0`, `1`, `2`, or `4`; PUS-C requires `2` |
-| `pus_acknowledgement_flags` | uint | `0..15` |
+| `pus_acknowledgement_flags` | uint | four-bit field, `0..15` |
 | `pus_source_id` | uint | Must fit `pus_source_id_octets` |
 
 ### Telemetry fields
@@ -107,7 +109,7 @@ canonical selector:
 | `pus_a_tm_packet_subcounter_present` | bool | Optional for PUS-A TM only |
 | `pus_packet_subcounter` | uint | Required when the PUS-A subcounter is present; `0..255` |
 | `pus_message_type_counter` | uint | PUS-C TM only; `0..65535` |
-| `pus_time_reference_status` | uint | PUS-C TM only; `0..7` |
+| `pus_time_reference_status` | uint | PUS-C TM only; four-bit field, `0..15` |
 | `pus_destination_id` | uint | Must fit `pus_destination_id_octets` |
 
 ### CUC telemetry time
@@ -130,6 +132,13 @@ T-field counters.
 Complete executable configurations are committed in
 [`example/config`](../example/config), including PUS-C TM profiles with and
 without a CUC time field.
+
+## Validation ownership
+
+Configuration selects the expected wire profile. It does not replace runtime
+validation. `ccsds::Packet` validates profile-dependent parsing/finalization and
+`ccsds::Validator` reports named generic and PUS checks through
+`ccsds::ValidationReport`. See [VALIDATION.md](VALIDATION.md).
 
 ## Idle Packets
 

--- a/docs/CROSSBUILD.md
+++ b/docs/CROSSBUILD.md
@@ -1,137 +1,66 @@
 # Cross-Build Guide (aarch64 Linux and Bare-metal MCU)
 
-[../](README.md) - CCSDSPack Documentation
+[Documentation index](README.md) | [Structured validation](VALIDATION.md)
 
-This document collects everything you need to cross-build CCSDSPack for:
-- aarch64/arm64 Linux (e.g., Raspberry Pi 4/5)
-- Bare‑metal static library for ARM Cortex‑M (e.g., STM32, M4/M7)
+CCSDSPack v2 is a C++17 library. This document covers:
 
-It also shows how to use the `package.sh` helper to generate packages or archives.
+- aarch64/arm64 Linux cross-builds;
+- the bare-metal ARM Cortex-M static-library profile;
+- `package.sh` package/archive generation.
 
----
-## Contents
-- [aarch64 (arm64) cross-build for Linux](#aarch64-arm64-cross-build-for-linux)
-  - [Prerequisites on Ubuntu 22.04 (Jammy) and newer](#prerequisites-on-ubuntu-2204-jammy-and-newer)
-  - [Prerequisites on Ubuntu 20.04 (Focal)](#prerequisites-on-ubuntu-2004-focal)
-  - [Build and package for aarch64](#build-and-package-for-aarch64)
-- [Bare‑metal (MCU) static library](#bare-metal-mcu-static-library)
-  - [Prerequisites](#prerequisites)
-  - [Build and package for MCU](#build-and-package-for-mcu)
-- [package.sh reference](#packagesh-reference)
-- [Troubleshooting](#troubleshooting)
+## aarch64 Linux
 
----
-## aarch64 (arm64) cross-build for Linux
+The toolchain file `cmake/toolchains/aarch64-linux-gnu.cmake` is provided for
+cross-compiling to arm64/aarch64.
 
-The toolchain file `cmake/toolchains/aarch64-linux-gnu.cmake` is provided for cross-compiling to arm64/aarch64.
+### Ubuntu 22.04 and newer
 
-### Prerequisites on Ubuntu 22.04 (Jammy) and newer
-On Jammy-based systems (including GitHub Actions ubuntu-22.04 runners), it is usually enough to enable the foreign architecture and install the toolchain + runtime libraries used by `cpack`'s dependency scanner:
+Enable the foreign architecture and install the cross toolchain and runtime
+libraries required by package dependency inspection:
 
 ```bash
 sudo dpkg --add-architecture arm64
-dpkg --print-foreign-architectures   # should show: arm64 (and i386 if you added it)
-
-# 2) Backup current sources
-sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak.$(date +%s)
-
-# 3) Write a clean dual-arch sources.list
-sudo tee /etc/apt/sources.list >/dev/null <<'EOF'
-# amd64 from main archive
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
-
-# arm64 from ports (the place that actually serves non-amd64 reliably)
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
-EOF
-
-# 4) Clean and refresh indexes (force IPv4 because some networks are drama)
-sudo apt-get clean
-sudo rm -rf /var/lib/apt/lists/*
-sudo apt-get -o Acquire::ForceIPv4=true update
-
-# 5) Install the cross toolchain and the arm64 runtimes shlibdeps wants
+sudo apt-get update
 sudo apt-get install -y \
   gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-static rsync \
   libc6:arm64 libgcc-s1:arm64 libstdc++6:arm64
-
-# 6) Sanity check that the files exist
-dpkg -L libc6:arm64        | grep -E 'ld-linux-aarch64\.so\.1|libc\.so\.6' || true
-dpkg -L libgcc-s1:arm64    | grep libgcc_s.so.1 || true
-dpkg -L libstdc++6:arm64   | grep 'libstdc\+\+\.so\.6' || true
 ```
 
-### Prerequisites on Ubuntu 20.04 (Focal)
-On Focal, arm64 runtime packages are reliably served via `ports.ubuntu.com`. Configure a clean dual-arch sources list:
+Systems whose normal Ubuntu mirror does not serve arm64 must use the matching
+`ports.ubuntu.com/ubuntu-ports` entries for that architecture.
+
+Build and package:
 
 ```bash
-# 1) add arm64 architecture
-sudo dpkg --add-architecture arm64
-sudo dpkg --print-foreign-architectures  # should show: arm64
-
-# 2) Backup current sources
-sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak.$(date +%s)
-
-# 3) Write a clean dual-arch sources.list for Focal
-sudo tee /etc/apt/sources.list >/dev/null <<'EOF'
-# amd64 from main archive (Focal)
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse
-
-# arm64 from ports (Focal)
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted universe multiverse
-EOF
-
-# 4) Clean and refresh indexes
-sudo apt-get clean
-sudo rm -rf /var/lib/apt/lists/*
-sudo apt-get -o Acquire::ForceIPv4=true update
-
-# 5) Install toolchain and the arm64 runtime libs
-sudo apt-get install -y \
-  gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-static rsync \
-  libc6:arm64 libgcc-s1:arm64 libstdc++6:arm64
-
-# 6) Sanity checks
-dpkg -L libc6:arm64      | grep -E 'ld-linux-aarch64\.so\.1|libc\.so\.6' || true
-dpkg -L libgcc-s1:arm64  | grep libgcc_s.so.1 || true
-dpkg -L libstdc++6:arm64 | grep 'libstdc\+\+\.so\.6' || true
-```
-
-### Build and package for aarch64
-Use the provided toolchain file and `package.sh`:
-
-```bash
-# From the project root
 ./package.sh -p DEB -t cmake/toolchains/aarch64-linux-gnu.cmake
-
-# Artifacts will be placed under ./packages/
-ls -l packages/
 ```
 
-If you prefer to just build (no packaging), configure and build in your usual build directory:
+Build without packaging:
 
 ```bash
-mkdir -p build-aarch64 && cd build-aarch64
-cmake -S .. -B . -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/aarch64-linux-gnu.cmake
-cmake --build . -- -j
+cmake -S . -B build-aarch64 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/aarch64-linux-gnu.cmake
+cmake --build build-aarch64 -j
 ```
 
----
-## Bare‑metal (MCU) static library
+## Bare-metal MCU static library
 
-You can build a static library suitable for microcontrollers (exceptionless, no executables) by enabling `CCSDSPACK_BUILD_MCU` and using the `arm-none-eabi` toolchain.
+`CCSDSPACK_BUILD_MCU=ON` builds the protocol library as a static archive and
+defines `CCSDS_MCU` publicly. Host-only configuration parsing and command-line
+executables are excluded.
+
+The MCU library still contains the protocol-facing C++17 API, including:
+
+- `ccsds::Packet` and `ccsds::Manager`;
+- `ccsds::MissionProfile`;
+- PUS-A/PUS-C TC/TM codecs;
+- CUC time support;
+- `ccsds::Result` error handling;
+- `ccsds::Validator`, `ValidationCode`, and fixed-capacity `ValidationReport`.
+
+The structured report uses `std::array` and performs no dynamic allocation
+itself. The MCU build does not require RTTI or exceptions.
 
 ### Prerequisites
 
@@ -144,64 +73,67 @@ sudo apt install -y \
   libstdc++-arm-none-eabi-newlib
 ```
 
-### Build and package for MCU
-Example for Cortex‑M7 (adjust flags for M4, etc.):
+### Package a Cortex-M7 archive
 
 ```bash
-# Package a TGZ archive with headers + static library
-./package.sh -t cmake/toolchains/arm-none-eabi.cmake -p MCU \
+./package.sh \
+  -t cmake/toolchains/arm-none-eabi.cmake \
+  -p MCU \
   -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
-
-# Artifacts will be placed under ./packages/
-ls -l packages/
 ```
 
-If you only want to build the static library:
+`package.sh -m` forwards the flags to `CCSDSPACK_MCU_FLAGS`, so the flags apply
+to the library itself as well as the MCU compile/link probe.
+
+### Build only the static library
 
 ```bash
-mkdir -p build-mcu && cd build-mcu
-cmake -S .. -B . \
+cmake -S . -B build-mcu \
   -DCMAKE_BUILD_TYPE=Release \
   -DCCSDSPACK_BUILD_MCU=ON \
-  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/arm-none-eabi.cmake \
-  -DMCU_FLAGS="-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
-cmake --build . -j
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/arm-none-eabi.cmake \
+  -DCCSDSPACK_MCU_FLAGS="-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
+
+cmake --build build-mcu -j
 ```
 
----
-## package.sh reference
+`CCSDSPACK_MCU_FLAGS` is the current CMake cache variable for target-specific
+MCU flags. Older documentation referring to `MCU_FLAGS` should not be used for
+direct CMake configuration.
 
-`package.sh` is a convenience wrapper around CMake and CPack. It accepts the following options:
+## Using the Validator on bare metal
 
-- `-p, --package-type`  Package type: `DEB`, `RPM`, `TGZ`, `MCU` (default: `DEB`).
-- `-t, --toolchain`     Path to a CMake toolchain file for cross-builds (e.g., `cmake/toolchains/aarch64-linux-gnu.cmake`).
-- `-m, --mcu-flags`     Extra flags to use when `-p MCU` is selected (e.g., Cortex‑M tuning flags).
-- `-h, --help`          Show usage and examples.
+Validation uses the same API as a hosted build:
 
-Examples:
+```cpp
+ccsds::Validator validator;
+const auto report = validator.validate(packet);
 
-```bash
-# Native x86_64 .deb
-./package.sh -p DEB
-
-# aarch64 .deb
-./package.sh -p DEB -t cmake/toolchains/aarch64-linux-gnu.cmake
-
-# Bare‑metal Cortex‑M7 archive (TGZ)
-./package.sh -p MCU -t cmake/toolchains/arm-none-eabi.cmake \
-  -m "-fno-exceptions -fno-rtti -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard"
+if (report.failed(ccsds::ValidationCode::PusDirection)) {
+  // mission-specific fault handling
+}
 ```
 
-Artifacts are written to `./packages/`.
+There is no dependency on `ccsds::Config`, file I/O, iostreams, exceptions, or
+RTTI in the Validator API. The packet types themselves retain their existing
+C++ containers and ownership model; the fixed-capacity statement applies to the
+`ValidationReport`, not to every object in the library.
 
----
-## Troubleshooting
+## `package.sh` reference
 
-- `E: Unable to locate package libc6:arm64` on 20.04
-  - Follow the Focal-specific dual-arch setup using `ports.ubuntu.com` above.
-- `cpack` produces no artifacts
-  - Ensure the project built successfully and that CPack configuration is enabled for the chosen generator.
-- aarch64 binary can’t run locally
-  - Use `qemu-user-static` or test on an actual arm64 machine.
-- Building in CI
-  - See `.github/workflows/linux.yml` — on ubuntu-22.04 runners we only add `arm64` and install the required `:arm64` libs without rewriting sources.
+- `-p, --package-type`: `DEB`, `RPM`, `TGZ`, or `MCU`;
+- `-t, --toolchain`: CMake toolchain file;
+- `-m, --mcu-flags`: additional flags forwarded to the MCU library and probe;
+- `-h, --help`: command usage.
+
+Artifacts are written under `packages/`.
+
+## Release validation
+
+Cross-compilation proves that a target can be built; it is not a substitute for
+execution on the target. v2 release acceptance records arm64 installed-package
+execution and representative Cortex-M7 hardware execution separately under the
+release-validation issue.
+
+Historical v1.2 Raspberry Pi and STM32 results remain useful regression evidence
+but are not silently treated as v2 hardware acceptance.

--- a/docs/ERROR.md
+++ b/docs/ERROR.md
@@ -5,25 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 
 # Error and Result handling
 
-[Documentation index](README.md) | [API reference](https://exospacelabs.github.io/CCSDSPack/html/)
+[Documentation index](README.md) | [Structured validation](VALIDATION.md) | [API reference](https://exospacelabs.github.io/CCSDSPack/html/)
 
-CCSDSPack reports checked failures through `ccsds::Result<T>` and `ccsds::Error`, defined in `inc/CCSDSResult.h`. Public packet and Manager operations do not use exceptions as their normal error channel.
+CCSDSPack reports checked operation failures through `ccsds::Result<T>` and
+`ccsds::Error`, defined in `inc/CCSDSResult.h`. Public packet and Manager
+operations do not use exceptions as their normal error channel.
 
-## Basic pattern
+## Basic Result pattern
 
 ```cpp
 const auto result = packet.deserializeBounded(bytes);
 if (!result) {
-  std::cerr << "CCSDSPack error "
-            << static_cast<unsigned>(result.error().code())
-            << ": " << result.error().message() << '\n';
+  log(result.error().code(), result.error().message());
   return result.error().code();
 }
 
 const std::size_t consumed = result.value();
 ```
 
-A `Result<T>` contains either a success value or an `Error`. Check `has_value()` or use the explicit boolean conversion before calling `value()` or `error()`.
+A `Result<T>` contains either a success value or an `Error`. Check the result
+before calling `value()` or `error()`.
 
 ## Error categories
 
@@ -38,13 +39,31 @@ A `Result<T>` contains either a success value or an `Error`. Check `has_value()`
 | `INVALID_APPLICATION_DATA` | 6 | Invalid or oversized application data. |
 | `NULL_POINTER` | 7 | A required pointer was null. |
 | `INVALID_CHECKSUM` | 8 | The configured CRC16 validation failed. |
-| `VALIDATION_FAILURE` | 9 | The Validator rejected a packet or stream property. |
+| `VALIDATION_FAILURE` | 9 | A validation operation rejected packet or stream state. |
 | `TEMPLATE_SET_FAILURE` | 10 | A Manager template could not be installed. |
 | `FILE_READ_ERROR` | 11 | Input could not be read. |
 | `FILE_WRITE_ERROR` | 12 | Output could not be written. |
 | `CONFIG_FILE_ERROR` | 13 | A configuration file, key, type, or value is invalid. |
 
-Branch on the error category and include `message()` in diagnostics. The message supplies operation-specific detail.
+## Structured Validator reports
+
+`ccsds::Validator::validate()` is intentionally different from an operation that
+can fail to execute. It returns a `ccsds::ValidationReport` containing named
+`ValidationCode` checks:
+
+```cpp
+const auto report = validator.validate(packet);
+if (report.failed(ccsds::ValidationCode::Crc16)) {
+  // CRC validation was performed and failed.
+}
+```
+
+A report is not an `Error` and does not use numeric report positions. This lets
+bare-metal code branch on stable enum values without allocating error strings or
+depending on a six-element boolean-vector layout.
+
+Malformed wire input can still return a normal `Error` from parsing before a
+Packet exists to pass to the Validator.
 
 ## Result aliases
 
@@ -55,17 +74,13 @@ using ResultBuffer = Result<std::vector<std::uint8_t>>;
 
 ## Propagation helpers
 
-`CCSDSResult.h` also defines internal/publicly visible propagation macros used by existing v1 code:
-
-- `RETURN_IF_ERROR`;
-- `RET_IF_ERR_MSG`;
-- `ASSIGN_MV` and `ASSIGN_CP`;
-- `ASSIGN_OR_PRINT`;
-- `ASSERT_SUCCESS`;
-- `FORWARD_RESULT`.
-
-Normal application code can remain clearer by checking `Result<T>` explicitly, particularly at API boundaries where logs and recovery policy belong to the caller.
+`CCSDSResult.h` defines propagation helpers used by existing library code,
+including `RET_IF_ERR_MSG`, `ASSIGN_MV`, `ASSIGN_CP`, and `FORWARD_RESULT`.
+Application code is usually clearer when it checks `Result<T>` explicitly at API
+boundaries.
 
 ## Hosted and MCU builds
 
-The same result types are available in host and `CCSDS_MCU` builds. Requesting the inactive `std::variant` alternative is programmer misuse, so always check the result before accessing it even when the project is compiled with `-fno-exceptions`.
+The same Result types and structured Validator API are available in host and
+`CCSDS_MCU` builds. The project remains C++17 and supports MCU builds with
+`-fno-exceptions -fno-rtti`.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Examples
 
-[Documentation index](README.md) | [Configuration](CONFIG.md) | [Space Packet profile](CCSDS_133_0_B_2_PROFILE.md)
+[Documentation index](README.md) | [Configuration](CONFIG.md) | [Structured validation](VALIDATION.md) | [Space Packet profile](CCSDS_133_0_B_2_PROFILE.md)
 
 These examples use the v2 C++17 API. They create CCSDS Space Packets with Packet Version Number `000`. The default packet-error-control profile is the project-specific CRC16 trailer; configure `PacketErrorControlMode::None` explicitly for CRC-free packets.
 
@@ -86,6 +86,32 @@ int main() {
 ```
 
 `serialize()` returns `ResultBuffer` and reports the exact finalization error. `update()` returns `ResultBool` when finalization without bytes is required. Getters inspect the stored state and do not perform hidden finalization.
+
+## Validate a packet with named checks
+
+```cpp
+ccsds::Validator validator;
+const auto report = validator.validate(decoded);
+
+if (!report.valid()) {
+  for (const auto &check : report) {
+    if (!check.passed) {
+      handleValidationFailure(check.code,
+                              ccsds::validationCodeName(check.code));
+    }
+  }
+}
+```
+
+The report contains only checks that were performed. Query a specific condition without relying on report indices:
+
+```cpp
+if (report.failed(ccsds::ValidationCode::PacketDataLength)) {
+  handleLengthFailure();
+}
+```
+
+The same Validator API is available in the C++17 `CCSDS_MCU` build. The report uses fixed `std::array` storage and performs no dynamic allocation itself. See [VALIDATION.md](VALIDATION.md).
 
 ## Segment a payload with Manager
 
@@ -210,7 +236,9 @@ The sender and receiver must both select `None`. The mode is never inferred from
 ccsds::Packet sender;
 sender.setPacketErrorControlMode(ccsds::PacketErrorControlMode::None);
 sender.setDataFieldSize(1024);
-sender.setPrimaryHeader({0, 0, 0, 0x123, ccsds::UNSEGMENTED, 0, 0});
+sender.setPrimaryHeader(ccsds::PrimaryHeader{
+  0, 0, 0, 0x123, ccsds::UNSEGMENTED, 0, 0
+});
 sender.setApplicationData({0x01, 0x02});
 const auto wireResult = sender.serialize();
 if (!wireResult) return wireResult.error().code();
@@ -230,7 +258,9 @@ the `BufferHeader` path through `setSecondaryHeader()`.
 ```cpp
 ccsds::Packet packet;
 packet.setDataFieldSize(1024);
-packet.setPrimaryHeader({0, 0, 1, 0x123, ccsds::UNSEGMENTED, 0, 0});
+packet.setPrimaryHeader(ccsds::PrimaryHeader{
+  0, 0, 1, 0x123, ccsds::UNSEGMENTED, 0, 0
+});
 
 const auto secondaryResult = packet.setSecondaryHeader(
   std::vector<std::uint8_t>{0xAA, 0x55}

--- a/docs/EXECUTABLES.md
+++ b/docs/EXECUTABLES.md
@@ -5,16 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 
 # Executables
 
-[Documentation index](README.md) | [Canonical CLI reference](CLI.md)
+[Documentation index](README.md) | [Canonical CLI reference](CLI.md) | [Structured validation](VALIDATION.md)
 
 CCSDSPack provides these host-side executables:
 
 - `ccsds_encoder`: converts application bytes into one or more adjacent Space Packets;
 - `ccsds_decoder`: parses adjacent Space Packets and reassembles application bytes;
-- `ccsds_validator`: reports packet, identifier, CRC-profile, and sequence-stream failures;
+- `ccsds_validator`: parses packet streams and reports the named checks produced by the library Validator;
 - `CCSDSPack_tester`: runs the native regression and conformance test suite.
 
-The authoritative option, packet-error-control, trailing-byte, validation, and exit-code documentation is maintained in [CLI.md](CLI.md). This page remains as a stable compatibility entry point for older links.
+The authoritative option, packet-error-control, trailing-byte, validation, and exit-code documentation is maintained in [CLI.md](CLI.md). The Validator API itself is documented in [VALIDATION.md](VALIDATION.md).
 
 ## Build controls
 
@@ -27,7 +27,10 @@ cmake -S . -B build \
 cmake --build build
 ```
 
-The executable location depends on the selected generator and platform. The default project layout places native binaries under the configured build output's `bin` directory.
+These executables are hosted components and are not built when
+`CCSDSPACK_BUILD_MCU=ON`. The underlying Packet, Manager, MissionProfile, PUS,
+time, Result, and structured Validator APIs remain available in the MCU static
+library.
 
 ## Typical flow
 
@@ -37,7 +40,9 @@ ccsds_validator -i packets.bin -c template.cfg --verbose
 ccsds_decoder -i packets.bin -o recovered.bin -c template.cfg
 ```
 
-The encoder and decoder require a template configuration. The validator can operate without one, but a template enables Packet Identification checks. All tools must use the same `crc16` or `none` packet-error-control profile as the packet stream.
+The encoder and decoder require a template configuration. The validator can operate without one for generic packets, but a template enables Packet Identification, segmentation-class, and mission-profile comparison. All tools must use the same `crc16` or `none` packet-error-control profile as the packet stream.
+
+The validator executable delegates protocol/profile checks to `ccsds::Validator`; it does not maintain an independent copy of the validation rules.
 
 Run the installed or built test executable with:
 

--- a/docs/FLOW.md
+++ b/docs/FLOW.md
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 
 # Packet processing flow
 
-[Documentation index](README.md) | [Examples](EXAMPLES.md) | [v1.2 profile](CCSDS_133_0_B_2_PROFILE.md)
+[Documentation index](README.md) | [Examples](EXAMPLES.md) | [Validation](VALIDATION.md) | [v2 profile](CCSDS_133_0_B_2_PROFILE.md)
 
-CCSDSPack exposes two main levels:
+CCSDSPack exposes two main packet levels:
 
 - `ccsds::Packet` represents exactly one CCSDS Space Packet PDU;
 - `ccsds::Manager` generates or consumes a stream whose packets share one complete Packet Identification value.
+
+`ccsds::Validator` is the separate read-only validation layer for packet state,
+mission-profile/PUS coherence, templates, and sequence streams.
 
 ## Construct one packet
 
 1. Create a `Packet`.
 2. Assign a version-0 `PrimaryHeader`.
-3. Configure the Packet Data Field capacity and packet-error-control mode.
+3. Configure the Packet Data Field capacity and packet-error-control mode/profile.
 4. Add an optional secondary header and application data.
 5. Call `serialize()` and check the returned `ResultBuffer`.
 
-`serialize()` finalizes Packet Data Length, the stored sequence count, and the optional CCSDSPack CRC16 trailer. It returns the exact validation/finalization error instead of an empty byte vector. `update()` provides the same checked finalization without producing bytes. Inspection getters do not perform hidden finalization.
+`serialize()` finalizes Packet Data Length, the stored sequence count, and the optional CCSDSPack CRC16 trailer. It returns the exact finalization error instead of an empty byte vector. `update()` provides the same checked finalization without producing bytes. Inspection getters do not perform hidden finalization.
 
 ## Generate a packet stream
 
@@ -42,15 +45,42 @@ Applications handling multiple identifiers use separate Manager instances or ind
 
 ## Parse one packet
 
-1. Configure the receiving `Packet` with the expected packet-error-control mode.
-2. Call `deserializeBounded()` on a buffer beginning with a packet.
-3. Use the returned byte count to locate the next packet or preserve unrelated trailing bytes.
+1. Configure the receiving `Packet` with the expected mission profile and packet-error-control mode.
+2. For PUS, select the canonical revision/direction secondary-header selector.
+3. Call `deserializeBounded()` on a buffer beginning with a packet.
+4. Use the returned byte count to locate the next packet or preserve unrelated trailing bytes.
 
-The parser derives the exact boundary from Packet Data Length, rejects truncation, validates the configured CRC16 trailer when enabled, and commits decoded state only after validation succeeds.
+The parser derives the exact boundary from Packet Data Length, rejects truncation, validates the configured CRC16 trailer when enabled, validates the selected PUS secondary-header bytes, and commits decoded state only after parsing succeeds.
 
-## Parse a packet stream
+## Validate packet state
+
+After construction or parsing, run the structured Validator when named
+coherence/profile diagnostics are required:
+
+```cpp
+ccsds::Validator validator;
+const auto report = validator.validate(packet);
+
+if (!report.valid()) {
+  for (const auto &check : report) {
+    if (!check.passed) {
+      // handle check.code
+    }
+  }
+}
+```
+
+The report uses named `ValidationCode` values rather than positional boolean
+indices. The packet, profile, and secondary header are not mutated. The
+Validator retains only its own sequence-stream state.
+
+## Parse and validate a packet stream
 
 A configured Manager can call `load()` or `read()` to parse adjacent packets transactionally. The operation rejects malformed framing, truncated packets, CRC failures, and mixed Packet Identification values without partially appending the failed input.
+
+For explicit stream validation, use one `Validator` instance per sequence stream.
+It checks legal segmentation transitions and modulo-16384 count continuity. Call
+`clear()` before assigning the Validator to an unrelated stream.
 
 The optional Manager synchronization pattern is project-specific stream framing. It is not part of the CCSDS Space Packet PDU.
 
@@ -58,4 +88,5 @@ The optional Manager synchronization pattern is project-specific stream framing.
 
 After packets are loaded, call `getApplicationDataBuffer()` and check the returned `ResultBuffer`. The Manager concatenates application data in stored packet order.
 
-See [Examples](EXAMPLES.md) for complete source snippets.
+See [Examples](EXAMPLES.md) for complete source snippets and
+[VALIDATION.md](VALIDATION.md) for the full structured validation model.

--- a/docs/MIGRATION_V1_TO_V2.md
+++ b/docs/MIGRATION_V1_TO_V2.md
@@ -2,7 +2,8 @@
 
 CCSDSPack v2 intentionally breaks source compatibility. It removes
 project-specific formats that could be mistaken for ECSS PUS revisions and
-makes packet finalization, mission tailoring, and time encoding explicit.
+makes packet finalization, mission tailoring, validation, and time encoding
+explicit.
 
 ## Namespace migration
 
@@ -68,6 +69,45 @@ if (!wire) {
 send(wire.value());
 ```
 
+## Validator migration
+
+The v1/v1.2 Validator exposed a boolean result and a positional six-element
+`std::vector<bool>` report. Code had to know that, for example, one index meant
+CRC and another meant sequence continuity.
+
+v2 replaces those positional report semantics with named checks:
+
+```cpp
+ccsds::Validator validator;
+const auto report = validator.validate(packet);
+
+if (report.failed(ccsds::ValidationCode::Crc16)) {
+  handleBadCrc();
+}
+
+if (report.failed(ccsds::ValidationCode::PusDirection)) {
+  handleWrongPusDirection();
+}
+```
+
+`ccsds::ValidationReport`:
+
+- uses a fixed `std::array` with capacity for 32 named checks;
+- performs no dynamic allocation itself;
+- is available in hosted and `CCSDS_MCU` builds;
+- requires only C++17;
+- does not require RTTI or exceptions;
+- contains only checks that were actually performed;
+- can be iterated or queried with `contains()`, `passed()`, and `failed()`.
+
+`ccsds::Validator::validate()` does not mutate the packet, mission profile, or
+secondary header. The Validator still maintains its own sequence-stream state.
+Call `clear()` before reusing it for an unrelated sequence stream.
+
+The `ccsds_validator` executable now delegates packet/profile validation to the
+library Validator instead of keeping an independent copy of the validation
+rules. See [VALIDATION.md](VALIDATION.md).
+
 ## PUS construction and numeric time
 
 Raw timestamp byte vectors are replaced by a numeric CUC value plus an explicit
@@ -104,7 +144,8 @@ The same profile must be active before parsing:
 
 ```cpp
 ccsds::Packet decoded;
-decoded.setMissionProfile(profile);
+const auto profileResult = decoded.setMissionProfile(profile);
+if (!profileResult) return profileResult.error().code();
 const auto consumed = decoded.deserializeBounded(wire.value(), "PUS:revC:TM");
 ```
 
@@ -129,8 +170,29 @@ Legacy `pus_version`, `pus_event_id`, `pus_time_code`, and
 `secondary_header_type=PusA|PusB|PusC` values fail with a migration error.
 Complete v2 profiles are in [`example/config`](../example/config).
 
+## Hosted versus bare-metal use
+
+The public protocol library remains C++17. `ccsds::Packet`, `ccsds::Manager`,
+mission profiles, PUS codecs, CUC time, Result types, and the structured Validator
+are built into the MCU static library.
+
+`ccsds::Config` and the command-line executables are host-side conveniences and
+are excluded when `CCSDSPACK_BUILD_MCU=ON` defines `CCSDS_MCU`.
+
+A typical MCU build can use:
+
+```text
+-fno-exceptions -fno-rtti
+```
+
+without changing the Validator API.
+
 ## Wire-format impact
 
 The removed classes encoded project-specific layouts. Existing legacy packet
 bytes must be regenerated with a selected revision, direction, mission profile,
 and time layout; renaming a class or selector is insufficient.
+
+The generic Packet Data Length, CRC coverage, bounded parsing, APID-width, and
+sequence corrections were already part of v1.2.0. They are retained by v2 and
+should not be presented as new v1.2-to-v2 wire-format breaks.

--- a/docs/MISSION_TAILORING.md
+++ b/docs/MISSION_TAILORING.md
@@ -4,8 +4,8 @@
 
 CCSDS packet error control and the ECSS PUS-A/PUS-C secondary-header layouts
 contain mission-selected parameters. CCSDSPack records those choices in one
-validated `ccsds::MissionProfile`, which is shared by Packet, Manager, and the
-command-line tools.
+validated `ccsds::MissionProfile`, shared by Packet, Manager, PUS codecs, the
+structured Validator, and hosted command-line tools.
 
 ## Namespace and type model
 
@@ -19,10 +19,9 @@ grouped by revision and direction:
 | PUS-C TC | `ccsds::pus::rev_c::TcHeader` | `PUS:revC:TC` |
 | PUS-C TM | `ccsds::pus::rev_c::TmHeader` | `PUS:revC:TM` |
 
-The lowercase namespace is a v2 source-level convention. It does not alter the
-wire format or runtime performance. The nested PUS namespaces keep
-standards-specific codecs out of the generic packet API and prevent a revision
-from being confused with packet direction.
+The lowercase namespace is a v2 source-level convention. It does not alter wire
+format or runtime performance. The nested PUS namespaces keep revision-specific
+codecs separate from the generic packet API.
 
 `ccsds::pus::SecondaryHeaderFactory` owns the fixed standards registry. The
 direction-neutral `ccsds::SecondaryHeaderFactory` remains the extension point
@@ -52,7 +51,7 @@ TM. PUS-A identifier widths are mission-tailored to 0, 1, 2, or 4 octets.
 ## Numeric CUC time
 
 PUS telemetry can carry a numeric CCSDS Unsegmented Time Code (CUC). The profile
-defines the wire representation; the header stores the numeric coarse and fine
+defines the wire representation; the header stores numeric coarse and fine
 counters:
 
 ```cpp
@@ -61,14 +60,11 @@ profile.telemetryTimeCode = ccsds::time::Format::Cuc;
 profile.telemetryCuc = {
   ccsds::time::Epoch::Ccsds1958Tai,
   ccsds::time::PFieldMode::Explicit,
-  4, // coarse octets
-  2  // fine octets
+  4,
+  2
 };
 
-ccsds::time::CucTime timestamp{
-  0x01020304, // integral seconds from the selected epoch
-  0xA0B0      // binary fraction scaled by 2^(8 * fineOctets)
-};
+ccsds::time::CucTime timestamp{0x01020304, 0xA0B0};
 ```
 
 The implemented basic CUC profile supports:
@@ -76,29 +72,35 @@ The implemented basic CUC profile supports:
 - 1 through 4 coarse-time octets;
 - 0 through 3 fine-time octets;
 - the CCSDS epoch at 1958-01-01 TAI or an agency-defined epoch;
-- an implicit P-field supplied by the mission profile or an explicit one-octet
-  P-field carried on the wire;
+- implicit or explicit one-octet P-field policy;
 - network-byte-order encoding and exact P-field validation during decoding.
 
 CCSDSPack represents the counter and validates its encoding. It does not convert
 UTC calendar timestamps, apply leap-second tables, or define an agency epoch.
-Those responsibilities belong to the mission time-correlation layer and its
-interface control document.
 
-## Validation rules
+## Validation ownership
 
-A profile is rejected when it is ambiguous or permits a different wire layout.
-The checks include:
+`validateMissionProfile()` validates the configuration of the wire contract
+itself. It rejects:
 
-- explicit supported PUS revision and direction;
-- TC/TM consistency with the primary-header Packet Type;
-- supported identifier widths and PUS-C fixed widths;
-- no TC-only fields in TM profiles or TM-only fields in TC profiles;
-- no timestamp metadata when time is disabled;
-- valid CUC epoch, P-field policy, and coarse/fine widths;
-- counter values fitting their configured widths;
-- consistent packet-error-control policy;
-- zero-valued configured spare octets.
+- missing/unsupported PUS revision or direction;
+- unsupported identifier widths and incorrect fixed PUS-C widths;
+- TC-only fields in TM profiles or TM-only fields in TC profiles;
+- timestamp metadata when time is disabled;
+- invalid CUC epoch, P-field policy, or coarse/fine widths;
+- inconsistent PUS packet-error-control selection.
+
+`ccsds::Packet` and the concrete PUS codecs validate packet/header state during
+attachment, parsing, and finalization.
+
+`ccsds::Validator` then exposes those packet/profile relationships as named
+checks, including revision, direction, Packet Type, identifiers, reserved/spare
+fields, acknowledgement flags, PUS-A TM subcounter policy, PUS-C TM
+four-bit time-reference status, CUC timestamp fit, and packet-error-control
+consistency. See [VALIDATION.md](VALIDATION.md).
+
+Configured spare-octet **count** belongs to the MissionProfile. Actual encoded
+spare octets are required to be zero and are checked by the PUS codec/Validator.
 
 Parsing never guesses revision, direction, identifier widths, time layout, or
 packet error control from the remaining bytes.
@@ -106,9 +108,12 @@ packet error control from the remaining bytes.
 ## Configuration ownership
 
 The same configuration profile is loaded by `ccsds::Packet`, propagated by
-`ccsds::Manager`, and used by the encoder, decoder, and validator. See
-[CONFIG.md](CONFIG.md) for the complete schema and the committed profiles in
+`ccsds::Manager`, and used by the hosted encoder, decoder, and validator. See
+[CONFIG.md](CONFIG.md) and the committed profiles in
 [`example/config`](../example/config).
+
+`ccsds::Config` is host-only. Bare-metal C++17 applications construct the same
+MissionProfile directly and use the same packet/PUS/Validator APIs.
 
 CCSDSPack validates and applies mission choices. It does not decide which PUS
 services, identifiers, packet-error control, epoch, or time resolution a mission
@@ -117,5 +122,5 @@ should use.
 ## Change control
 
 Adding a profile field or support claim requires explicit units and ranges,
-deterministic serialization and parsing, positive and negative tests,
-independent wire vectors, and an update to the compliance matrix.
+deterministic serialization/parsing, positive and negative tests, independent
+wire evidence, and an update to the compliance documentation.

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -12,14 +12,14 @@
 
 Supported options:
 
-- `-p` or `--package-type`: package type, one of `DEB`, `RPM`, `TGZ`, or `MCU`; default is `DEB`.
-- `-t` or `--toolchain`: optional CMake toolchain file for cross-builds.
-- `-m` or `--mcu-flags`: additional MCU compiler flags when producing an `MCU` package.
-- `--help`: show command usage and examples.
+- `-p` or `--package-type`: `DEB`, `RPM`, `TGZ`, or `MCU`; default is `DEB`;
+- `-t` or `--toolchain`: optional CMake toolchain file for cross-builds;
+- `-m` or `--mcu-flags`: additional MCU compiler flags, forwarded to the MCU library build and compile/link probe;
+- `--help`: command usage and examples.
 
 Successful packages are written under `packages/`.
 
-Do not build with `sudo`. Root privileges are only required when installing or removing a system package. Building as root can leave root-owned files in the repository checkout.
+Do not build with `sudo`. Root privileges are only required when installing or removing a system package.
 
 ### RPM prerequisite
 
@@ -31,57 +31,46 @@ rpmbuild --version
 
 ## Installing a DEB
 
-System package installation requires root permissions:
-
 ```bash
 sudo dpkg -i packages/ccsdspack-v<version>-Linux-<architecture>.deb
 ```
 
-Inspect the installed package:
+Inspect or remove it with:
 
 ```bash
 dpkg -s ccsdspack
 dpkg -L ccsdspack
-```
-
-Remove it with:
-
-```bash
 sudo dpkg --remove ccsdspack
 ```
 
 ## Installed test fixtures
 
-Packages that include `CCSDSPack_tester` also install a sibling `test_resources` directory under the executable installation directory. The tester uses relative `test_resources/...` paths for committed fixtures and temporary file-I/O round trips.
-
-These resources belong only to the regression tester. They are not a dependency of:
-
-- `libccsdspack`;
-- `ccsds_encoder`;
-- `ccsds_decoder`;
-- `ccsds_validator`;
-- applications linking `ccsdspack::CCSDSPack`.
-
-Applications must not treat the installed test resources as public runtime data or API assets.
+Packages that include `CCSDSPack_tester` also install a sibling `test_resources`
+directory under the executable installation directory. These fixtures are for
+the regression suite only. They are not runtime dependencies of the library,
+the CLI programs, or external applications.
 
 ## CMake package consumption
 
-After installation, use the exported CMake package:
+After installation:
 
 ```cmake
 find_package(CCSDSPack CONFIG REQUIRED)
 target_link_libraries(my_app PRIVATE ccsdspack::CCSDSPack)
 ```
 
-A release consumer can require the exact version:
+A v2 consumer can require the breaking-release API explicitly:
 
 ```cmake
-find_package(CCSDSPack 1.2.0 EXACT CONFIG REQUIRED)
+find_package(CCSDSPack 2.0.0 EXACT CONFIG REQUIRED)
 ```
+
+The package exports the C++17 library API, including the structured Validator.
 
 ## Raspberry Pi arm64 validation
 
-On a native 64-bit Raspberry Pi system, run the complete installed-package validation from a checkout matching the package candidate:
+On a native 64-bit Raspberry Pi system, run the installed-package validation
+from a checkout matching the package candidate:
 
 ```bash
 ARM64_DEB="$(find ./packages -type f -name '*arm64*.deb' -print -quit)"
@@ -90,22 +79,30 @@ bash test/package_tester/aarch64_validate.sh "$ARM64_DEB" \
   2>&1 | tee ~/ccsdspack-aarch64-validation.log
 ```
 
-Launch the script as a normal user. It invokes `sudo dpkg -i` because package installation requires root permissions. It then copies the installed test-only fixtures into a writable temporary directory, preserves their expected relative layout, and runs the tester unprivileged without writing into `/bin`.
-
 The required final marker is:
 
 ```text
 CCSDSPACK_AARCH64_TEST:PASS
 ```
 
-The recorded v1.2 Raspberry Pi 5 result and complete reproduction procedure are in [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md).
+The recorded v1.2 Raspberry Pi 5 result remains historical regression evidence.
+The v2 release records a fresh arm64 result under the v2 release-validation gate.
 
 ## Cross-builds and bare metal
 
-For aarch64 Linux cross-compilation and bare-metal Cortex-M packaging, see the [Cross-build guide](CROSSBUILD.md). It documents toolchain prerequisites and `package.sh` examples.
+For aarch64 Linux cross-compilation and the bare-metal Cortex-M static library,
+see [CROSSBUILD.md](CROSSBUILD.md).
 
-The STM32H745 reference harness and STM32H755-native integration guidance are under:
+The MCU package path uses `CCSDSPACK_BUILD_MCU=ON`, C++17, and the supplied
+`CCSDSPACK_MCU_FLAGS`. A typical Cortex-M7 build disables exceptions and RTTI.
+The MCU package contains the protocol library, including `ccsds::Validator`; it
+does not contain host-only CLI/configuration components.
+
+The STM32H7 reference harness is under:
 
 ```text
 test/package_tester/stm32h7xx/
 ```
+
+Historical v1.2 STM32 evidence is not treated as the final v2 hardware result;
+representative v2 PUS/Validator execution is recorded separately before release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ CCSDSPack is a C++17 library for creating, serializing, parsing, validating, and
 ## Start here
 
 - [Examples](EXAMPLES.md): current C++17 construction, segmentation, file I/O, parsing, CRC-free operation, and configuration examples.
-- [Configuration reference](CONFIG.md): packet-template and command-line configuration keys.
+- [Structured validation](VALIDATION.md): fixed-capacity named validation checks for generic CCSDS, mission profiles, PUS, templates, and sequence streams.
+- [Configuration reference](CONFIG.md): host-side packet-template and command-line configuration keys.
 - [Command-line tools](CLI.md): encoder, decoder, validator, packet-error-control modes, and exit behaviour.
 - [Generated API reference](https://exospacelabs.github.io/CCSDSPack/html/): installed public types and functions.
 - [PUS mission tailoring](MISSION_TAILORING.md): explicit PUS-A/PUS-C revision, direction, identifier, time, spare, and packet-error-control choices.
@@ -20,26 +21,32 @@ CCSDSPack is a C++17 library for creating, serializing, parsing, validating, and
 
 ## Compliance and behaviour
 
-- [v2 compliance baseline](CCSDS_COMPLIANCE.md): current PUS and inherited generic packet scope.
+- [v2 compliance baseline](CCSDS_COMPLIANCE.md): current PUS, validation, and inherited generic packet scope.
 - [Concise v1.2 compliance statement](../COMPLIANCE.md): historical generic packet release claim.
-- [CCSDS Space Packet compliance matrix](../CCSDS_COMPLIANCE.md): clause-level traceability, PICS scope classification, implementation references, and evidence.
+- [CCSDS Space Packet compliance matrix](../CCSDS_COMPLIANCE.md): historical clause-level generic Space Packet traceability.
 - [CCSDS 133.0-B-2 EC2 Space Packet PDU profile](CCSDS_133_0_B_2_PROFILE.md): detailed protocol scope, packet rules, limitations, and evidence.
-- [v1.2 current behaviour](V1_2_CURRENT_BEHAVIOUR.md): implementation behaviour and compatibility notes.
-- [Packet processing flow](FLOW.md): packet and Manager lifecycle from construction through parsing.
+- [v1.2 current behaviour](V1_2_CURRENT_BEHAVIOUR.md): historical implementation behaviour and compatibility notes.
+- [Packet processing flow](FLOW.md): Packet, Manager, and Validator lifecycle.
 
 ## Integration and delivery
 
-- [Packages](PACKAGES.md): native packages and CMake package consumption.
-- [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md): accepted Raspberry Pi arm64 and STM32H755 CM7 evidence.
-- [STM32H755 validation procedure](V1_2_STM32_VALIDATION_STEPS.md): exact build, flash, UART, and acceptance steps used for the MCU release gate.
-- [Cross-build guide](CROSSBUILD.md): aarch64 Linux and bare-metal Cortex-M builds.
+- [Packages](PACKAGES.md): v2 native packages and CMake package consumption.
+- [Cross-build guide](CROSSBUILD.md): aarch64 Linux and C++17 bare-metal Cortex-M builds.
+- [v1.2 hardware validation](V1_2_HARDWARE_VALIDATION.md): historical Raspberry Pi arm64 and STM32H755 CM7 evidence.
+- [STM32H755 validation procedure](V1_2_STM32_VALIDATION_STEPS.md): historical MCU validation procedure retained for v2 regression/retest work.
 - [Legacy cross-compilation notes](CROSSCOMPILE.md): older environment-specific guidance retained for reference.
 - [Container image](../docker/README.md): Docker build and runtime usage.
 
 ## Reference
 
-- [Error and Result handling](ERROR.md): exception-free result types and error categories.
+- [Error and Result handling](ERROR.md): exception-free Result types and the distinction from structured validation reports.
 - [Executable overview](EXECUTABLES.md): compatibility entry point for the canonical CLI reference.
+
+## Generated diagrams
+
+UML generation is currently manual-only. It is not a v2.0.0 CI or release gate.
+The workflow remains available through `workflow_dispatch` for future documentation
+maintenance when the diagrams provide enough value to justify regeneration.
 
 ## Internal project notes
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,126 @@
+# Structured packet validation
+
+CCSDSPack v2 exposes packet validation through `ccsds::Validator` and the fixed-capacity `ccsds::ValidationReport`.
+
+The validator is part of the C++17 library and is compiled in both hosted and `CCSDS_MCU` builds. It does not require exceptions or RTTI. The report itself stores checks in a fixed `std::array` and performs no dynamic allocation.
+
+## Basic use
+
+```cpp
+ccsds::Validator validator;
+const auto report = validator.validate(packet);
+
+if (!report.valid()) {
+  for (const auto &check : report) {
+    if (!check.passed) {
+      handleValidationFailure(check.code,
+                              ccsds::validationCodeName(check.code));
+    }
+  }
+}
+```
+
+`validate()` does not modify the `Packet`, its mission profile, or its secondary header. A Validator does retain sequence-stream state between calls when sequence validation is enabled.
+
+## Structured checks
+
+`ValidationCode` names the performed checks. Callers do not depend on positional report indices.
+
+Generic Space Packet checks include:
+
+- `PrimaryHeader`;
+- `PacketVersion`;
+- `PacketDataLength`;
+- `Crc16` when CRC16 packet error control is enabled;
+- `SecondaryHeaderPresence`;
+- `SequenceFlags`;
+- `SequenceCount` when sequence-count validation is enabled;
+- `PacketIdentifier` and `SegmentationClass` when template comparison is enabled;
+- `MissionProfile` and `TemplateMissionProfile`.
+
+PUS profiles additionally expose checks for:
+
+- `PacketErrorControlProfile`;
+- `PusHeader`;
+- `PusRevision`;
+- `PusDirection`;
+- `PusPacketType`;
+- `PusProfile`;
+- `PusSecondaryHeaderSize`;
+- `PusReservedBits`;
+- `PusSpareFields`;
+- `PusAcknowledgement` and `PusSourceId` for telecommands;
+- `PusDestinationId` for telemetry;
+- `PusPacketSubcounter` for PUS-A telemetry;
+- `PusTimeReferenceStatus` for PUS-C telemetry;
+- `PusTimestamp` for the configured CUC timestamp policy.
+
+Only checks that are relevant and actually performed are stored in a report. For example, a CRC-free profile does not create a `Crc16` entry.
+
+## Querying a report
+
+```cpp
+const auto report = validator.validate(packet);
+
+if (report.failed(ccsds::ValidationCode::PacketDataLength)) {
+  // handle a length mismatch
+}
+
+if (report.failed(ccsds::ValidationCode::PusDirection)) {
+  // handle a revision/direction/profile mismatch
+}
+
+if (report.contains(ccsds::ValidationCode::Crc16)
+    && report.failed(ccsds::ValidationCode::Crc16)) {
+  // CRC16 was enabled and failed
+}
+```
+
+`ValidationReport::Capacity` is fixed at 32 checks. The v2 validation set is bounded below that capacity.
+
+## Stateful sequence validation
+
+`Validator` represents one sequence-validation stream. With packet-coherence and sequence-count validation enabled, it checks:
+
+- legal segmented/unsegmented transitions;
+- Packet Sequence Count continuity;
+- modulo-16384 rollover.
+
+Sequence state advances only after the enabled validation checks for the packet pass. Call `clear()` before reusing the Validator for an unrelated stream.
+
+## Template validation
+
+A packet template can be installed with `setTemplatePacket()` and enabled with `configure()`:
+
+```cpp
+ccsds::Validator validator;
+validator.setTemplatePacket(packetTemplate);
+validator.configure(true, true, true);
+```
+
+Template validation compares:
+
+- the complete Packet Identification value;
+- segmented versus unsegmented class;
+- the complete `MissionProfile` wire tailoring.
+
+Sequence Flags, Packet Sequence Count, and Packet Data Length are not treated as fixed Packet Identification fields.
+
+## Parser validation versus object validation
+
+Malformed wire bytes can fail before a `Packet` object is produced. `deserializeBounded()` remains responsible for bounded parsing, primary-header decoding, declared packet size, CRC verification, and secondary-header decoding.
+
+`Validator` operates on an existing `Packet` and provides structured named checks for the packet state and the selected profile. The command-line `ccsds_validator` uses these library paths rather than maintaining a separate protocol-validation implementation.
+
+## Bare-metal profile
+
+The validation API is intentionally compatible with the v2 MCU build:
+
+```bash
+cmake -S . -B build-mcu \
+  -DCCSDSPACK_BUILD_MCU=ON \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/arm-none-eabi.cmake \
+  -DCCSDSPACK_MCU_FLAGS="-fno-exceptions -fno-rtti"
+```
+
+The project language standard remains C++17. Host-only `ccsds::Config` and command-line tools are excluded from `CCSDS_MCU`, while `ccsds::Validator`, `ValidationCode`, and `ValidationReport` remain part of the static-library API.

--- a/inc/CCSDSValidator.h
+++ b/inc/CCSDSValidator.h
@@ -3,31 +3,141 @@
 
 /**
  * @file CCSDSValidator.h
- * @brief Defines stateful CCSDS packet coherence, sequence, and template validation.
+ * @brief Defines structured, stateful CCSDS and PUS packet validation.
  */
 #ifndef CCSDS_VALIDATOR_H
 #define CCSDS_VALIDATOR_H
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include "CCSDSPacket.h"
 
 namespace ccsds {
+
+  /** @brief Stable validation checks exposed by ccsds::Validator. */
+  enum class ValidationCode : std::uint8_t {
+    PrimaryHeader = 0,
+    PacketVersion,
+    PacketDataLength,
+    PacketErrorControlProfile,
+    Crc16,
+    SecondaryHeaderPresence,
+    SequenceFlags,
+    SequenceCount,
+    PacketIdentifier,
+    SegmentationClass,
+    MissionProfile,
+    TemplateMissionProfile,
+    PusHeader,
+    PusRevision,
+    PusDirection,
+    PusPacketType,
+    PusProfile,
+    PusSecondaryHeaderSize,
+    PusReservedBits,
+    PusSpareFields,
+    PusAcknowledgement,
+    PusSourceId,
+    PusDestinationId,
+    PusTimeReferenceStatus,
+    PusTimestamp
+  };
+
+  /** @brief Returns a stable printable label for one validation code. */
+  [[nodiscard]] const char *validationCodeName(ValidationCode code) noexcept;
+
+  /** @brief One performed validation check. */
+  struct ValidationCheck {
+    ValidationCode code{ValidationCode::PrimaryHeader};
+    bool passed{true};
+  };
+
+  /**
+   * @brief Fixed-capacity structured validation result.
+   *
+   * The report intentionally uses std::array rather than a dynamically allocated
+   * container so the diagnostic surface remains deterministic in MCU/bare-metal
+   * builds. Only checks that were actually performed are present.
+   */
+  class ValidationReport {
+  public:
+    static constexpr std::size_t Capacity{32U};
+
+    /** @brief Returns true when every performed check passed. */
+    [[nodiscard]] bool valid() const noexcept {
+      for (std::size_t i = 0U; i < m_size; ++i) {
+        if (!m_checks[i].passed) return false;
+      }
+      return true;
+    }
+
+    /** @brief Contextual success conversion. */
+    [[nodiscard]] explicit operator bool() const noexcept { return valid(); }
+
+    /** @brief Number of performed checks stored in the report. */
+    [[nodiscard]] std::size_t size() const noexcept { return m_size; }
+
+    /** @brief Returns true when the named check was performed. */
+    [[nodiscard]] bool contains(const ValidationCode code) const noexcept {
+      for (std::size_t i = 0U; i < m_size; ++i) {
+        if (m_checks[i].code == code) return true;
+      }
+      return false;
+    }
+
+    /** @brief Returns true only when the named check exists and passed. */
+    [[nodiscard]] bool passed(const ValidationCode code) const noexcept {
+      for (std::size_t i = 0U; i < m_size; ++i) {
+        if (m_checks[i].code == code) return m_checks[i].passed;
+      }
+      return false;
+    }
+
+    /** @brief Returns true only when the named check exists and failed. */
+    [[nodiscard]] bool failed(const ValidationCode code) const noexcept {
+      return contains(code) && !passed(code);
+    }
+
+    /** @brief Returns the first performed check. */
+    [[nodiscard]] const ValidationCheck *begin() const noexcept {
+      return m_checks.data();
+    }
+
+    /** @brief Returns one-past-the-last performed check. */
+    [[nodiscard]] const ValidationCheck *end() const noexcept {
+      return m_checks.data() + m_size;
+    }
+
+  private:
+    void set(const ValidationCode code, const bool passed) noexcept {
+      for (std::size_t i = 0U; i < m_size; ++i) {
+        if (m_checks[i].code == code) {
+          m_checks[i].passed = m_checks[i].passed && passed;
+          return;
+        }
+      }
+      if (m_size >= Capacity) return;
+      m_checks[m_size++] = {code, passed};
+    }
+
+    std::array<ValidationCheck, Capacity> m_checks{};
+    std::size_t m_size{0U};
+
+    friend class Validator;
+  };
+
   /**
    * @class Validator
-   * @brief Validates packet structure and one sequence-count stream.
+   * @brief Validates packet coherence, profiles, PUS fields, and one sequence stream.
    *
-   * Validator can check packet coherence, modulo-16384 sequence continuity, and
-   * comparison against a template. Sequence validation is stateful and is evaluated
-   * as part of the packet-coherence path: each accepted coherent packet advances the
-   * expected count and updates segmented-sequence state. Call clear() before starting
-   * an unrelated stream, then restore a template if template comparison is required.
-   *
-   * Template comparison covers the complete Packet Identification value: version,
-   * packet type, data-field-header flag, and APID. It does not require equal sequence
-   * flags, sequence count, or Packet Data Length.
+   * Validator is C++17-only, exception-free, and does not require RTTI. The
+   * ValidationReport itself performs no dynamic allocation. Packet validation is
+   * read-only; only the Validator's sequence-tracking state changes between calls.
    */
   class Validator {
   public:
-    /** @brief Constructs a validator with packet-coherence and sequence checks enabled. */
+    /** @brief Constructs a validator with coherence and sequence checks enabled. */
     Validator() = default;
 
     /** @brief Destroys the validator. */
@@ -35,55 +145,42 @@ namespace ccsds {
 
     /**
      * @brief Constructs a validator with a packet template.
-     * @param templatePacket Template copied for optional identifier comparison.
+     * @param templatePacket Template copied for optional identifier/profile comparison.
      * @note Call configure() to enable template comparison.
      */
     explicit Validator(const Packet &templatePacket) : m_templatePacket(templatePacket) {}
 
     /**
      * @brief Replaces the comparison template.
-     * @param templatePacket Packet whose identifier and segmentation class form the template.
+     * @param templatePacket Packet whose identifier, profile, and segmentation class form the template.
      */
     void setTemplatePacket(const Packet &templatePacket) { m_templatePacket = templatePacket; }
 
     /**
-     * @brief Configures which validation groups are performed.
-     * @param validatePacketCoherence Check Packet Data Length, CRC16, and segmentation state.
-     * @param validateSequenceCount Check modulo-16384 count continuity inside the coherence group.
-     * @param validateAgainstTemplate Compare complete Packet Identification and segmentation class.
-     *
-     * Disabled checks retain their documented report positions and are initialized as
-     * passing so getReport() remains index-stable.
+     * @brief Configures the validation groups.
+     * @param validatePacketCoherence Validate primary header, length, CRC, profile, PUS, and segmentation.
+     * @param validateSequenceCount Validate modulo-16384 sequence continuity.
+     * @param validateAgainstTemplate Compare packet identification, profile, and segmentation class.
      */
     void configure(bool validatePacketCoherence,
                    bool validateSequenceCount,
                    bool validateAgainstTemplate);
 
     /**
-     * @brief Validates one packet and advances sequence state after coherent input.
-     * @param packet Packet to inspect; the packet is not mutated.
-     * @return True when every enabled check passes.
-     * @note Call getReport() immediately afterward for individual check results.
-     */
-    bool validate(const Packet &packet);
-
-    /**
-     * @brief Returns the latest validation report in a stable six-element layout.
-     * @return Boolean results with the following indices:
+     * @brief Validates one packet and returns named checks instead of report indices.
+     * @param packet Packet to inspect; the packet, profile, and secondary header are not mutated.
+     * @return Fixed-capacity structured report.
      *
-     * - 0: encoded Packet Data Length matches stored packet-data-field size;
-     * - 1: stored/received CRC16 matches recalculation, or PEC is disabled;
-     * - 2: sequence flags form a coherent segmentation-state transition;
-     * - 3: sequence count equals the expected modulo-16384 value;
-     * - 4: complete Packet Identification matches the template;
-     * - 5: segmented/unsegmented class matches the template.
+     * Sequence state advances only after all enabled checks for the packet pass.
      */
-    [[nodiscard]] std::vector<bool> getReport() const { return m_report; }
+    [[nodiscard]] ValidationReport validate(const Packet &packet);
+
+    /** @brief Returns the most recent structured report. */
+    [[nodiscard]] const ValidationReport &getReport() const noexcept { return m_report; }
 
     /**
      * @brief Clears the latest report, sequence state, and stored template.
-     * @note Validation enable flags are retained. Call setTemplatePacket() again before
-     * using template comparison after clear().
+     * @note Validation enable flags are retained.
      */
     void clear();
 
@@ -92,25 +189,24 @@ namespace ccsds {
     static constexpr std::uint16_t SEGMENT_OPEN_MASK{0x4000U};
     static constexpr std::uint16_t SEQUENCE_INITIALIZED_MASK{0x8000U};
 
-    [[nodiscard]] bool sequenceInitialized() const {
+    [[nodiscard]] bool sequenceInitialized() const noexcept {
       return (m_sequenceCounter & SEQUENCE_INITIALIZED_MASK) != 0U;
     }
-    [[nodiscard]] bool segmentOpen() const {
+    [[nodiscard]] bool segmentOpen() const noexcept {
       return (m_sequenceCounter & SEGMENT_OPEN_MASK) != 0U;
     }
-    [[nodiscard]] std::uint16_t expectedSequenceCount() const {
+    [[nodiscard]] std::uint16_t expectedSequenceCount() const noexcept {
       return m_sequenceCounter & SEQUENCE_COUNT_MASK;
     }
-    void acceptSequence(const Header &header);
+    void acceptSequence(const Header &header) noexcept;
+    void setCheck(ValidationCode code, bool passed) noexcept { m_report.set(code, passed); }
 
-    Packet m_templatePacket;               ///< Template used for identifier comparison.
-    bool m_validatePacketCoherence{true};  ///< Enables length, CRC, flag, and sequence checks.
-    bool m_validateAgainstTemplate{false}; ///< Enables template identifier/class checks.
-    bool m_validateSegmentedCount{true};   ///< Enables count continuity within coherence checks.
-    std::uint16_t m_sequenceCounter{0};    ///< Expected count plus initialized/open-segment flags.
-    std::vector<bool> m_report{};          ///< Most recent six-element validation report.
-    std::size_t m_reportSize{6};           ///< Stable number of report entries.
-    CRC16Config m_CRCConfig;               ///< CRC parameters used for coherence checks.
+    Packet m_templatePacket;               ///< Template used for identifier/profile comparison.
+    bool m_validatePacketCoherence{true};  ///< Enables structural/profile/PUS checks.
+    bool m_validateAgainstTemplate{false}; ///< Enables template checks.
+    bool m_validateSequenceCount{true};    ///< Enables count continuity.
+    std::uint16_t m_sequenceCounter{0U};   ///< Expected count plus initialized/open-segment flags.
+    ValidationReport m_report{};           ///< Most recent structured validation report.
   };
 } // namespace ccsds
 

--- a/inc/CCSDSValidator.h
+++ b/inc/CCSDSValidator.h
@@ -40,6 +40,7 @@ namespace ccsds {
     PusAcknowledgement,
     PusSourceId,
     PusDestinationId,
+    PusPacketSubcounter,
     PusTimeReferenceStatus,
     PusTimestamp
   };

--- a/inc/PusSecondaryHeaders.h
+++ b/inc/PusSecondaryHeaders.h
@@ -225,11 +225,11 @@ namespace ccsds::pus {
                       time::CucTime timestamp = {});
     /** @brief Returns the PUS-C message-type counter. */
     [[nodiscard]] std::uint16_t getMessageTypeCounter() const { return m_messageTypeCounter; }
-    /** @brief Returns the PUS-C time-reference status. */
+    /** @brief Returns the four-bit PUS-C time-reference status. */
     [[nodiscard]] std::uint8_t getTimeReferenceStatus() const { return m_timeReferenceStatus; }
     /** @brief Sets the PUS-C message-type counter. */
     void setMessageTypeCounter(std::uint16_t value) { m_messageTypeCounter = value; }
-    /** @brief Sets the three-bit PUS-C time-reference status. */
+    /** @brief Sets the four-bit PUS-C time-reference status. */
     ResultBool setTimeReferenceStatus(std::uint8_t value);
     /** @brief Parses a complete PUS-C telemetry secondary header. */
     [[nodiscard]] ResultBool deserialize(const std::vector<std::uint8_t> &data) override;

--- a/package.sh
+++ b/package.sh
@@ -90,7 +90,7 @@ if [[ $use_toolchain -eq 1 ]]; then
       cmake -S .. -B . \
         -DCMAKE_BUILD_TYPE=Release \
         -DCCSDSPACK_BUILD_MCU=ON \
-        -DMCU_FLAGS="${mcu_flags}" \
+        -DCCSDSPACK_MCU_FLAGS="${mcu_flags}" \
         -DCMAKE_TOOLCHAIN_FILE="${toolchain}"
     fi
   else

--- a/src/CCSDSValidator.cpp
+++ b/src/CCSDSValidator.cpp
@@ -3,16 +3,95 @@
 
 #include "CCSDSValidator.h"
 #include "CCSDSUtils.h"
+#include "PusSecondaryHeaders.h"
+
+namespace {
+  bool identifierFits(const std::uint32_t value, const std::uint8_t octets) noexcept {
+    if (octets == 0U) return value == 0U;
+    if (octets >= 4U) return true;
+    return value < (1UL << (octets * 8U));
+  }
+
+  bool validRevision(const ccsds::pus::Revision revision) noexcept {
+    return revision == ccsds::pus::Revision::A
+           || revision == ccsds::pus::Revision::C;
+  }
+
+  bool validDirection(const ccsds::pus::Direction direction) noexcept {
+    return direction == ccsds::pus::Direction::Telecommand
+           || direction == ccsds::pus::Direction::Telemetry;
+  }
+
+  bool reservedBitsValid(const std::vector<std::uint8_t> &bytes,
+                         const ccsds::pus::Revision revision,
+                         const ccsds::pus::Direction direction) noexcept {
+    if (bytes.empty()) return false;
+    if (revision == ccsds::pus::Revision::A
+        && direction == ccsds::pus::Direction::Telecommand) {
+      return (bytes[0] & 0x80U) == 0U && ((bytes[0] >> 4U) & 0x07U) == 1U;
+    }
+    if (revision == ccsds::pus::Revision::A
+        && direction == ccsds::pus::Direction::Telemetry) {
+      return bytes[0] == 0x10U;
+    }
+    if (revision == ccsds::pus::Revision::C) {
+      return (bytes[0] >> 4U) == 2U;
+    }
+    return false;
+  }
+
+  bool spareFieldsValid(const std::vector<std::uint8_t> &bytes,
+                        const std::uint8_t spareOctets) noexcept {
+    const auto spare = static_cast<std::size_t>(spareOctets);
+    if (spare > bytes.size()) return false;
+    for (std::size_t i = bytes.size() - spare; i < bytes.size(); ++i) {
+      if (bytes[i] != 0U) return false;
+    }
+    return true;
+  }
+}
+
+const char *ccsds::validationCodeName(const ValidationCode code) noexcept {
+  switch (code) {
+    case ValidationCode::PrimaryHeader: return "CCSDS primary header";
+    case ValidationCode::PacketVersion: return "CCSDS packet version";
+    case ValidationCode::PacketDataLength: return "Packet Data Length";
+    case ValidationCode::PacketErrorControlProfile: return "Packet error-control profile";
+    case ValidationCode::Crc16: return "CRC16";
+    case ValidationCode::SecondaryHeaderPresence: return "Secondary-header presence";
+    case ValidationCode::SequenceFlags: return "Sequence flags";
+    case ValidationCode::SequenceCount: return "Sequence count";
+    case ValidationCode::PacketIdentifier: return "Packet Identification";
+    case ValidationCode::SegmentationClass: return "Segmentation class";
+    case ValidationCode::MissionProfile: return "Mission profile";
+    case ValidationCode::TemplateMissionProfile: return "Template mission profile";
+    case ValidationCode::PusHeader: return "PUS secondary header";
+    case ValidationCode::PusRevision: return "PUS revision";
+    case ValidationCode::PusDirection: return "PUS direction";
+    case ValidationCode::PusPacketType: return "PUS direction / Packet Type";
+    case ValidationCode::PusProfile: return "PUS header profile";
+    case ValidationCode::PusSecondaryHeaderSize: return "PUS secondary-header size";
+    case ValidationCode::PusReservedBits: return "PUS reserved/version bits";
+    case ValidationCode::PusSpareFields: return "PUS spare fields";
+    case ValidationCode::PusAcknowledgement: return "PUS acknowledgement flags";
+    case ValidationCode::PusSourceId: return "PUS source ID";
+    case ValidationCode::PusDestinationId: return "PUS destination ID";
+    case ValidationCode::PusPacketSubcounter: return "PUS-A packet subcounter";
+    case ValidationCode::PusTimeReferenceStatus: return "PUS-C time-reference status";
+    case ValidationCode::PusTimestamp: return "PUS CUC timestamp";
+  }
+  return "Unknown validation check";
+}
 
 void ccsds::Validator::configure(const bool validatePacketCoherence,
                                  const bool validateSequenceCount,
                                  const bool validateAgainstTemplate) {
   m_validatePacketCoherence = validatePacketCoherence;
-  m_validateSegmentedCount = validateSequenceCount;
+  m_validateSequenceCount = validateSequenceCount;
   m_validateAgainstTemplate = validateAgainstTemplate;
 }
 
-void ccsds::Validator::acceptSequence(const Header &header) {
+void ccsds::Validator::acceptSequence(const Header &header) noexcept {
   const auto next = static_cast<std::uint16_t>(
     (header.getSequenceCount() + 1U) & SEQUENCE_COUNT_MASK);
   auto state = static_cast<std::uint16_t>(SEQUENCE_INITIALIZED_MASK | next);
@@ -23,89 +102,181 @@ void ccsds::Validator::acceptSequence(const Header &header) {
   m_sequenceCounter = state;
 }
 
-bool ccsds::Validator::validate(const Packet &packet) {
-  m_report.assign(m_reportSize, true);
-  bool result{true};
+ccsds::ValidationReport ccsds::Validator::validate(const Packet &packet) {
+  m_report = {};
 
   const auto &header = packet.getPrimaryHeader();
   const auto headerData = header.serialize();
-  if (headerData.size() != 6U) {
-    m_report.assign(m_reportSize, false);
-    return false;
-  }
-  const auto dataFieldBytes = packet.getFullDataFieldBytes();
+  const bool primaryHeaderValid = header.getHeaderStatus() != INVALID
+                                  && headerData.size() == 6U;
+  setCheck(ValidationCode::PrimaryHeader, primaryHeaderValid);
+  if (!primaryHeaderValid) return m_report;
+
+  bool sequenceFlagsValid{true};
+  bool sequenceCountValid{true};
 
   if (m_validatePacketCoherence) {
-    const auto packetDataFieldSize =
-      dataFieldBytes.size() + packet.getPacketErrorControlSize();
-    m_report[0] = packetDataFieldSize > 0U
-                  && header.getDataLength() == packetDataFieldSize - 1U;
-    result &= m_report[0];
+    setCheck(ValidationCode::PacketVersion, header.getVersionNumber() == 0U);
+
+    const auto serializedSize = packet.getSerializedSize();
+    const auto packetDataFieldSize = serializedSize >= 6U ? serializedSize - 6U : 0U;
+    setCheck(ValidationCode::PacketDataLength,
+             packetDataFieldSize > 0U
+             && header.getDataLength() == packetDataFieldSize - 1U);
 
     if (packet.getPacketErrorControlMode() == PacketErrorControlMode::CRC16) {
       auto crcInput = headerData;
+      const auto dataFieldBytes = packet.getFullDataFieldBytes();
       crcInput.insert(crcInput.end(), dataFieldBytes.begin(), dataFieldBytes.end());
+      const CRC16Config crcConfig{};
       const auto calculatedCRC = ccsds::crc16(
-        crcInput, m_CRCConfig.polynomial, m_CRCConfig.initialValue,
-        m_CRCConfig.finalXorValue);
-      m_report[1] = calculatedCRC == packet.getCRC();
+        crcInput, crcConfig.polynomial, crcConfig.initialValue,
+        crcConfig.finalXorValue);
+      setCheck(ValidationCode::Crc16, calculatedCRC == packet.getCRC());
     }
-    result &= m_report[1];
+
+    const auto secondary = packet.getSecondaryHeader();
+    const bool secondaryPresence =
+      (header.getSecondaryHeaderFlag() != 0U) == static_cast<bool>(secondary);
+    setCheck(ValidationCode::SecondaryHeaderPresence, secondaryPresence);
+
+    const auto &profile = packet.getMissionProfile();
+    const auto profileResult = validateMissionProfile(profile);
+    setCheck(ValidationCode::MissionProfile, static_cast<bool>(profileResult));
+
+    if (!profile.pusEnabled) {
+      if (secondary && secondary->isPusHeader()) {
+        setCheck(ValidationCode::PusHeader, false);
+      }
+    } else {
+      const bool revisionValid = validRevision(profile.pusRevision);
+      const bool directionValid = validDirection(profile.direction);
+      setCheck(ValidationCode::PusRevision, revisionValid);
+      setCheck(ValidationCode::PusDirection, directionValid);
+      setCheck(ValidationCode::PacketErrorControlProfile,
+               packet.getPacketErrorControlMode() == profile.packetErrorControl);
+
+      if (directionValid) {
+        const auto expectedType = profile.direction == pus::Direction::Telecommand ? 1U : 0U;
+        setCheck(ValidationCode::PusPacketType, header.getType() == expectedType);
+      } else {
+        setCheck(ValidationCode::PusPacketType, false);
+      }
+
+      const bool pusHeaderPresent = secondary && secondary->isPusHeader();
+      setCheck(ValidationCode::PusHeader, pusHeaderPresent);
+
+      if (pusHeaderPresent) {
+        const auto &pusHeader = static_cast<const pus::SecondaryHeader &>(*secondary);
+        setCheck(ValidationCode::PusRevision,
+                 revisionValid && pusHeader.getRevision() == profile.pusRevision);
+        setCheck(ValidationCode::PusDirection,
+                 directionValid && pusHeader.getDirection() == profile.direction);
+        setCheck(ValidationCode::PusProfile,
+                 pusHeader.matchesMissionProfile(profile));
+
+        const auto bytes = secondary->serialize();
+        const bool sizeValid = !bytes.empty()
+                               && bytes.size() == secondary->getSize();
+        setCheck(ValidationCode::PusSecondaryHeaderSize, sizeValid);
+        setCheck(ValidationCode::PusReservedBits,
+                 sizeValid && reservedBitsValid(bytes, profile.pusRevision,
+                                                profile.direction));
+        setCheck(ValidationCode::PusSpareFields,
+                 sizeValid && spareFieldsValid(bytes,
+                                               profile.secondaryHeaderSpareOctets));
+
+        if (pusHeader.getDirection() == pus::Direction::Telecommand) {
+          const auto &tc = static_cast<const pus::TcSecondaryHeader &>(pusHeader);
+          setCheck(ValidationCode::PusAcknowledgement,
+                   tc.getAcknowledgementFlags() <= 0x0FU);
+          setCheck(ValidationCode::PusSourceId,
+                   identifierFits(tc.getSourceId(), profile.sourceIdOctets));
+        } else if (pusHeader.getDirection() == pus::Direction::Telemetry) {
+          const auto &tm = static_cast<const pus::TmSecondaryHeader &>(pusHeader);
+          setCheck(ValidationCode::PusDestinationId,
+                   identifierFits(tm.getDestinationId(), profile.destinationIdOctets));
+
+          if (profile.telemetryTimestampPresent) {
+            const auto timestamp = time::serialize(tm.getTimestamp(), profile.telemetryCuc);
+            setCheck(ValidationCode::PusTimestamp, static_cast<bool>(timestamp));
+          } else {
+            setCheck(ValidationCode::PusTimestamp,
+                     tm.getTimestamp() == time::CucTime{});
+          }
+
+          if (pusHeader.getRevision() == pus::Revision::A) {
+            const auto &aTm = static_cast<const pus::rev_a::TmHeader &>(pusHeader);
+            setCheck(ValidationCode::PusPacketSubcounter,
+                     profile.pusATmPacketSubcounterPresent
+                     || aTm.getPacketSubcounter() == 0U);
+          } else if (pusHeader.getRevision() == pus::Revision::C) {
+            const auto &cTm = static_cast<const pus::rev_c::TmHeader &>(pusHeader);
+            setCheck(ValidationCode::PusTimeReferenceStatus,
+                     cTm.getTimeReferenceStatus() <= 0x0FU);
+          }
+        }
+      }
+    }
 
     const auto flags = static_cast<ESequenceFlag>(header.getSequenceFlags());
-    const auto open = segmentOpen();
+    const bool open = segmentOpen();
     switch (flags) {
       case UNSEGMENTED:
       case FIRST_SEGMENT:
-        m_report[2] = !open;
+        sequenceFlagsValid = !open;
         break;
       case CONTINUING_SEGMENT:
       case LAST_SEGMENT:
-        m_report[2] = open;
+        sequenceFlagsValid = open;
         break;
       default:
-        m_report[2] = false;
+        sequenceFlagsValid = false;
         break;
     }
-    result &= m_report[2];
+    setCheck(ValidationCode::SequenceFlags, sequenceFlagsValid);
 
-    if (m_validateSegmentedCount && sequenceInitialized()) {
-      m_report[3] = header.getSequenceCount() == expectedSequenceCount();
-    }
-    result &= m_report[3];
-
-    if (m_report[2] && m_report[3]) {
-      acceptSequence(header);
+    if (m_validateSequenceCount) {
+      sequenceCountValid = !sequenceInitialized()
+                           || header.getSequenceCount() == expectedSequenceCount();
+      setCheck(ValidationCode::SequenceCount, sequenceCountValid);
     }
   }
 
   if (m_validateAgainstTemplate) {
     const auto &templateHeader = m_templatePacket.getPrimaryHeader();
     const auto templateHeaderData = templateHeader.serialize();
-    if (templateHeaderData.size() != 6U) {
-      m_report[4] = false;
-      m_report[5] = false;
-      return false;
-    }
+    const bool templateHeaderValid = templateHeader.getHeaderStatus() != INVALID
+                                     && templateHeaderData.size() == 6U;
+    setCheck(ValidationCode::PacketIdentifier,
+             templateHeaderValid
+             && templateHeaderData[0] == headerData[0]
+             && templateHeaderData[1] == headerData[1]);
 
-    m_report[4] = templateHeaderData[0] == headerData[0]
-                  && templateHeaderData[1] == headerData[1];
-    result &= m_report[4];
-
-    if (templateHeader.getSequenceFlags() == UNSEGMENTED) {
-      m_report[5] = header.getSequenceFlags() == UNSEGMENTED;
-    } else {
-      m_report[5] = header.getSequenceFlags() != UNSEGMENTED;
+    bool segmentationClassValid{false};
+    if (templateHeaderValid) {
+      segmentationClassValid = templateHeader.getSequenceFlags() == UNSEGMENTED
+        ? header.getSequenceFlags() == UNSEGMENTED
+        : header.getSequenceFlags() != UNSEGMENTED;
     }
-    result &= m_report[5];
+    setCheck(ValidationCode::SegmentationClass, segmentationClassValid);
+    setCheck(ValidationCode::TemplateMissionProfile,
+             missionProfilesEqual(m_templatePacket.getMissionProfile(),
+                                  packet.getMissionProfile()));
   }
 
-  return result;
+  if (m_validatePacketCoherence && sequenceFlagsValid
+      && (!m_validateSequenceCount || sequenceCountValid)
+      && m_report.valid()) {
+    acceptSequence(header);
+  }
+
+  return m_report;
 }
 
 void ccsds::Validator::clear() {
   m_sequenceCounter = 0U;
-  m_report.clear();
+  m_report = {};
   m_templatePacket = {};
   m_templatePacket.setUpdatePacketEnable(false);
 }

--- a/src/exec_validator.cpp
+++ b/src/exec_validator.cpp
@@ -28,12 +28,13 @@ void printHelp() {
     << "  -c, --config <filename>                Template/framing configuration\n"
     << "  -e, --packet-error-control <mode>      crc16 or none; overrides config\n"
     << "                                           (default: config, otherwise crc16)\n"
-    << "  -v, --verbose                          Print every check for every packet\n"
-    << "  -p, --print-packets                    Print packets that pass parse-time checks\n"
+    << "  -v, --verbose                          Print every performed validation check\n"
+    << "  -p, --print-packets                    Print packets that parse successfully\n"
     << "  -h, --help                             Show this help message\n\n"
-    << "Validation reports Packet Data Length, CRC16, CCSDS version, APID, packet\n"
-    << "type, secondary-header flag, sequence flags, and sequence-count continuity\n"
-    << "as separate checks. A config is required for APID/type/header-flag comparison.\n";
+    << "Packet parsing and protocol/profile checks are performed by the CCSDSPack\n"
+    << "library. Structured validation covers generic CCSDS coherence, sequence\n"
+    << "continuity, template identity/profile matching, and PUS revision/direction,\n"
+    << "identifier, reserved/spare, optional-field, and CUC timestamp checks.\n";
 }
 
 int printError(const ccsds::Error &error) {
@@ -98,134 +99,42 @@ loadValidatorSettings(const std::unordered_map<std::string, std::string> &args) 
   return settings;
 }
 
-struct SequenceState {
-  bool initialized{};
-  bool segmentOpen{};
-  std::uint16_t expectedCount{};
-};
-
-struct PacketChecks {
-  bool length{true};
-  bool crc{true};
-  bool version{true};
-  bool apid{true};
-  bool packetType{true};
-  bool secondaryHeaderFlag{true};
-  bool sequenceFlags{true};
-  bool sequenceCount{true};
-  bool pus{true};
-  bool crcChecked{};
-  bool apidChecked{};
-  bool identifierChecked{};
-  bool pusChecked{};
-};
-
-const char *statusText(const bool passed, const bool checked) {
-  if (!checked) return "NOT CHECKED";
-  return passed ? "PASSED" : "FAILED";
-}
-
-void emitCheck(const std::string &name,
-               const bool passed,
-               const bool checked,
-               const bool verbose,
-               std::ostringstream &report) {
-  std::ostringstream line;
-  line << "  [REPORT] " << std::left << std::setw(31) << name
-       << " : " << statusText(passed, checked) << '\n';
-  report << line.str();
-  if (verbose || (checked && !passed)) std::cout << line.str();
-}
-
-void updateSequenceState(const ccsds::Header &header,
-                         SequenceState &state,
-                         PacketChecks &checks) {
-  const auto flags = static_cast<ccsds::ESequenceFlag>(header.getSequenceFlags());
-
-  switch (flags) {
-    case ccsds::UNSEGMENTED:
-    case ccsds::FIRST_SEGMENT:
-      checks.sequenceFlags = !state.segmentOpen;
-      break;
-    case ccsds::CONTINUING_SEGMENT:
-    case ccsds::LAST_SEGMENT:
-      checks.sequenceFlags = state.segmentOpen;
-      break;
-    default:
-      checks.sequenceFlags = false;
-      break;
+void emitValidationReport(const ccsds::ValidationReport &validation,
+                          const bool verbose,
+                          std::ostringstream &report) {
+  for (const auto &check : validation) {
+    if (!verbose && check.passed) continue;
+    std::ostringstream line;
+    line << "  [REPORT] " << std::left << std::setw(31)
+         << ccsds::validationCodeName(check.code)
+         << " : " << (check.passed ? "PASSED" : "FAILED") << '\n';
+    report << line.str();
+    std::cout << line.str();
   }
-
-  checks.sequenceCount = !state.initialized
-                         || header.getSequenceCount() == state.expectedCount;
-
-  if (!checks.sequenceFlags || !checks.sequenceCount) return;
-
-  state.initialized = true;
-  state.expectedCount = static_cast<std::uint16_t>(
-    (header.getSequenceCount() + 1U) & 0x3FFFU);
-  state.segmentOpen = flags == ccsds::FIRST_SEGMENT
-                      || flags == ccsds::CONTINUING_SEGMENT;
 }
 
-PacketChecks validatePacketBytes(const std::vector<std::uint8_t> &packetBytes,
-                                 const ccsds::Header &header,
-                                 const ValidatorSettings &settings,
-                                 SequenceState &sequenceState) {
-  PacketChecks checks;
-
-  const std::size_t declaredSize =
-    6U + static_cast<std::size_t>(header.getDataLength()) + 1U;
-  checks.length = packetBytes.size() == declaredSize;
-  checks.version = header.getVersionNumber() == 0U;
-
-  checks.crcChecked = settings.mode == ccsds::PacketErrorControlMode::CRC16;
-  if (checks.crcChecked) {
-    checks.crc = packetBytes.size() >= 8U;
-    if (checks.crc) {
-      const std::uint16_t received = static_cast<std::uint16_t>(
-        (static_cast<std::uint16_t>(packetBytes[packetBytes.size() - 2U]) << 8U)
-        | packetBytes.back());
-      const std::vector<std::uint8_t> crcInput(packetBytes.begin(),
-                                               packetBytes.end() - 2);
-      checks.crc = ccsds::crc16(crcInput) == received;
-    }
-  }
-
+ccsds::ResultBool configurePacketForParsing(ccsds::Packet &packet,
+                                            const ValidatorSettings &settings) {
   if (settings.hasTemplate) {
-    const auto &templateHeader = settings.templatePacket.getPrimaryHeader();
-    checks.apidChecked = true;
-    checks.identifierChecked = true;
-    checks.apid = header.getAPID() == templateHeader.getAPID();
-    checks.packetType = header.getType() == templateHeader.getType();
-    checks.secondaryHeaderFlag =
-      header.getSecondaryHeaderFlag() == templateHeader.getSecondaryHeaderFlag();
-
-    const auto &profile = settings.templatePacket.getMissionProfile();
-    if (profile.pusEnabled) {
-      checks.pusChecked = true;
-      ccsds::Packet parsed;
-      const auto profileResult = parsed.setMissionProfile(profile);
-      parsed.setPacketErrorControlMode(settings.mode);
-      checks.pus = profileResult && static_cast<bool>(parsed.deserializeBounded(
-        packetBytes, ccsds::pus::selector(profile.pusRevision, profile.direction)));
-    }
+    FORWARD_RESULT(packet.setMissionProfile(
+      settings.templatePacket.getMissionProfile()));
+  } else {
+    auto profile = packet.getMissionProfile();
+    profile.packetErrorControl = settings.mode;
+    FORWARD_RESULT(packet.setMissionProfile(profile));
   }
-
-  updateSequenceState(header, sequenceState, checks);
-  return checks;
+  packet.setPacketErrorControlMode(settings.mode);
+  return true;
 }
 
-bool allChecksPass(const PacketChecks &checks) {
-  return checks.length
-         && (!checks.crcChecked || checks.crc)
-         && checks.version
-         && (!checks.apidChecked || checks.apid)
-         && (!checks.identifierChecked || checks.packetType)
-         && (!checks.identifierChecked || checks.secondaryHeaderFlag)
-         && (!checks.pusChecked || checks.pus)
-         && checks.sequenceFlags
-         && checks.sequenceCount;
+ccsds::Result<std::size_t> parsePacket(ccsds::Packet &packet,
+                                       const std::vector<std::uint8_t> &packetBytes) {
+  const auto &profile = packet.getMissionProfile();
+  if (profile.pusEnabled) {
+    return packet.deserializeBounded(
+      packetBytes, ccsds::pus::selector(profile.pusRevision, profile.direction));
+  }
+  return packet.deserializeBounded(packetBytes);
 }
 
 } // namespace
@@ -291,70 +200,45 @@ int main(const int argc, char *argv[]) {
 
   const bool verbose = args["verbose"] == "true";
   const bool printPacketsEnabled = args["print-packets"] == "true";
-  SequenceState sequenceState;
   bool overallResult{true};
   std::vector<std::size_t> failedPackets;
 
-  for (std::size_t index = 0; index < layout.packets.size(); ++index) {
+  ccsds::Validator validator;
+  validator.configure(true, true, settings.hasTemplate);
+  if (settings.hasTemplate) validator.setTemplatePacket(settings.templatePacket);
+
+  for (std::size_t index = 0U; index < layout.packets.size(); ++index) {
     const auto &slice = layout.packets[index];
     const std::vector<std::uint8_t> packetBytes(
       inputBytes.begin() + static_cast<std::ptrdiff_t>(slice.offset),
       inputBytes.begin() + static_cast<std::ptrdiff_t>(slice.offset + slice.size));
-    const std::vector<std::uint8_t> headerBytes(packetBytes.begin(),
-                                                packetBytes.begin() + 6);
 
-    ccsds::Header header;
-    const auto headerResult = header.deserialize(headerBytes);
-    if (!headerResult) {
-      std::cout << "[ CCSDS VALIDATOR ] Packet " << index + 1U << '\n';
-      std::cout << "  [REPORT] CCSDS primary header            : FAILED\n";
-      failedPackets.push_back(index + 1U);
-      overallResult = false;
-      continue;
-    }
-
-    const PacketChecks checks = validatePacketBytes(packetBytes,
-                                                    header,
-                                                    settings,
-                                                    sequenceState);
     std::ostringstream packetReport;
     packetReport << "[ CCSDS VALIDATOR ] Packet " << index + 1U << '\n';
     if (verbose) std::cout << packetReport.str();
 
-    emitCheck("Packet Data Length", checks.length, true, verbose, packetReport);
-    emitCheck("CRC16", checks.crc, checks.crcChecked, verbose, packetReport);
-    emitCheck("CCSDS version", checks.version, true, verbose, packetReport);
-    emitCheck("APID", checks.apid, checks.apidChecked, verbose, packetReport);
-    emitCheck("Packet type", checks.packetType,
-              checks.identifierChecked, verbose, packetReport);
-    emitCheck("Secondary-header flag", checks.secondaryHeaderFlag,
-              checks.identifierChecked, verbose, packetReport);
-    emitCheck("PUS secondary header", checks.pus,
-              checks.pusChecked, verbose, packetReport);
-    emitCheck("Sequence flags", checks.sequenceFlags, true, verbose, packetReport);
-    emitCheck("Sequence count", checks.sequenceCount, true, verbose, packetReport);
+    ccsds::Packet packet;
+    const auto configured = configurePacketForParsing(packet, settings);
+    if (!configured) return printError(configured.error());
 
-    const bool packetPassed = allChecksPass(checks);
-    overallResult = overallResult && packetPassed;
-    if (!packetPassed) failedPackets.push_back(index + 1U);
-
-    if (printPacketsEnabled && checks.length
-        && (!checks.crcChecked || checks.crc)
-        && checks.version) {
-      ccsds::Packet packet;
-      if (settings.hasTemplate) {
-        const auto profileResult = packet.setMissionProfile(
-          settings.templatePacket.getMissionProfile());
-        if (!profileResult) continue;
-      }
-      packet.setPacketErrorControlMode(settings.mode);
-      const auto &profile = packet.getMissionProfile();
-      const auto parseResult = profile.pusEnabled
-        ? packet.deserializeBounded(
-            packetBytes, ccsds::pus::selector(profile.pusRevision, profile.direction))
-        : packet.deserializeBounded(packetBytes);
-      if (parseResult) ccsds::printPacket(packet);
+    const auto parsed = parsePacket(packet, packetBytes);
+    if (!parsed) {
+      overallResult = false;
+      failedPackets.push_back(index + 1U);
+      std::cout << "  [REPORT] Packet parse                     : FAILED\n";
+      std::cerr << "  " << parsed.error().message() << std::endl;
+      continue;
     }
+
+    const auto validation = validator.validate(packet);
+    emitValidationReport(validation, verbose, packetReport);
+
+    if (!validation.valid()) {
+      overallResult = false;
+      failedPackets.push_back(index + 1U);
+    }
+
+    if (printPacketsEnabled) ccsds::printPacket(packet);
   }
 
   const std::size_t trailingBytes = inputBytes.size() - layout.consumedBytes;
@@ -367,7 +251,7 @@ int main(const int argc, char *argv[]) {
 
   if (!failedPackets.empty()) {
     std::cerr << "[ CCSDS VALIDATOR ] Failed packet(s):";
-    for (const auto packet : failedPackets) std::cerr << ' ' << packet;
+    for (const auto packetIndex : failedPackets) std::cerr << ' ' << packetIndex;
     std::cerr << std::endl;
   }
 

--- a/src/exec_validator.cpp
+++ b/src/exec_validator.cpp
@@ -32,7 +32,7 @@ void printHelp() {
     << "  -p, --print-packets                    Print packets that parse successfully\n"
     << "  -h, --help                             Show this help message\n\n"
     << "Packet parsing and protocol/profile checks are performed by the CCSDSPack\n"
-    << "library. Structured validation covers generic CCSDS coherence, sequence\n"
+    << "library. Checks include the CCSDS version and packet boundary, sequence\n"
     << "continuity, template identity/profile matching, and PUS revision/direction,\n"
     << "identifier, reserved/spare, optional-field, and CUC timestamp checks.\n";
 }
@@ -111,6 +111,18 @@ void emitValidationReport(const ccsds::ValidationReport &validation,
     report << line.str();
     std::cout << line.str();
   }
+}
+
+void emitParseFailure(const ccsds::Error &error, const bool pusProfile) {
+  const auto &message = error.message();
+  if (pusProfile) {
+    std::cout << "  [REPORT] PUS secondary header             : FAILED\n";
+  } else if (message.find("packet version") != std::string::npos) {
+    std::cout << "  [REPORT] CCSDS version                    : FAILED\n";
+  } else {
+    std::cout << "  [REPORT] Packet parse                     : FAILED\n";
+  }
+  std::cerr << "  " << message << std::endl;
 }
 
 ccsds::ResultBool configurePacketForParsing(ccsds::Packet &packet,
@@ -225,13 +237,7 @@ int main(const int argc, char *argv[]) {
     if (!parsed) {
       overallResult = false;
       failedPackets.push_back(index + 1U);
-      const auto &profile = packet.getMissionProfile();
-      if (profile.pusEnabled) {
-        std::cout << "  [REPORT] PUS secondary header             : FAILED\n";
-      } else {
-        std::cout << "  [REPORT] Packet parse                     : FAILED\n";
-      }
-      std::cerr << "  " << parsed.error().message() << std::endl;
+      emitParseFailure(parsed.error(), packet.getMissionProfile().pusEnabled);
       continue;
     }
 

--- a/src/exec_validator.cpp
+++ b/src/exec_validator.cpp
@@ -225,7 +225,12 @@ int main(const int argc, char *argv[]) {
     if (!parsed) {
       overallResult = false;
       failedPackets.push_back(index + 1U);
-      std::cout << "  [REPORT] Packet parse                     : FAILED\n";
+      const auto &profile = packet.getMissionProfile();
+      if (profile.pusEnabled) {
+        std::cout << "  [REPORT] PUS secondary header             : FAILED\n";
+      } else {
+        std::cout << "  [REPORT] Packet parse                     : FAILED\n";
+      }
       std::cerr << "  " << parsed.error().message() << std::endl;
       continue;
     }

--- a/test/cli_integration.py
+++ b/test/cli_integration.py
@@ -182,7 +182,7 @@ def main() -> int:
         apid_path = temp / "apid-mismatch.bin"
         apid_path.write_bytes(golden_crc)
         result = run([str(validator), "-i", str(apid_path), "-c", str(config1)], expected=18)
-        assert_contains(result, "APID")
+        assert_contains(result, "Packet Identification")
 
         sequence_bad = bytearray(golden_rollover)
         second = 9

--- a/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
+++ b/test/package_tester/stm32h7xx/CM7/Inc/ccsdspack_mcu_test.h
@@ -13,6 +13,7 @@
 #include "CCSDSPack.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -44,7 +45,14 @@ namespace CCSDSPackMcuTest {
     InvalidIdleSerialized = 23,
     ValidIdleHeaderFailed = 24,
     ValidIdleDataFailed = 25,
-    ValidIdleSerializationFailed = 26
+    ValidIdleSerializationFailed = 26,
+    StructuredValidatorReportMissing = 27,
+    PusProfileFailed = 28,
+    PusHeaderFailed = 29,
+    PusDataFailed = 30,
+    PusSerializationFailed = 31,
+    PusValidatorFailed = 32,
+    PusValidatorReportMissing = 33
   };
 
   class CustomSecondaryHeader final : public ccsds::SecondaryHeaderAbstract {
@@ -84,10 +92,10 @@ namespace CCSDSPackMcuTest {
    * @return Pass, or the first non-zero ResultCode identifying the failed stage.
    *
    * The suite deliberately exercises std::vector, std::string, shared ownership,
-   * factory registration, packet generation, CRC16, bounded parsing, Validator,
-   * CRC-free packets, PVN enforcement, and Idle Packet rules. It therefore checks
-   * the C++ runtime and heap configuration as well as the packet logic when run on
-   * the target MCU.
+   * factory registration, packet generation, CRC16, bounded parsing, the structured
+   * Validator, a representative PUS-C TC profile, CRC-free packets, PVN enforcement,
+   * and Idle Packet rules. It therefore checks the C++ runtime and heap configuration
+   * as well as the packet logic when run on the target MCU.
    */
   inline int run() {
     ccsds::Packet templatePacket;
@@ -169,8 +177,51 @@ namespace CCSDSPackMcuTest {
 
     ccsds::Validator validator(templatePacket);
     validator.configure(true, false, true);
-    if (!validator.validate(decoded)) {
+    const auto validation = validator.validate(decoded);
+    if (!validation.valid()) {
       return ValidatorRejectedPacket;
+    }
+    if (!validation.contains(ccsds::ValidationCode::PacketDataLength)
+        || !validation.contains(ccsds::ValidationCode::Crc16)
+        || !validation.contains(ccsds::ValidationCode::PacketIdentifier)
+        || !validation.passed(ccsds::ValidationCode::TemplateMissionProfile)) {
+      return StructuredValidatorReportMissing;
+    }
+
+    auto pusProfile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::C, ccsds::pus::Direction::Telecommand);
+    ccsds::Packet pusPacket;
+    if (const auto result = pusPacket.setPrimaryHeader(ccsds::PrimaryHeader{
+          0, 1, 1, 0x42, ccsds::UNSEGMENTED, 0, 0
+        }); !result) {
+      return PusHeaderFailed;
+    }
+    if (const auto result = pusPacket.setMissionProfile(pusProfile); !result) {
+      return PusProfileFailed;
+    }
+    if (const auto result = pusPacket.setSecondaryHeader(
+          std::make_shared<ccsds::pus::rev_c::TcHeader>(
+            pusProfile, 17U, 1U, 0x1234U, 0x09U)); !result) {
+      return PusHeaderFailed;
+    }
+    if (const auto result = pusPacket.setApplicationData({0xAAU, 0x55U}); !result) {
+      return PusDataFailed;
+    }
+    if (!pusPacket.serialize()) {
+      return PusSerializationFailed;
+    }
+
+    ccsds::Validator pusValidator;
+    const auto pusValidation = pusValidator.validate(pusPacket);
+    if (!pusValidation.valid()) {
+      return PusValidatorFailed;
+    }
+    if (!pusValidation.passed(ccsds::ValidationCode::PusRevision)
+        || !pusValidation.passed(ccsds::ValidationCode::PusDirection)
+        || !pusValidation.passed(ccsds::ValidationCode::PusPacketType)
+        || !pusValidation.passed(ccsds::ValidationCode::PusAcknowledgement)
+        || !pusValidation.passed(ccsds::ValidationCode::PusSourceId)) {
+      return PusValidatorReportMissing;
     }
 
     ccsds::Packet crcDisabled;

--- a/test/src/testGroupValidator.cpp
+++ b/test/src/testGroupValidator.cpp
@@ -56,7 +56,8 @@ namespace {
 
   ccsds::Packet pusCTcPacket(ccsds::MissionProfile profile) {
     ccsds::Packet packet;
-    if (!packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U})) return {};
+    if (!packet.setPrimaryHeader(
+          ccsds::PrimaryHeader{0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U})) return {};
     if (!packet.setMissionProfile(profile)) return {};
     if (!packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TcHeader>(
           profile, 17U, 1U, 0x1234U, 0x09U))) return {};
@@ -248,7 +249,8 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
     profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
 
     ccsds::Packet packet;
-    TEST_VOID(packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setPrimaryHeader(
+      ccsds::PrimaryHeader{0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
     TEST_VOID(packet.setMissionProfile(profile));
     TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TcHeader>(
       profile, 17U, 1U, 0x10000U, 0x10U)));
@@ -268,7 +270,8 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
     profile.secondaryHeaderSpareOctets = 1U;
 
     ccsds::Packet packet;
-    TEST_VOID(packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setPrimaryHeader(
+      ccsds::PrimaryHeader{0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
     TEST_VOID(packet.setMissionProfile(profile));
     TEST_VOID(packet.setSecondaryHeader(std::make_shared<MalformedPusCTcHeader>(profile)));
     TEST_VOID(packet.setApplicationData({0xAAU}));
@@ -285,7 +288,8 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
     profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
 
     ccsds::Packet packet;
-    TEST_VOID(packet.setPrimaryHeader({0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setPrimaryHeader(
+      ccsds::PrimaryHeader{0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
     TEST_VOID(packet.setMissionProfile(profile));
     TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_a::TmHeader>(
       profile, 3U, 25U, 7U, 0U)));
@@ -310,7 +314,8 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
     };
 
     ccsds::Packet packet;
-    TEST_VOID(packet.setPrimaryHeader({0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setPrimaryHeader(
+      ccsds::PrimaryHeader{0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
     TEST_VOID(packet.setMissionProfile(profile));
     TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TmHeader>(
       profile, 3U, 25U, 1U, 0x1234U, 0U,

--- a/test/src/testGroupValidator.cpp
+++ b/test/src/testGroupValidator.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <CCSDSValidator.h>
+#include <PusSecondaryHeaders.h>
 #include <iostream>
+#include <memory>
 #include <vector>
 #include "tests.h"
 
@@ -20,13 +22,9 @@ namespace {
     packet.setPacketErrorControlMode(mode);
     const auto headerResult = packet.setPrimaryHeader(
       ccsds::PrimaryHeader{version, type, secondaryHeaderFlag, apid, flags, count, 0});
-    if (!headerResult) {
-      return {};
-    }
+    if (!headerResult) return {};
     const auto dataResult = packet.setApplicationData(data);
-    if (!dataResult || !packet.serialize()) {
-      return {};
-    }
+    if (!dataResult || !packet.serialize()) return {};
     packet.setUpdatePacketEnable(false);
     return packet;
   }
@@ -55,6 +53,40 @@ namespace {
     validator.setTemplatePacket(packet);
     return validator;
   }
+
+  ccsds::Packet pusCTcPacket(ccsds::MissionProfile profile) {
+    ccsds::Packet packet;
+    if (!packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U})) return {};
+    if (!packet.setMissionProfile(profile)) return {};
+    if (!packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TcHeader>(
+          profile, 17U, 1U, 0x1234U, 0x09U))) return {};
+    if (!packet.setApplicationData({0xAAU})) return {};
+    if (!packet.serialize()) return {};
+    packet.setUpdatePacketEnable(false);
+    return packet;
+  }
+
+  class MalformedPusCTcHeader final : public ccsds::pus::TcSecondaryHeader {
+  public:
+    explicit MalformedPusCTcHeader(ccsds::MissionProfile profile)
+      : TcSecondaryHeader(profile, 17U, 1U, 0x1234U, 0x09U) {}
+
+    [[nodiscard]] ccsds::ResultBool deserialize(
+        const std::vector<std::uint8_t> &data) override {
+      (void)data;
+      return true;
+    }
+
+    [[nodiscard]] std::uint16_t getSize() const override { return tcSize(); }
+
+    [[nodiscard]] std::vector<std::uint8_t> serialize() const override {
+      std::vector<std::uint8_t> bytes{
+        0x39U, 17U, 1U, 0x12U, 0x34U
+      };
+      bytes.insert(bytes.end(), m_profile.secondaryHeaderSpareOctets, 0xFFU);
+      return bytes;
+    }
+  };
 }
 
 void testGroupValidator(TestManager *tester, const std::string &description) {
@@ -63,13 +95,13 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
   tester->unitTest("Validator accepts a non-zero unsegmented sequence count.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 5));
+    return validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 5)).valid();
   });
 
   tester->unitTest("Validator accepts first segment sequence count zero.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(finalizedPacket(1, ccsds::FIRST_SEGMENT, 0));
+    return validator.validate(finalizedPacket(1, ccsds::FIRST_SEGMENT, 0)).valid();
   });
 
   tester->unitTest("Validator tracks a coherent segmented sequence.", [] {
@@ -78,45 +110,44 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
     const auto last = finalizedPacket(1, ccsds::LAST_SEGMENT, 12);
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(first)
-           && validator.validate(continuing)
-           && validator.validate(last);
+    return validator.validate(first).valid()
+           && validator.validate(continuing).valid()
+           && validator.validate(last).valid();
   });
 
   tester->unitTest("Validator rejects continuation without an open segmented sequence.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    const auto packet = finalizedPacket(1, ccsds::CONTINUING_SEGMENT, 7);
-    if (validator.validate(packet)) return false;
-    const auto report = validator.getReport();
-    return report.size() == 6U && !report[2] && report[3];
+    const auto report = validator.validate(
+      finalizedPacket(1, ccsds::CONTINUING_SEGMENT, 7));
+    return !report.valid()
+           && report.failed(ccsds::ValidationCode::SequenceFlags)
+           && report.passed(ccsds::ValidationCode::SequenceCount);
   });
 
   tester->unitTest("Validator rejects an unsegmented packet before a segmented sequence is closed.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    if (!validator.validate(finalizedPacket(1, ccsds::FIRST_SEGMENT, 3))) return false;
-    const auto packet = finalizedPacket(1, ccsds::UNSEGMENTED, 4);
-    if (validator.validate(packet)) return false;
-    const auto report = validator.getReport();
-    return report.size() == 6U && !report[2] && report[3];
+    if (!validator.validate(finalizedPacket(1, ccsds::FIRST_SEGMENT, 3)).valid()) return false;
+    const auto report = validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 4));
+    return report.failed(ccsds::ValidationCode::SequenceFlags)
+           && report.passed(ccsds::ValidationCode::SequenceCount);
   });
 
   tester->unitTest("Validator rejects a discontinuous sequence count.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    if (!validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 20))) return false;
-    const auto packet = finalizedPacket(1, ccsds::UNSEGMENTED, 22);
-    if (validator.validate(packet)) return false;
-    const auto report = validator.getReport();
-    return report.size() == 6U && report[2] && !report[3];
+    if (!validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 20)).valid()) return false;
+    const auto report = validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 22));
+    return report.passed(ccsds::ValidationCode::SequenceFlags)
+           && report.failed(ccsds::ValidationCode::SequenceCount);
   });
 
   tester->unitTest("Validator sequence count rolls over modulo 16384.", [] {
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 0x3FFFU))
-           && validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 0U));
+    return validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 0x3FFFU)).valid()
+           && validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 0U)).valid();
   });
 
   tester->unitTest("Validator accepts a packet matching its template identifier.", [] {
@@ -124,7 +155,7 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
                                         {1, 2, 3}, ccsds::PacketErrorControlMode::CRC16,
                                         0, 1, 0);
     auto validator = validatorWithTemplate(packet, false, true);
-    return validator.validate(packet);
+    return validator.validate(packet).valid();
   });
 
   tester->unitTest("Validator rejects a packet with a different template identifier.", [] {
@@ -135,16 +166,15 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
                                         {1, 2, 3}, ccsds::PacketErrorControlMode::CRC16,
                                         0, 1, 0);
     auto validator = validatorWithTemplate(templatePacket, false, true);
-    if (validator.validate(packet)) return false;
-    const auto report = validator.getReport();
-    return report.size() == 6U && !report[4];
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::PacketIdentifier);
   });
 
   tester->unitTest("Validator rejects segmented state against an unsegmented template.", [] {
     const auto templatePacket = finalizedPacket(1, ccsds::UNSEGMENTED, 0);
     const auto packet = finalizedPacket(1, ccsds::FIRST_SEGMENT, 1);
     auto validator = validatorWithTemplate(templatePacket, false, true);
-    return !validator.validate(packet);
+    return validator.validate(packet).failed(ccsds::ValidationCode::SegmentationClass);
   });
 
   tester->unitTest("Validator accepts packets without packet error control.", [] {
@@ -152,62 +182,142 @@ void testGroupValidator(TestManager *tester, const std::string &description) {
                                   ccsds::PacketErrorControlMode::None);
     ccsds::Validator validator;
     validator.configure(true, true, false);
-    return validator.validate(packet);
+    const auto report = validator.validate(packet);
+    return report.valid() && !report.contains(ccsds::ValidationCode::Crc16);
   });
 
-  tester->unitTest("Validator report is fully true for a valid packet.", [] {
+  tester->unitTest("Validator report exposes named checks instead of boolean indices.", [] {
     const auto packet = finalizedPacket(1, ccsds::UNSEGMENTED, 9);
     auto validator = validatorWithTemplate(packet);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({true, true, true, true, true, true});
+    const auto report = validator.validate(packet);
+    return report.valid()
+           && report.contains(ccsds::ValidationCode::PacketDataLength)
+           && report.contains(ccsds::ValidationCode::Crc16)
+           && report.contains(ccsds::ValidationCode::PacketIdentifier)
+           && report.size() <= ccsds::ValidationReport::Capacity;
   });
 
-  tester->unitTest("Validator report isolates a Packet Data Length failure.", [] {
+  tester->unitTest("Validator isolates a Packet Data Length failure.", [] {
     auto packet = rawPacketWithoutCRC(1, ccsds::UNSEGMENTED, 9, 7);
     auto templatePacket = rawPacketWithoutCRC(1, ccsds::UNSEGMENTED, 9, 2);
     auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({false, true, true, true, true, true});
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::PacketDataLength)
+           && report.passed(ccsds::ValidationCode::PacketIdentifier);
   });
 
-  tester->unitTest("Validator report isolates a CRC failure.", [] {
+  tester->unitTest("Validator isolates a CRC failure.", [] {
     auto packet = finalizedPacket(1, ccsds::UNSEGMENTED, 9, {1, 2, 3});
     TEST_VOID(packet.setApplicationData({1, 2, 4}));
     auto templatePacket = finalizedPacket(1, ccsds::UNSEGMENTED, 9, {1, 2, 3});
     auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({true, false, true, true, true, true});
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::Crc16)
+           && report.passed(ccsds::ValidationCode::PacketDataLength);
   });
 
-  tester->unitTest("Validator report isolates sequence-flag coherence.", [] {
-    auto packet = rawPacketWithoutCRC(1, ccsds::CONTINUING_SEGMENT, 5, 2);
-    auto templatePacket = rawPacketWithoutCRC(1, ccsds::FIRST_SEGMENT, 5, 2);
-    auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({true, true, false, true, true, true});
+  tester->unitTest("Validator compares mission profiles explicitly.", [] {
+    auto templatePacket = rawPacketWithoutCRC(1, ccsds::UNSEGMENTED, 0, 2);
+    auto packet = templatePacket;
+    ccsds::MissionProfile profile;
+    profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
+    TEST_VOID(packet.setMissionProfile(profile));
+    auto validator = validatorWithTemplate(templatePacket, false, false);
+    return validator.validate(packet).failed(
+      ccsds::ValidationCode::TemplateMissionProfile);
   });
 
-  tester->unitTest("Validator report isolates sequence-count continuity.", [] {
+  tester->unitTest("Validator reports PUS Packet Type and packet-error-control mismatches.", [] {
+    auto profile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::C, ccsds::pus::Direction::Telecommand);
+    auto packet = pusCTcPacket(profile);
+    packet.setPacketErrorControlMode(ccsds::PacketErrorControlMode::None);
+    TEST_VOID(packet.getPrimaryHeader().setType(0U));
+
     ccsds::Validator validator;
-    validator.configure(true, true, false);
-    if (!validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 5))) return false;
-    validator.validate(finalizedPacket(1, ccsds::UNSEGMENTED, 7));
-    return validator.getReport() == std::vector<bool>({true, true, true, false, true, true});
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::PacketErrorControlProfile)
+           && report.failed(ccsds::ValidationCode::PusPacketType)
+           && report.passed(ccsds::ValidationCode::PusRevision)
+           && report.passed(ccsds::ValidationCode::PusDirection);
   });
 
-  tester->unitTest("Validator report isolates template identity.", [] {
-    const auto templatePacket = finalizedPacket(1, ccsds::UNSEGMENTED, 0);
-    const auto packet = finalizedPacket(2, ccsds::UNSEGMENTED, 0);
-    auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({true, true, true, true, false, true});
+  tester->unitTest("Validator distinguishes invalid PUS acknowledgement and source-ID fields.", [] {
+    auto profile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::C, ccsds::pus::Direction::Telecommand);
+    profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
+
+    ccsds::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setMissionProfile(profile));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TcHeader>(
+      profile, 17U, 1U, 0x10000U, 0x10U)));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+
+    ccsds::Validator validator;
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::PusAcknowledgement)
+           && report.failed(ccsds::ValidationCode::PusSourceId)
+           && report.failed(ccsds::ValidationCode::PusSecondaryHeaderSize);
   });
 
-  tester->unitTest("Validator report isolates template sequence flags.", [] {
-    const auto templatePacket = finalizedPacket(1, ccsds::UNSEGMENTED, 0);
-    const auto packet = finalizedPacket(1, ccsds::FIRST_SEGMENT, 0);
-    auto validator = validatorWithTemplate(templatePacket);
-    validator.validate(packet);
-    return validator.getReport() == std::vector<bool>({true, true, true, true, true, false});
+  tester->unitTest("Validator distinguishes PUS reserved bits and spare-field failures.", [] {
+    auto profile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::C, ccsds::pus::Direction::Telecommand);
+    profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
+    profile.secondaryHeaderSpareOctets = 1U;
+
+    ccsds::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader({0U, 1U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setMissionProfile(profile));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<MalformedPusCTcHeader>(profile)));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+
+    ccsds::Validator validator;
+    const auto report = validator.validate(packet);
+    return report.failed(ccsds::ValidationCode::PusReservedBits)
+           && report.failed(ccsds::ValidationCode::PusSpareFields);
+  });
+
+  tester->unitTest("Validator distinguishes disabled PUS-A TM subcounter state.", [] {
+    auto profile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::A, ccsds::pus::Direction::Telemetry);
+    profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
+
+    ccsds::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader({0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setMissionProfile(profile));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_a::TmHeader>(
+      profile, 3U, 25U, 7U, 0U)));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+
+    ccsds::Validator validator;
+    return validator.validate(packet).failed(
+      ccsds::ValidationCode::PusPacketSubcounter);
+  });
+
+  tester->unitTest("Validator distinguishes an overflowing PUS TM CUC timestamp.", [] {
+    auto profile = ccsds::pus::makeProfile(
+      ccsds::pus::Revision::C, ccsds::pus::Direction::Telemetry);
+    profile.packetErrorControl = ccsds::PacketErrorControlMode::None;
+    profile.telemetryTimestampPresent = true;
+    profile.telemetryTimeCode = ccsds::time::Format::Cuc;
+    profile.telemetryCuc = {
+      ccsds::time::Epoch::Ccsds1958Tai,
+      ccsds::time::PFieldMode::Implicit,
+      4U,
+      0U
+    };
+
+    ccsds::Packet packet;
+    TEST_VOID(packet.setPrimaryHeader({0U, 0U, 1U, 42U, ccsds::UNSEGMENTED, 0U, 0U}));
+    TEST_VOID(packet.setMissionProfile(profile));
+    TEST_VOID(packet.setSecondaryHeader(std::make_shared<ccsds::pus::rev_c::TmHeader>(
+      profile, 3U, 25U, 1U, 0x1234U, 0U,
+      ccsds::time::CucTime{0x100000000ULL, 0U})));
+    TEST_VOID(packet.setApplicationData({0xAAU}));
+
+    ccsds::Validator validator;
+    return validator.validate(packet).failed(ccsds::ValidationCode::PusTimestamp);
   });
 }


### PR DESCRIPTION
## Summary

This PR replaces the inherited positional six-boolean Validator report with a structured C++17 validation API and reconciles the v2 documentation/release path around it.

### Structured Validator

- adds `ccsds::ValidationCode` for named generic CCSDS, mission-profile, template, and PUS checks;
- adds fixed-capacity `ccsds::ValidationReport` backed by `std::array` (`Capacity = 32`);
- changes `Validator::validate(const Packet&)` to return the structured report;
- retains stateful segmentation/Packet Sequence Count validation and modulo-16384 rollover;
- validates primary-header/version, Packet Data Length, CRC16 when enabled, secondary-header presence, Packet Identification, segmentation class, and template mission-profile equality;
- validates PUS revision, direction, CCSDS Packet Type, header/profile consistency, header size, version/reserved bits, zero spare fields, TC acknowledgement/source ID, TM destination ID, PUS-A TM subcounter policy, PUS-C TM time-reference status, and configured CUC timestamp fit;
- does not mutate the Packet, MissionProfile, or secondary header being validated;
- makes `ccsds_validator` delegate protocol/profile object checks to the library Validator instead of keeping parallel validation rules.

### Bare-metal / C++17

- project language standard remains C++17;
- Validator uses no RTTI or exceptions;
- `ValidationReport` itself performs no dynamic allocation;
- Validator remains part of the `CCSDS_MCU` static library;
- fixes `package.sh -m` so MCU flags are passed to the actual library through `CCSDSPACK_MCU_FLAGS`;
- extends the ARM compile/link consumer probe to exercise named Validator checks and a representative PUS-C TC packet.

The fixed-capacity statement applies to `ValidationReport`; this PR does not claim that the entire existing Packet/PUS implementation is globally heap-free.

### UML CI

Automatic UML generation is disabled for v2.0.0 development/release work:

- `.github/workflows/uml.yml` is now `workflow_dispatch` only;
- no push/PR triggers;
- no automatic commit/push step;
- read-only repository permission;
- the manual workflow remains available for future documentation maintenance.

Issue #84 is closed as deferred/not planned for v2.0.0. UML is not a compliance or release gate.

### Documentation reconciliation

Updated current-facing documentation includes:

- root README, compliance matrix, concise compliance statement, changelog, and draft v2 release notes;
- transition roadmap and acceptance list;
- structured validation reference;
- Space Packet profile, PUS mission tailoring, configuration, CLI, examples, processing flow, error handling, packages, cross-build, executables, and v1-to-v2 migration guidance.

Also corrected:

- PUS-C TM time-reference status documentation to the implemented four-bit `0..15` field;
- stale bare-metal `MCU_FLAGS` guidance to `CCSDSPACK_MCU_FLAGS`;
- stale v1.x release-note/change-log material.

Historical v1.2 hardware documents remain historical and are not rewritten as v2 evidence.

## Validation

Current PR head is green on the required active gates:

- 108/108 native tests pass;
- Linux passes on ubuntu-latest, Ubuntu 22.04, and Ubuntu 24.04;
- Windows passes;
- Doxygen passes;
- CLI integration passes;
- installed shared-library consumer passes;
- installed-package examples pass;
- Ubuntu 22.04 package/cross-build generation passes with the updated ARM structured-Validator/PUS-C compile-link probe;
- no UML workflow is triggered.

Closes #72.

Updates #85.

Updates #87.

Updates #88.